### PR TITLE
feat: add Storybook component library and architecture decision records

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -1,0 +1,32 @@
+name: Chromatic
+
+on:
+  push:
+    branches: [main, "docs/**", "feat/**", "fix/**"]
+  pull_request:
+    branches: [main]
+
+jobs:
+  chromatic:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install dependencies
+        run: npm install
+        working-directory: frontend
+
+      - name: Run Chromatic
+        uses: chromaui/action@latest
+        with:
+          projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
+          workingDir: frontend
+          buildScriptName: build-storybook

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,75 @@
+﻿# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in Supply-Link a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, colour, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+---
+
+## Our Standards
+
+Examples of behaviour that contributes to a positive environment:
+
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints and experiences
+- Gracefully accepting constructive criticism
+- Focusing on what is best for the community
+- Showing empathy towards other community members
+
+Examples of unacceptable behaviour:
+
+- The use of sexualised language or imagery, and sexual attention or advances of any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information (physical or email address) without explicit permission
+- Other conduct which could reasonably be considered inappropriate in a professional setting
+
+---
+
+## Enforcement Responsibilities
+
+Project maintainers are responsible for clarifying and enforcing our standards of acceptable behaviour and will take appropriate and fair corrective action in response to any behaviour they deem inappropriate, threatening, offensive, or harmful.
+
+Maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned with this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+---
+
+## Scope
+
+This Code of Conduct applies within all project spaces — GitHub issues, pull requests, discussions, the repository wiki, and any other official project channel. It also applies when an individual is officially representing the project in public spaces (e.g. posting from an official social media account or speaking at an event on behalf of the project).
+
+---
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behaviour may be reported by opening a **private** GitHub issue or contacting the maintainers directly. All complaints will be reviewed and investigated promptly and fairly. Maintainers are obligated to respect the privacy and security of the reporter.
+
+### Enforcement Guidelines
+
+Maintainers will follow these guidelines when determining consequences:
+
+**1. Correction**
+*Impact:* Use of inappropriate language or other unprofessional behaviour.
+*Consequence:* A private written warning with clarity around the nature of the violation and an explanation of why the behaviour was inappropriate.
+
+**2. Warning**
+*Impact:* A violation through a single incident or series of actions.
+*Consequence:* A warning with consequences for continued behaviour. No interaction with the people involved for a specified period, including unsolicited interaction with those enforcing the Code of Conduct.
+
+**3. Temporary Ban**
+*Impact:* A serious violation of community standards, including sustained inappropriate behaviour.
+*Consequence:* A temporary ban from any sort of interaction or public communication with the community for a specified period.
+
+**4. Permanent Ban**
+*Impact:* Demonstrating a pattern of violation of community standards, harassment of an individual, or aggression toward or disparagement of classes of individuals.
+*Consequence:* A permanent ban from any sort of public interaction within the community.
+
+---
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct/](https://www.contributor-covenant.org/version/2/1/code_of_conduct/).
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder](https://github.com/mozilla/diversity).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,213 @@
+# Contributing to Supply-Link
+
+Thanks for your interest in contributing. Supply-Link is an open-source project and we welcome contributions across smart contracts, frontend, docs, design, and testing.
+
+---
+
+## Table of Contents
+
+- [Code of Conduct](#code-of-conduct)
+- [Prerequisites](#prerequisites)
+- [Local Setup](#local-setup)
+  - [Frontend](#frontend)
+  - [Smart Contract](#smart-contract)
+- [Branching Strategy](#branching-strategy)
+- [Commit Message Convention](#commit-message-convention)
+- [Pull Request Process](#pull-request-process)
+- [What Reviewers Look For](#what-reviewers-look-for)
+
+---
+
+## Code of Conduct
+
+This project follows the [Contributor Covenant Code of Conduct](https://www.contributor-covenant.org/version/2/1/code_of_conduct/). By participating you agree to uphold it. Report unacceptable behaviour to the maintainers via a private GitHub issue or email.
+
+---
+
+## Prerequisites
+
+Install these tools before working on the project:
+
+| Tool | Version | Install |
+|---|---|---|
+| Node.js | 20+ | [nodejs.org](https://nodejs.org) |
+| Rust | stable (1.78+) | `curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \| sh` |
+| wasm32 target | — | `rustup target add wasm32-unknown-unknown` |
+| Stellar CLI | latest | [Install guide](https://developers.stellar.org/docs/tools/developer-tools/cli/stellar-cli) |
+| Freighter Wallet | latest | [freighter.app](https://freighter.app) browser extension |
+
+Verify your setup:
+
+```bash
+node --version      # v20+
+cargo --version     # cargo 1.78+
+stellar --version   # stellar 0.x
+```
+
+---
+
+## Local Setup
+
+### Frontend
+
+```bash
+cd Supply-Link/frontend
+
+# 1. Copy environment variables
+cp .env.example .env.local
+
+# 2. Install dependencies
+npm install
+
+# 3. Start the dev server
+npm run dev
+# → http://localhost:3000
+```
+
+The `.env.example` file documents every required variable. At minimum you need:
+
+```
+NEXT_PUBLIC_CONTRACT_ID=<testnet contract address>
+NEXT_PUBLIC_NETWORK=testnet
+```
+
+The testnet contract is already deployed at `CBUWSKT2UGOAXK4ZREVDJV5XHSYB42PZ3CERU2ZFUTUMAZLJEHNZIECA`.
+
+### Smart Contract
+
+```bash
+cd Supply-Link/smart-contract
+
+# 1. Build the WASM binary
+cargo build --target wasm32-unknown-unknown --release
+
+# 2. Run tests (unit + property-based)
+cargo test
+
+# 3. Generate HTML documentation
+cargo doc --open
+
+# 4. Deploy to testnet (requires a funded Stellar account)
+stellar contract deploy \
+  --wasm target/wasm32-unknown-unknown/release/supply_link.wasm \
+  --network testnet \
+  --source <YOUR_ACCOUNT_ALIAS>
+```
+
+To set up a testnet account:
+
+```bash
+stellar keys generate --global alice --network testnet
+stellar keys fund alice --network testnet   # uses Friendbot
+```
+
+---
+
+## Branching Strategy
+
+| Branch | Purpose |
+|---|---|
+| `main` | Production-ready code. Direct pushes are blocked. |
+| `feat/<short-description>` | New features, e.g. `feat/qr-scanner` |
+| `fix/<short-description>` | Bug fixes, e.g. `fix/transfer-auth` |
+| `docs/<short-description>` | Documentation only, e.g. `docs/contract-api` |
+| `chore/<short-description>` | Tooling, deps, CI, e.g. `chore/upgrade-sdk` |
+| `test/<short-description>` | Tests only, e.g. `test/prop-event-count` |
+
+Rules:
+- Branch off `main` for every piece of work.
+- Keep branches short-lived — open a PR as soon as you have something reviewable.
+- Delete your branch after it is merged.
+
+---
+
+## Commit Message Convention
+
+This project uses [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
+
+```
+<type>(<scope>): <short summary>
+
+[optional body]
+
+[optional footer(s)]
+```
+
+**Types:**
+
+| Type | When to use |
+|---|---|
+| `feat` | A new feature |
+| `fix` | A bug fix |
+| `docs` | Documentation changes only |
+| `style` | Formatting, whitespace (no logic change) |
+| `refactor` | Code change that is neither a fix nor a feature |
+| `test` | Adding or updating tests |
+| `chore` | Build process, dependency updates, CI |
+| `perf` | Performance improvement |
+
+**Scopes** (optional but encouraged): `contract`, `frontend`, `wallet`, `tracking`, `products`, `ci`, `deps`.
+
+**Examples:**
+
+```
+feat(contract): add remove_authorized_actor function
+fix(frontend): correct QR code URL encoding for product IDs
+docs(contract): add Rust doc comments to all public functions
+test(contract): add property-based tests for event count
+chore(deps): upgrade soroban-sdk to 22.0.11
+```
+
+Breaking changes: append `!` after the type/scope and add a `BREAKING CHANGE:` footer.
+
+```
+feat(contract)!: rename event_type field to kind
+
+BREAKING CHANGE: TrackingEvent.event_type is now TrackingEvent.kind
+```
+
+---
+
+## Pull Request Process
+
+1. **Fork** the repository and create your branch from `main`.
+2. **Make your changes** following the coding standards below.
+3. **Write or update tests** for any logic you add or change.
+4. **Run the full test suite** locally before pushing:
+   ```bash
+   # Smart contract
+   cd smart-contract && cargo test
+
+   # Frontend
+   cd frontend && npm test
+   ```
+5. **Open a PR** against `main` with:
+   - A clear title following the Conventional Commits format.
+   - A description explaining *what* changed and *why*.
+   - Screenshots or a short demo for UI changes.
+   - A reference to the related issue, e.g. `Closes #42`.
+6. **Address review feedback** — push additional commits to the same branch; do not force-push after a review has started.
+7. **Squash and merge** once approved. The maintainer will do this.
+
+---
+
+## What Reviewers Look For
+
+**Smart contract (Rust / Soroban)**
+- All public functions have `///` doc comments covering parameters, return values, panics, auth requirements, and emitted events.
+- `owner.require_auth()` (or equivalent) is called before any state mutation that requires authorization.
+- No unbounded loops over user-supplied data.
+- New functions have corresponding unit tests and, where applicable, property-based tests using `proptest`.
+- `cargo clippy -- -D warnings` passes with no errors.
+
+**Frontend (TypeScript / Next.js)**
+- No `any` types without a comment explaining why.
+- Wallet interactions go through the existing `lib/stellar/` abstractions.
+- New UI components live in `components/ui/` (primitives) or the relevant feature folder.
+- `npm run lint` passes with no errors.
+
+**General**
+- Commits follow the Conventional Commits convention.
+- No secrets, private keys, or `.env` files committed.
+- Documentation is updated alongside code changes.
+- PR is focused — one logical change per PR.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Supply-Link
+﻿# Supply-Link
 
 > Decentralized supply chain provenance tracker built on [Stellar](https://stellar.org)'s Soroban smart contract platform.
 
@@ -33,15 +33,15 @@ Paper trails are forged. Databases are siloed. No single source of truth exists 
 
 ## The Solution
 
-Supply-Link provides a decentralized, immutable ledger where every product event — harvest, processing, shipping, quality check, retail receipt — is recorded on-chain and verifiable by anyone with a QR code scan.
+Supply-Link provides a decentralized, immutable ledger where every product event â€” harvest, processing, shipping, quality check, retail receipt â€” is recorded on-chain and verifiable by anyone with a QR code scan.
 
 ### Core Features
 
-- **Product Registration** — Register products at origin with cryptographic proof of authenticity and a unique blockchain ID
-- **Event Tracking** — Record every supply chain step with timestamp, location, actor address, and metadata
-- **QR Verification** — Consumers scan a QR code to see the complete, tamper-proof product journey
-- **Multi-party Authorization** — Farmers, processors, shippers, and retailers each sign their own events
-- **Ownership Transfer** — Transfer product custody on-chain with full audit trail
+- **Product Registration** â€” Register products at origin with cryptographic proof of authenticity and a unique blockchain ID
+- **Event Tracking** â€” Record every supply chain step with timestamp, location, actor address, and metadata
+- **QR Verification** â€” Consumers scan a QR code to see the complete, tamper-proof product journey
+- **Multi-party Authorization** â€” Farmers, processors, shippers, and retailers each sign their own events
+- **Ownership Transfer** â€” Transfer product custody on-chain with full audit trail
 
 ---
 
@@ -49,8 +49,8 @@ Supply-Link provides a decentralized, immutable ledger where every product event
 
 ```
 Supply-Link/
-├── frontend/          # Next.js 16 + React 19 + TypeScript web app
-└── smart-contract/    # Rust + Soroban smart contracts
+â”œâ”€â”€ frontend/          # Next.js 16 + React 19 + TypeScript web app
+â””â”€â”€ smart-contract/    # Rust + Soroban smart contracts
 ```
 
 ### Technology Stack
@@ -70,15 +70,15 @@ Supply-Link/
 ### Data Flow
 
 ```
-Producer → Register Product → Stellar Blockchain
-    ↓
-Processor → Add Event → Stellar Blockchain
-    ↓
-Shipper → Add Event → Stellar Blockchain
-    ↓
-Retailer → Add Event → Stellar Blockchain
-    ↓
-Consumer → Scan QR → View Full History
+Producer â†’ Register Product â†’ Stellar Blockchain
+    â†“
+Processor â†’ Add Event â†’ Stellar Blockchain
+    â†“
+Shipper â†’ Add Event â†’ Stellar Blockchain
+    â†“
+Retailer â†’ Add Event â†’ Stellar Blockchain
+    â†“
+Consumer â†’ Scan QR â†’ View Full History
 ```
 
 ---
@@ -135,25 +135,25 @@ pub struct TrackingEvent {
 
 ```
 frontend/
-├── app/
-│   ├── (marketing)/        Landing page
-│   ├── (app)/
-│   │   ├── dashboard/      Analytics & overview
-│   │   ├── products/       Product registration & list
-│   │   └── tracking/       Event tracking
-│   ├── verify/[id]/        Public QR verification page
-│   └── api/health/         Health check endpoint
-├── components/
-│   ├── ui/                 Reusable primitives (Button, Card, etc.)
-│   ├── layouts/            App shell (Navbar, Sidebar)
-│   ├── wallet/             Freighter wallet connect
-│   ├── products/           Product cards & registration form
-│   └── tracking/           Event timeline & add-event form
-└── lib/
-    ├── stellar/            Soroban SDK client & contract bindings
-    ├── state/              Zustand stores
-    ├── hooks/              Custom React hooks
-    └── types/              Shared TypeScript domain types
+â”œâ”€â”€ app/
+â”‚   â”œâ”€â”€ (marketing)/        Landing page
+â”‚   â”œâ”€â”€ (app)/
+â”‚   â”‚   â”œâ”€â”€ dashboard/      Analytics & overview
+â”‚   â”‚   â”œâ”€â”€ products/       Product registration & list
+â”‚   â”‚   â””â”€â”€ tracking/       Event tracking
+â”‚   â”œâ”€â”€ verify/[id]/        Public QR verification page
+â”‚   â””â”€â”€ api/health/         Health check endpoint
+â”œâ”€â”€ components/
+â”‚   â”œâ”€â”€ ui/                 Reusable primitives (Button, Card, etc.)
+â”‚   â”œâ”€â”€ layouts/            App shell (Navbar, Sidebar)
+â”‚   â”œâ”€â”€ wallet/             Freighter wallet connect
+â”‚   â”œâ”€â”€ products/           Product cards & registration form
+â”‚   â””â”€â”€ tracking/           Event timeline & add-event form
+â””â”€â”€ lib/
+    â”œâ”€â”€ stellar/            Soroban SDK client & contract bindings
+    â”œâ”€â”€ state/              Zustand stores
+    â”œâ”€â”€ hooks/              Custom React hooks
+    â””â”€â”€ types/              Shared TypeScript domain types
 ```
 
 ---
@@ -173,7 +173,7 @@ frontend/
 cd frontend
 npm install
 npm run dev
-# → http://localhost:3000
+# â†’ http://localhost:3000
 ```
 
 ### Smart Contract
@@ -196,7 +196,7 @@ stellar contract deploy \
 | Feature | Stellar | Ethereum | Bitcoin |
 |---|---|---|---|
 | Finality | ~5 seconds | Minutes | Hours |
-| Tx cost | ~$0.00001 | $10–100 | High |
+| Tx cost | ~$0.00001 | $10â€“100 | High |
 | Energy | Efficient PoA | PoS | PoW |
 | Cross-border | Native | Limited | Limited |
 
@@ -206,11 +206,11 @@ Stellar's speed and near-zero cost make it ideal for supply chain use cases wher
 
 ## Use Cases
 
-- **Food & Agriculture** — Track coffee from Ethiopian farm to Seattle café, verify organic/fair-trade claims
-- **Pharmaceuticals** — Verify medication authenticity from factory to pharmacy, prevent counterfeits
-- **Fashion** — Prove ethical sourcing and fair-wage manufacturing
-- **Electronics** — Verify conflict-free mineral sourcing
-- **Luxury Goods** — Authenticate high-value items, track resale ownership
+- **Food & Agriculture** â€” Track coffee from Ethiopian farm to Seattle cafÃ©, verify organic/fair-trade claims
+- **Pharmaceuticals** â€” Verify medication authenticity from factory to pharmacy, prevent counterfeits
+- **Fashion** â€” Prove ethical sourcing and fair-wage manufacturing
+- **Electronics** â€” Verify conflict-free mineral sourcing
+- **Luxury Goods** â€” Authenticate high-value items, track resale ownership
 
 ---
 
@@ -218,17 +218,17 @@ Stellar's speed and near-zero cost make it ideal for supply chain use cases wher
 
 | Phase | Status | Scope |
 |---|---|---|
-| Phase 1 – MVP | 🔄 In Progress | Product registration, event tracking, wallet integration, QR codes |
-| Phase 2 – Security | 📅 Q2 2026 | Access control, security audit, E2E tests |
-| Phase 3 – UX | 📅 Q3 2026 | Timeline visualization, analytics dashboard, mobile |
-| Phase 4 – Integrations | 📅 Q3 2026 | REST API, webhooks, SDK |
-| Phase 5 – Scale | 📅 Q4 2026 | Multi-language, enterprise features, mainnet launch |
+| Phase 1 â€“ MVP | ðŸ”„ In Progress | Product registration, event tracking, wallet integration, QR codes |
+| Phase 2 â€“ Security | ðŸ“… Q2 2026 | Access control, security audit, E2E tests |
+| Phase 3 â€“ UX | ðŸ“… Q3 2026 | Timeline visualization, analytics dashboard, mobile |
+| Phase 4 â€“ Integrations | ðŸ“… Q3 2026 | REST API, webhooks, SDK |
+| Phase 5 â€“ Scale | ðŸ“… Q4 2026 | Multi-language, enterprise features, mainnet launch |
 
 ---
 
 ## Contributing
 
-Contributions are welcome across all skill levels — smart contracts, frontend, docs, design, and testing.
+Contributions are welcome across all skill levels â€” smart contracts, frontend, docs, design, and testing.
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for the full guide.
 
@@ -236,8 +236,56 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for the full guide.
 
 ## License
 
-MIT — free to use, modify, and distribute.
+MIT â€” free to use, modify, and distribute.
 
 ---
 
-*Built with ❤️ on [Stellar](https://stellar.org) & [Soroban](https://soroban.stellar.org)*
+
+
+---
+
+## Contract API Reference
+
+> Full HTML docs: run `cargo doc --open` inside `smart-contract/`.
+> Testnet contract: `CBUWSKT2UGOAXK4ZREVDJV5XHSYB42PZ3CERU2ZFUTUMAZLJEHNZIECA`
+
+### Functions
+
+| Function | Auth Required | Returns | Panics |
+|---|---|---|---|
+| `register_product(id, name, origin, owner)` | `owner` | `Product` | never (under normal conditions) |
+| `add_tracking_event(product_id, caller, location, event_type, metadata)` | `caller` (owner or authorized actor) | `TrackingEvent` | `"product not found"`, `"caller is not authorized"` |
+| `get_product(id)` | none | `Product` | `"product not found"` |
+| `get_tracking_events(product_id)` | none | `Vec<TrackingEvent>` | never |
+| `product_exists(id)` | none | `bool` | never |
+| `get_events_count(product_id)` | none | `u32` | never |
+| `transfer_ownership(product_id, new_owner)` | current `owner` | `bool` | `"product not found"` |
+| `add_authorized_actor(product_id, actor)` | `owner` | `bool` | `"product not found"` |
+| `remove_authorized_actor(product_id, actor)` | `owner` | `bool` (false if not found) | `"product not found"` |
+| `update_product_metadata(product_id, name, origin)` | `owner` | `Product` | `"product not found"` |
+| `get_authorized_actors(product_id)` | none | `Vec<Address>` | never |
+| `get_product_count()` | none | `u64` | never |
+| `list_products(offset, limit)` | none | `Vec<String>` | never |
+
+### Emitted Events
+
+| Topic | Body | Trigger |
+|---|---|---|
+| `("product_registered", id)` | `Product` | `register_product` |
+| `("event_added", product_id, event_type)` | `TrackingEvent` | `add_tracking_event` |
+| `("ownership_transferred", product_id)` | `Address` (new owner) | `transfer_ownership` |
+| `("actor_authorized", product_id)` | `Address` (actor) | `add_authorized_actor` |
+| `("product_updated", product_id)` | `Product` | `update_product_metadata` |
+
+### Storage Keys
+
+| Key | Type | Description |
+|---|---|---|
+| `Product(String)` | `Product` | Product record keyed by product ID |
+| `Events(String)` | `Vec<TrackingEvent>` | Append-only event log keyed by product ID |
+| `ProductCount` | `u64` | Global monotonic registration counter |
+| `ProductIndex(u64)` | `String` | Index-to-ID map for paginated listing |
+
+---
+
+*Built with â¤ï¸ on [Stellar](https://stellar.org) & [Soroban](https://soroban.stellar.org)*

--- a/README.md
+++ b/README.md
@@ -226,6 +226,36 @@ Stellar's speed and near-zero cost make it ideal for supply chain use cases wher
 
 ---
 
+
+---
+
+## Architecture Decision Records
+
+Key architectural decisions are documented in [docs/adr/](docs/adr/):
+
+| ADR | Decision |
+|---|---|
+| [ADR-001](docs/adr/ADR-001-stellar-soroban-over-ethereum.md) | Why Stellar/Soroban over Ethereum |
+| [ADR-002](docs/adr/ADR-002-nextjs-app-router.md) | Why Next.js App Router over Pages Router |
+| [ADR-003](docs/adr/ADR-003-zustand-over-redux.md) | Why Zustand over Redux/Context |
+| [ADR-004](docs/adr/ADR-004-freighter-wallet.md) | Why Freighter as the wallet provider |
+
+---
+
+## UI Component Library
+
+Stories for all UI components are written with [Storybook](https://storybook.js.org).
+
+```bash
+cd frontend
+npm install
+npm run storybook
+# -> http://localhost:6006
+```
+
+Components covered: `Button` (all variants), `Card`, `Badge` (all event types), `WalletConnect` (connected/disconnected/loading), `ProductCard`, `EventTimeline`.
+
+Visual regression tests run automatically on every PR via [Chromatic](https://www.chromatic.com). Set `CHROMATIC_PROJECT_TOKEN` in your repository secrets to enable it.
 ## Contributing
 
 Contributions are welcome across all skill levels â€” smart contracts, frontend, docs, design, and testing.

--- a/docs/adr/ADR-001-stellar-soroban-over-ethereum.md
+++ b/docs/adr/ADR-001-stellar-soroban-over-ethereum.md
@@ -1,0 +1,49 @@
+# ADR-001: Choice of Stellar/Soroban over Ethereum
+
+**Status:** Accepted  
+**Date:** 2024-01-15  
+**Deciders:** Core team
+
+---
+
+## Context
+
+Supply-Link records every supply-chain event on-chain. A typical product journey generates 4–20 events. With thousands of products in flight simultaneously, the platform needs to handle tens of thousands of on-chain writes per day at a cost that is viable for small producers (Ethiopian farmers, small-batch manufacturers) who cannot absorb $10–100 gas fees per transaction.
+
+We evaluated three platforms:
+
+| Criterion | Stellar/Soroban | Ethereum (L1) | Ethereum L2 (Arbitrum) |
+|---|---|---|---|
+| Finality | ~5 seconds | 12–15 min (probabilistic) | ~1 min |
+| Tx cost | ~$0.00001 | $10–100 | $0.01–0.50 |
+| Smart contract language | Rust (Soroban SDK) | Solidity | Solidity |
+| Native cross-border payments | Yes (Stellar DEX, anchors) | No | No |
+| Ecosystem maturity | Growing | Very mature | Mature |
+| Energy model | Federated Byzantine Agreement | Proof of Stake | Proof of Stake |
+
+---
+
+## Decision
+
+We will build on **Stellar** using **Soroban** smart contracts written in Rust.
+
+---
+
+## Consequences
+
+**Positive:**
+- Near-zero transaction costs make it economically viable for every supply-chain participant to sign their own events, even at high volume.
+- 5-second finality means QR verification is near-real-time — consumers get an up-to-date product history immediately after scanning.
+- Rust + Soroban SDK gives us memory safety, a strong type system, and deterministic WASM execution — all desirable properties for auditable supply-chain logic.
+- Stellar's built-in cross-border payment rails open a future path to paying producers directly on-chain.
+- The Freighter wallet is a first-class browser extension for Stellar, giving us a polished wallet UX without building our own.
+
+**Negative / Trade-offs:**
+- Soroban is newer than the EVM ecosystem; fewer third-party auditors and tooling options exist today.
+- The developer talent pool for Soroban/Rust is smaller than Solidity.
+- No EVM compatibility means we cannot reuse existing Solidity contracts or EVM tooling (Hardhat, Foundry, etc.).
+- Stellar's storage model (persistent vs. temporary vs. instance) requires careful rent management that Ethereum developers are not accustomed to.
+
+**Mitigations:**
+- We document the storage model explicitly in the contract source and in `docs/adr/`.
+- We write comprehensive `///` doc comments and generate HTML docs via `cargo doc` to compensate for the smaller auditor pool.

--- a/docs/adr/ADR-002-nextjs-app-router.md
+++ b/docs/adr/ADR-002-nextjs-app-router.md
@@ -1,0 +1,46 @@
+# ADR-002: Next.js App Router over Pages Router
+
+**Status:** Accepted  
+**Date:** 2024-01-15  
+**Deciders:** Core team
+
+---
+
+## Context
+
+The Supply-Link frontend needs:
+
+1. A public, unauthenticated QR verification page (`/verify/[id]`) that should be server-rendered for SEO and fast first paint.
+2. An authenticated app shell (`/dashboard`, `/products`, `/tracking`) that is client-rendered and wallet-gated.
+3. Nested layouts — the app shell has a persistent Navbar; the marketing landing page does not.
+4. Streaming and Suspense support for progressive loading of on-chain data.
+
+We chose Next.js as the framework. Within Next.js we had to decide between the **Pages Router** (stable, widely documented) and the **App Router** (introduced in Next.js 13, stable from 13.4+).
+
+---
+
+## Decision
+
+We will use the **Next.js App Router** (`app/` directory).
+
+---
+
+## Consequences
+
+**Positive:**
+- Nested layouts (`app/(app)/layout.tsx` vs `app/layout.tsx`) let us share the Navbar only inside the authenticated shell without prop-drilling or conditional rendering hacks.
+- React Server Components allow the `/verify/[id]` page to fetch on-chain data server-side, improving SEO and time-to-first-byte for consumers scanning QR codes.
+- `loading.tsx` files give us automatic Suspense boundaries with skeleton UIs at the route level — no manual `<Suspense>` wrapping needed.
+- `error.tsx` files provide per-route error boundaries, isolating wallet or contract errors to the affected page.
+- Route groups (`(app)`, `(marketing)`) let us co-locate related routes without affecting the URL structure.
+- This is the direction Next.js is investing in; Pages Router is in maintenance mode.
+
+**Negative / Trade-offs:**
+- App Router has a steeper learning curve than Pages Router, especially around the Server/Client component boundary and `"use client"` directives.
+- Some third-party libraries (particularly those that use browser APIs at module load time) require `"use client"` wrappers — e.g. `html5-qrcode`, Freighter API.
+- Caching behaviour (fetch cache, `revalidate`) is more complex than `getServerSideProps` / `getStaticProps`.
+- Fewer community examples exist compared to Pages Router.
+
+**Mitigations:**
+- All wallet and blockchain interactions are isolated in `lib/stellar/` and wrapped in `"use client"` components, keeping the Server/Client boundary explicit.
+- We use `loading.tsx` skeletons consistently so the complexity of Suspense is hidden from feature developers.

--- a/docs/adr/ADR-003-zustand-over-redux.md
+++ b/docs/adr/ADR-003-zustand-over-redux.md
@@ -1,0 +1,53 @@
+# ADR-003: Zustand over Redux/Context for State Management
+
+**Status:** Accepted  
+**Date:** 2024-01-15  
+**Deciders:** Core team
+
+---
+
+## Context
+
+Supply-Link needs to share state across multiple routes and components:
+
+- **Wallet state** — connected address, XLM balance, network mismatch flag.
+- **Product list** — fetched from the Soroban contract, cached client-side.
+- **Transaction state** — pending/confirmed/failed status for in-flight on-chain transactions.
+
+We evaluated three options:
+
+| Criterion | Zustand | Redux Toolkit | React Context + useReducer |
+|---|---|---|---|
+| Bundle size | ~1 KB | ~15 KB | 0 (built-in) |
+| Boilerplate | Minimal | Moderate (slices, actions) | Moderate (reducers, providers) |
+| DevTools | Yes (Redux DevTools via middleware) | Yes (first-class) | No |
+| Async actions | Simple (plain async functions) | `createAsyncThunk` | Manual |
+| Outside-React access | Yes (`useStore.getState()`) | Yes (`store.getState()`) | No |
+| TypeScript ergonomics | Excellent | Good | Good |
+| Re-render control | Selector-based, fine-grained | Selector-based | Coarse (whole subtree) |
+
+---
+
+## Decision
+
+We will use **Zustand** for all global client state.
+
+---
+
+## Consequences
+
+**Positive:**
+- Minimal boilerplate: the entire store is defined in a single `lib/state/store.ts` file with no action creators, reducers, or provider wrappers.
+- Fine-grained subscriptions via selectors prevent unnecessary re-renders — important for wallet state that is read by many components.
+- Async wallet operations (connect, fetch balance) are plain `async` functions inside the store — no middleware or thunk configuration needed.
+- The store is accessible outside React components (e.g. in `lib/stellar/` utility functions) via `useStore.getState()`.
+- Tiny bundle footprint (~1 KB) is appropriate for a dApp where users may be on mobile connections.
+
+**Negative / Trade-offs:**
+- No built-in time-travel debugging (Redux DevTools integration requires the `zustand/middleware` devtools middleware).
+- Less opinionated structure means discipline is needed to keep the store from growing into a monolith — we mitigate this by keeping domain slices as separate objects within the store.
+- Smaller ecosystem of middleware compared to Redux.
+
+**Mitigations:**
+- The store is kept in a single file (`lib/state/store.ts`) and reviewed as part of every PR that touches state.
+- We add the Zustand devtools middleware in development builds for debugging.

--- a/docs/adr/ADR-004-freighter-wallet.md
+++ b/docs/adr/ADR-004-freighter-wallet.md
@@ -1,0 +1,55 @@
+# ADR-004: Freighter as the Wallet Provider
+
+**Status:** Accepted  
+**Date:** 2024-01-15  
+**Deciders:** Core team
+
+---
+
+## Context
+
+Supply-Link requires users (producers, processors, shippers, retailers) to sign Soroban transactions from a browser. We needed a wallet solution that:
+
+1. Supports Stellar/Soroban transaction signing natively.
+2. Has a browser extension available for Chrome/Firefox/Brave.
+3. Exposes a JavaScript API we can call from Next.js.
+4. Is actively maintained and has a security track record.
+5. Does not require users to expose their private key to the dApp.
+
+We evaluated:
+
+| Option | Stellar native | Soroban support | Browser extension | JS API | Maintained by |
+|---|---|---|---|---|---|
+| **Freighter** | Yes | Yes | Yes (Chrome, Firefox, Brave) | `@stellar/freighter-api` | Stellar Development Foundation |
+| Albedo | Yes | Partial | Web-based (no extension) | Yes | Community |
+| Rabet | Yes | Partial | Yes | Yes | Community |
+| WalletConnect | No (EVM-focused) | No | N/A | Yes | WalletConnect Foundation |
+| Hardware wallet (Ledger) | Yes | Partial | Via Ledger Live | Limited | Ledger |
+
+---
+
+## Decision
+
+We will use **Freighter** as the sole wallet provider, integrated via the official `@stellar/freighter-api` npm package.
+
+---
+
+## Consequences
+
+**Positive:**
+- Freighter is maintained by the Stellar Development Foundation — the same organisation that maintains Soroban. This alignment means Freighter is always updated alongside new Soroban features.
+- `@stellar/freighter-api` provides a clean, promise-based API for address retrieval, network detection, and transaction signing — no raw XDR manipulation needed in the frontend.
+- Users never expose their private key; Freighter signs transactions inside the extension sandbox.
+- Network mismatch detection (`getNetworkDetails()`) lets us warn users when their Freighter is on mainnet while the app targets testnet.
+- The extension is available on all major Chromium-based browsers and Firefox, covering the vast majority of our target users.
+
+**Negative / Trade-offs:**
+- Users must install the Freighter browser extension before they can interact with the dApp — this is a friction point for first-time users.
+- Mobile browsers are not supported (Freighter is desktop-only). Mobile support is deferred to Phase 3.
+- We are coupled to a single wallet provider. If Freighter is deprecated or has a security incident, we would need to integrate an alternative.
+- No WalletConnect support means users with hardware wallets or mobile-only setups cannot use the dApp today.
+
+**Mitigations:**
+- We show a `FreighterNotInstalledModal` with a direct install link when the extension is not detected, reducing drop-off.
+- All wallet interactions are abstracted behind `lib/stellar/client.ts` — swapping the wallet provider in the future requires changes only in that file.
+- We monitor Freighter's GitHub and security advisories as part of our dependency review process.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,35 @@
+# Architecture Decision Records
+
+This directory contains Architecture Decision Records (ADRs) for Supply-Link.
+
+An ADR documents a significant architectural decision: the context that led to it, the decision itself, and its consequences (positive and negative).
+
+## Index
+
+| ADR | Title | Status |
+|---|---|---|
+| [ADR-001](ADR-001-stellar-soroban-over-ethereum.md) | Choice of Stellar/Soroban over Ethereum | Accepted |
+| [ADR-002](ADR-002-nextjs-app-router.md) | Next.js App Router over Pages Router | Accepted |
+| [ADR-003](ADR-003-zustand-over-redux.md) | Zustand over Redux/Context for State Management | Accepted |
+| [ADR-004](ADR-004-freighter-wallet.md) | Freighter as the Wallet Provider | Accepted |
+
+## Template
+
+New ADRs should follow this structure:
+
+```markdown
+# ADR-NNN: Title
+
+**Status:** Proposed | Accepted | Deprecated | Superseded by ADR-NNN  
+**Date:** YYYY-MM-DD  
+**Deciders:** [names or team]
+
+## Context
+What is the issue that motivates this decision?
+
+## Decision
+What is the change we are making?
+
+## Consequences
+What becomes easier or harder as a result?
+```

--- a/frontend/.storybook/main.ts
+++ b/frontend/.storybook/main.ts
@@ -1,0 +1,19 @@
+import type { StorybookConfig } from "@storybook/nextjs";
+
+const config: StorybookConfig = {
+  stories: ["../components/**/*.stories.@(ts|tsx)", "../app/**/*.stories.@(ts|tsx)"],
+  addons: [
+    "@storybook/addon-essentials",
+    "@storybook/addon-interactions",
+    "@storybook/addon-a11y",
+  ],
+  framework: {
+    name: "@storybook/nextjs",
+    options: {},
+  },
+  docs: {
+    autodocs: "tag",
+  },
+};
+
+export default config;

--- a/frontend/.storybook/preview.ts
+++ b/frontend/.storybook/preview.ts
@@ -1,0 +1,18 @@
+import type { Preview } from "@storybook/react";
+import "../app/globals.css";
+
+const preview: Preview = {
+  parameters: {
+    controls: {
+      matchers: {
+        color: /(background|color)$/i,
+        date: /Date$/i,
+      },
+    },
+    nextjs: {
+      appDirectory: true,
+    },
+  },
+};
+
+export default preview;

--- a/frontend/components/products/ProductCard.stories.tsx
+++ b/frontend/components/products/ProductCard.stories.tsx
@@ -1,0 +1,92 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { Card, CardHeader, CardContent } from "@/components/ui/Card";
+import type { Product } from "@/lib/types";
+
+/** Standalone product card extracted from the products list page. */
+const meta: Meta = {
+  title: "Products/ProductCard",
+  tags: ["autodocs"],
+};
+
+export default meta;
+type Story = StoryObj;
+
+function ProductCard({ product }: { product: Product }) {
+  return (
+    <Card className="max-w-xs">
+      <CardHeader>
+        <div className="flex items-start justify-between gap-2">
+          <h2 className="text-lg font-semibold leading-tight">{product.name}</h2>
+          <span
+            className={`shrink-0 text-xs px-2 py-0.5 rounded-full font-medium ${
+              product.active
+                ? "bg-green-500/10 text-green-500"
+                : "bg-gray-100 text-gray-400"
+            }`}
+          >
+            {product.active ? "Active" : "Inactive"}
+          </span>
+        </div>
+        <p className="text-sm text-gray-500 mt-1">Origin: {product.origin}</p>
+        <p className="text-xs text-gray-400 mt-1 font-mono truncate">ID: {product.id}</p>
+      </CardHeader>
+      <CardContent>
+        <div className="w-40 h-40 bg-gray-100 rounded-lg flex items-center justify-center text-xs text-gray-400">
+          QR Code
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+const baseProduct: Product = {
+  id: "prod-a1b2c3d4",
+  name: "Arabica Coffee Beans",
+  origin: "Yirgacheffe, Ethiopia",
+  owner: "GBXYZ1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ",
+  timestamp: Date.now(),
+  active: true,
+  authorizedActors: [],
+};
+
+export const Active: Story = {
+  render: () => <ProductCard product={baseProduct} />,
+};
+
+export const Inactive: Story = {
+  render: () => <ProductCard product={{ ...baseProduct, active: false }} />,
+};
+
+export const LongName: Story = {
+  render: () => (
+    <ProductCard
+      product={{
+        ...baseProduct,
+        name: "Single-Origin Fair-Trade Organic Arabica Coffee Beans — Premium Grade",
+      }}
+    />
+  ),
+};
+
+export const PharmaceuticalProduct: Story = {
+  render: () => (
+    <ProductCard
+      product={{
+        ...baseProduct,
+        id: "med-rx-00421",
+        name: "Amoxicillin 500mg",
+        origin: "Pfizer, Kalamazoo MI",
+      }}
+    />
+  ),
+};
+
+export const Grid: Story = {
+  render: () => (
+    <div className="grid grid-cols-3 gap-4 p-4">
+      <ProductCard product={baseProduct} />
+      <ProductCard product={{ ...baseProduct, id: "prod-b2c3d4e5", name: "Silk Fabric", origin: "Suzhou, China" }} />
+      <ProductCard product={{ ...baseProduct, id: "prod-c3d4e5f6", name: "Conflict-Free Cobalt", origin: "DRC Certified Mine", active: false }} />
+    </div>
+  ),
+};

--- a/frontend/components/tracking/EventTimeline.stories.tsx
+++ b/frontend/components/tracking/EventTimeline.stories.tsx
@@ -1,0 +1,88 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { EventTimeline } from "./EventTimeline";
+import type { TrackingEvent } from "@/lib/types";
+
+const meta: Meta<typeof EventTimeline> = {
+  title: "Tracking/EventTimeline",
+  component: EventTimeline,
+  tags: ["autodocs"],
+  parameters: { layout: "padded" },
+};
+
+export default meta;
+type Story = StoryObj<typeof EventTimeline>;
+
+const ACTOR = "GBXYZ1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+const PRODUCT_ID = "prod-a1b2c3d4";
+
+const fullJourney: TrackingEvent[] = [
+  {
+    productId: PRODUCT_ID,
+    location: "Yirgacheffe, Ethiopia",
+    actor: ACTOR,
+    timestamp: Date.now() - 1000 * 60 * 60 * 24 * 10,
+    eventType: "HARVEST",
+    metadata: JSON.stringify({ altitude: "1900m", variety: "Heirloom", certifiedOrganic: true }),
+  },
+  {
+    productId: PRODUCT_ID,
+    location: "Addis Ababa Processing Plant",
+    actor: ACTOR,
+    timestamp: Date.now() - 1000 * 60 * 60 * 24 * 7,
+    eventType: "PROCESSING",
+    metadata: JSON.stringify({ method: "Washed", moisture: "11%", grade: "Grade 1" }),
+  },
+  {
+    productId: PRODUCT_ID,
+    location: "Port of Djibouti",
+    actor: ACTOR,
+    timestamp: Date.now() - 1000 * 60 * 60 * 24 * 4,
+    eventType: "SHIPPING",
+    metadata: JSON.stringify({ vessel: "MSC Beatrice", container: "MSCU1234567", destination: "Rotterdam" }),
+  },
+  {
+    productId: PRODUCT_ID,
+    location: "Blue Bottle Coffee, Seattle WA",
+    actor: ACTOR,
+    timestamp: Date.now() - 1000 * 60 * 60 * 24 * 1,
+    eventType: "RETAIL",
+    metadata: JSON.stringify({ sku: "BB-ETH-001", price: "$24.99", batchSize: "200 bags" }),
+  },
+];
+
+export const FullJourney: Story = {
+  args: { events: fullJourney },
+};
+
+export const SingleEvent: Story = {
+  args: { events: [fullJourney[0]] },
+};
+
+export const HarvestOnly: Story = {
+  args: {
+    events: [fullJourney[0]],
+  },
+};
+
+export const NoMetadata: Story = {
+  args: {
+    events: fullJourney.map((e) => ({ ...e, metadata: "{}" })),
+  },
+};
+
+export const Empty: Story = {
+  args: { events: [] },
+};
+
+export const ManyEvents: Story = {
+  args: {
+    events: Array.from({ length: 12 }, (_, i) => ({
+      productId: PRODUCT_ID,
+      location: `Checkpoint ${i + 1}`,
+      actor: ACTOR,
+      timestamp: Date.now() - 1000 * 60 * 60 * 24 * (12 - i),
+      eventType: (["HARVEST", "PROCESSING", "SHIPPING", "RETAIL"] as const)[i % 4],
+      metadata: "{}",
+    })),
+  },
+};

--- a/frontend/components/ui/Badge.stories.tsx
+++ b/frontend/components/ui/Badge.stories.tsx
@@ -1,0 +1,49 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { Badge } from "./Badge";
+
+const meta: Meta<typeof Badge> = {
+  title: "UI/Badge",
+  component: Badge,
+  tags: ["autodocs"],
+  argTypes: {
+    variant: {
+      control: "select",
+      options: ["harvest", "processing", "shipping", "retail", "default"],
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Badge>;
+
+export const Harvest: Story = {
+  args: { children: "HARVEST", variant: "harvest" },
+};
+
+export const Processing: Story = {
+  args: { children: "PROCESSING", variant: "processing" },
+};
+
+export const Shipping: Story = {
+  args: { children: "SHIPPING", variant: "shipping" },
+};
+
+export const Retail: Story = {
+  args: { children: "RETAIL", variant: "retail" },
+};
+
+export const Default: Story = {
+  args: { children: "UNKNOWN", variant: "default" },
+};
+
+export const AllEventTypes: Story = {
+  render: () => (
+    <div className="flex flex-wrap gap-2 p-4">
+      <Badge variant="harvest">HARVEST</Badge>
+      <Badge variant="processing">PROCESSING</Badge>
+      <Badge variant="shipping">SHIPPING</Badge>
+      <Badge variant="retail">RETAIL</Badge>
+      <Badge variant="default">UNKNOWN</Badge>
+    </div>
+  ),
+};

--- a/frontend/components/ui/Button.stories.tsx
+++ b/frontend/components/ui/Button.stories.tsx
@@ -1,0 +1,62 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { Button } from "./Button";
+
+const meta: Meta<typeof Button> = {
+  title: "UI/Button",
+  component: Button,
+  tags: ["autodocs"],
+  argTypes: {
+    variant: {
+      control: "select",
+      options: ["primary", "secondary", "destructive", "ghost"],
+    },
+    size: {
+      control: "select",
+      options: ["sm", "md", "lg"],
+    },
+    disabled: { control: "boolean" },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Button>;
+
+export const Primary: Story = {
+  args: { children: "Connect Wallet", variant: "primary", size: "md" },
+};
+
+export const Secondary: Story = {
+  args: { children: "Cancel", variant: "secondary", size: "md" },
+};
+
+export const Destructive: Story = {
+  args: { children: "Revoke Access", variant: "destructive", size: "md" },
+};
+
+export const Ghost: Story = {
+  args: { children: "Learn More", variant: "ghost", size: "md" },
+};
+
+export const Small: Story = {
+  args: { children: "Small", variant: "primary", size: "sm" },
+};
+
+export const Large: Story = {
+  args: { children: "Register Product", variant: "primary", size: "lg" },
+};
+
+export const Disabled: Story = {
+  args: { children: "Connecting…", variant: "primary", disabled: true },
+};
+
+export const AllVariants: Story = {
+  render: () => (
+    <div className="flex flex-wrap gap-3 p-4">
+      <Button variant="primary">Primary</Button>
+      <Button variant="secondary">Secondary</Button>
+      <Button variant="destructive">Destructive</Button>
+      <Button variant="ghost">Ghost</Button>
+      <Button variant="primary" disabled>Disabled</Button>
+    </div>
+  ),
+};

--- a/frontend/components/ui/Card.stories.tsx
+++ b/frontend/components/ui/Card.stories.tsx
@@ -1,0 +1,73 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { Card, CardHeader, CardContent, CardFooter } from "./Card";
+import { Button } from "./Button";
+
+const meta: Meta<typeof Card> = {
+  title: "UI/Card",
+  component: Card,
+  tags: ["autodocs"],
+};
+
+export default meta;
+type Story = StoryObj<typeof Card>;
+
+export const Default: Story = {
+  render: () => (
+    <Card className="max-w-sm">
+      <CardContent>A simple card with content.</CardContent>
+    </Card>
+  ),
+};
+
+export const WithHeader: Story = {
+  render: () => (
+    <Card className="max-w-sm">
+      <CardHeader>
+        <h3 className="font-semibold text-base">Arabica Coffee Beans</h3>
+        <p className="text-sm text-gray-500">Origin: Yirgacheffe, Ethiopia</p>
+      </CardHeader>
+      <CardContent>
+        <p className="text-sm">Registered on-chain with ID: <code>prod-a1b2c3d4</code></p>
+      </CardContent>
+    </Card>
+  ),
+};
+
+export const WithFooter: Story = {
+  render: () => (
+    <Card className="max-w-sm">
+      <CardHeader>
+        <h3 className="font-semibold text-base">Transfer Ownership</h3>
+      </CardHeader>
+      <CardContent>
+        <p className="text-sm">Transfer this product to a new owner on-chain.</p>
+      </CardContent>
+      <CardFooter>
+        <Button variant="secondary" size="sm">Cancel</Button>
+        <Button variant="primary" size="sm">Confirm Transfer</Button>
+      </CardFooter>
+    </Card>
+  ),
+};
+
+export const ProductCard: Story = {
+  render: () => (
+    <Card className="max-w-xs">
+      <CardHeader>
+        <div className="flex items-start justify-between gap-2">
+          <h2 className="text-lg font-semibold leading-tight">Organic Coffee Beans</h2>
+          <span className="shrink-0 text-xs px-2 py-0.5 rounded-full font-medium bg-green-500/10 text-green-500">
+            Active
+          </span>
+        </div>
+        <p className="text-sm text-gray-500 mt-1">Origin: Ethiopia</p>
+        <p className="text-xs text-gray-400 mt-1 font-mono truncate">ID: prod-a1b2c3d4</p>
+      </CardHeader>
+      <CardContent>
+        <div className="w-32 h-32 bg-gray-100 rounded-lg flex items-center justify-center text-xs text-gray-400">
+          QR Code
+        </div>
+      </CardContent>
+    </Card>
+  ),
+};

--- a/frontend/components/wallet/WalletConnect.stories.tsx
+++ b/frontend/components/wallet/WalletConnect.stories.tsx
@@ -1,0 +1,75 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { Button } from "@/components/ui/Button";
+
+/**
+ * WalletConnect integrates with Zustand store and Freighter browser extension,
+ * so we render controlled display-only versions for each state.
+ */
+const meta: Meta = {
+  title: "Wallet/WalletConnect",
+  tags: ["autodocs"],
+};
+
+export default meta;
+type Story = StoryObj;
+
+/** Disconnected — the default state before the user connects. */
+export const Disconnected: Story = {
+  render: () => (
+    <div className="p-4">
+      <Button variant="primary" size="md">Connect Freighter</Button>
+    </div>
+  ),
+};
+
+/** Loading — shown while the Freighter handshake is in progress. */
+export const Loading: Story = {
+  render: () => (
+    <div className="p-4">
+      <Button variant="primary" size="md" disabled>Connecting…</Button>
+    </div>
+  ),
+};
+
+/** Connected — shows the truncated address, XLM balance, and disconnect button. */
+export const Connected: Story = {
+  render: () => (
+    <div className="p-4 flex items-center gap-2">
+      <button className="text-sm font-mono text-green-600 flex items-center gap-1">
+        GBXYZ…A1B2
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+          <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" />
+          <polyline points="15 3 21 3 21 9" />
+          <line x1="10" y1="14" x2="21" y2="3" />
+        </svg>
+      </button>
+      <span className="text-xs text-gray-500 bg-gray-100 px-2 py-1 rounded">
+        142.50 XLM
+      </span>
+      <button className="p-2 rounded hover:bg-gray-100" aria-label="Disconnect wallet">
+        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+          <path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4" />
+          <polyline points="16 17 21 12 16 7" />
+          <line x1="21" y1="12" x2="9" y2="12" />
+        </svg>
+      </button>
+    </div>
+  ),
+};
+
+/** ConnectedLowBalance — balance below the recommended threshold. */
+export const ConnectedLowBalance: Story = {
+  render: () => (
+    <div className="p-4 flex flex-col gap-2">
+      <div className="flex items-center gap-2">
+        <button className="text-sm font-mono text-green-600 flex items-center gap-1">
+          GBXYZ…A1B2
+        </button>
+        <span className="text-xs text-red-500 bg-red-50 px-2 py-1 rounded font-medium">
+          0.50 XLM ⚠
+        </span>
+      </div>
+      <p className="text-xs text-red-500">Low balance — transactions may fail.</p>
+    </div>
+  ),
+};

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,7 +7,9 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint",
-    "test": "vitest run"
+    "test": "vitest run",
+    "storybook": "storybook dev -p 6006",
+    "build-storybook": "storybook build"
   },
   "dependencies": {
     "@hookform/resolvers": "^5.2.2",
@@ -34,6 +36,13 @@
     "zustand": "^5.0.8"
   },
   "devDependencies": {
+    "@chromatic-com/storybook": "^3",
+    "@storybook/addon-a11y": "^8",
+    "@storybook/addon-essentials": "^8",
+    "@storybook/addon-interactions": "^8",
+    "@storybook/nextjs": "^8",
+    "@storybook/react": "^8",
+    "@storybook/test": "^8",
     "@tailwindcss/postcss": "^4",
     "@types/node": "^20",
     "@types/qrcode": "^1.5.6",
@@ -41,6 +50,7 @@
     "@types/react-dom": "^19",
     "eslint": "^9",
     "eslint-config-next": "16.1.6",
+    "storybook": "^8",
     "tailwindcss": "^4",
     "typescript": "^5",
     "vite-tsconfig-paths": "^5.1.4",

--- a/smart-contract/contracts/src/lib.rs
+++ b/smart-contract/contracts/src/lib.rs
@@ -3,46 +3,156 @@ use soroban_sdk::{contract, contractimpl, contracttype, Address, Env, String, Ve
 
 // ── Data models ──────────────────────────────────────────────────────────────
 
+/// Represents a product registered on the Supply-Link blockchain.
+///
+/// Products are the core entity of the supply chain. Once registered, a product
+/// accumulates [`TrackingEvent`]s as it moves through the supply chain. The
+/// `owner` field always reflects the *current* custodian; historical ownership
+/// is captured implicitly through `ownership_transferred` events.
+///
+/// # Storage
+/// Stored under [`DataKey::Product`] using the product's `id` as the key.
+/// Storage type is `persistent`, so entries survive ledger archival as long as
+/// the rent is paid.
 #[contracttype]
 #[derive(Clone)]
 pub struct Product {
+    /// Caller-supplied unique identifier for this product (e.g. `"batch-2024-001"`).
+    /// Must be unique across all registered products; duplicate IDs will silently
+    /// overwrite the existing entry.
     pub id: String,
+    /// Human-readable product name (e.g. `"Arabica Coffee Beans"`).
     pub name: String,
+    /// Geographic or organisational origin of the product
+    /// (e.g. `"Yirgacheffe, Ethiopia"`).
     pub origin: String,
+    /// Stellar address of the current product owner.
+    /// Only this address may call owner-gated functions such as
+    /// [`SupplyLinkContract::transfer_ownership`] and
+    /// [`SupplyLinkContract::add_authorized_actor`].
     pub owner: Address,
+    /// Unix timestamp (seconds) recorded by the Soroban ledger at registration
+    /// time. Set automatically; callers cannot supply this value.
     pub timestamp: u64,
+    /// Addresses that are permitted to call
+    /// [`SupplyLinkContract::add_tracking_event`] for this product in addition
+    /// to the owner. Managed via [`SupplyLinkContract::add_authorized_actor`]
+    /// and [`SupplyLinkContract::remove_authorized_actor`].
     pub authorized_actors: Vec<Address>,
 }
 
+/// A single supply-chain event recorded against a [`Product`].
+///
+/// Events are append-only. Once written they cannot be modified or deleted,
+/// providing an immutable audit trail. All events for a product are stored
+/// together under [`DataKey::Events`].
+///
+/// # Storage
+/// Stored as a `Vec<TrackingEvent>` under [`DataKey::Events`] keyed by
+/// `product_id`. Storage type is `persistent`.
 #[contracttype]
 #[derive(Clone)]
 pub struct TrackingEvent {
+    /// ID of the [`Product`] this event belongs to.
     pub product_id: String,
+    /// Free-form location string describing where the event occurred
+    /// (e.g. `"Port of Rotterdam, Netherlands"`).
     pub location: String,
+    /// Stellar address of the supply-chain participant who recorded this event.
+    /// Must be the product owner or an address in `authorized_actors`.
     pub actor: Address,
+    /// Unix timestamp (seconds) recorded by the Soroban ledger when the event
+    /// was submitted. Set automatically; callers cannot supply this value.
     pub timestamp: u64,
-    pub event_type: String, // HARVEST | PROCESSING | SHIPPING | RETAIL
-    pub metadata: String,   // JSON string
+    /// Supply-chain stage. Accepted values: `"HARVEST"`, `"PROCESSING"`,
+    /// `"SHIPPING"`, `"RETAIL"`. The contract stores this as a raw string and
+    /// does not validate the value — callers are responsible for using a
+    /// recognised stage name.
+    pub event_type: String,
+    /// Arbitrary JSON string carrying stage-specific metadata
+    /// (e.g. `{"temperature":"4°C","humidity":"60%"}`). The contract stores
+    /// this opaquely; consumers are responsible for parsing it.
+    pub metadata: String,
 }
 
 // ── Storage keys ─────────────────────────────────────────────────────────────
 
+/// Enumeration of all persistent storage keys used by the contract.
+///
+/// Using a typed enum prevents key collisions and makes storage layout
+/// explicit for auditors.
+///
+/// # Variants
+/// - [`DataKey::Product`] — stores a single [`Product`] by its string ID.
+/// - [`DataKey::Events`] — stores a `Vec<TrackingEvent>` for a product ID.
+/// - [`DataKey::ProductCount`] — stores a `u64` global counter of registered products.
+/// - [`DataKey::ProductIndex`] — maps a sequential `u64` index to a product ID
+///   string, enabling paginated listing via [`SupplyLinkContract::list_products`].
 #[contracttype]
 pub enum DataKey {
+    /// Key for a [`Product`] entry. The inner `String` is the product ID.
     Product(String),
+    /// Key for the event log of a product. The inner `String` is the product ID.
     Events(String),
+    /// Key for the global product registration counter.
     ProductCount,
+    /// Key for the index-to-ID mapping used by pagination.
+    /// The inner `u64` is the zero-based insertion index.
     ProductIndex(u64),
 }
 
 // ── Contract ─────────────────────────────────────────────────────────────────
 
+/// The Supply-Link Soroban smart contract.
+///
+/// Provides a decentralised, tamper-proof registry for supply-chain products
+/// and their associated tracking events on the Stellar blockchain.
+///
+/// # Deployment
+/// Testnet contract ID: `CBUWSKT2UGOAXK4ZREVDJV5XHSYB42PZ3CERU2ZFUTUMAZLJEHNZIECA`
+///
+/// # Authorization model
+/// - **Owner-gated** functions (`transfer_ownership`, `add_authorized_actor`,
+///   `remove_authorized_actor`, `update_product_metadata`) require the current
+///   product owner to sign the transaction via `require_auth()`.
+/// - **Actor-gated** functions (`add_tracking_event`) accept either the owner
+///   or any address in `authorized_actors`.
+/// - **Read-only** functions (`get_product`, `get_tracking_events`, etc.) have
+///   no authorization requirements.
 #[contract]
 pub struct SupplyLinkContract;
 
 #[contractimpl]
 impl SupplyLinkContract {
     /// Register a new product on-chain.
+    ///
+    /// Creates a [`Product`] entry in persistent storage and initialises the
+    /// global product counter and index mapping used by
+    /// [`Self::list_products`].
+    ///
+    /// # Parameters
+    /// - `env` — Soroban execution environment (injected by the runtime).
+    /// - `id` — Caller-supplied unique product identifier. If a product with
+    ///   this ID already exists it will be silently overwritten.
+    /// - `name` — Human-readable product name.
+    /// - `origin` — Geographic or organisational origin of the product.
+    /// - `owner` — Stellar address that will own the product. This address
+    ///   must sign the transaction.
+    ///
+    /// # Returns
+    /// The newly created [`Product`] struct.
+    ///
+    /// # Authorization
+    /// Requires `owner.require_auth()`. The transaction must be signed by
+    /// `owner`.
+    ///
+    /// # Panics
+    /// Does not panic under normal conditions. Panics if the Soroban runtime
+    /// rejects the auth check (i.e. `owner` did not sign).
+    ///
+    /// # Emitted Events
+    /// Publishes a `("product_registered", id)` event with the [`Product`]
+    /// struct as the event body.
     pub fn register_product(
         env: Env,
         id: String,
@@ -62,7 +172,7 @@ impl SupplyLinkContract {
         env.storage()
             .persistent()
             .set(&DataKey::Product(id.clone()), &product);
-        
+
         // Increment product count
         let count: u64 = env
             .storage()
@@ -72,23 +182,54 @@ impl SupplyLinkContract {
         env.storage()
             .persistent()
             .set(&DataKey::ProductCount, &(count + 1));
-        
+
         // Store product index mapping
         env.storage()
             .persistent()
             .set(&DataKey::ProductIndex(count), &id);
-        
+
         // Emit event
         env.events().publish(
             (Symbol::new(&env, "product_registered"), id.clone()),
-            product.clone()
+            product.clone(),
         );
-        
+
         product
     }
 
     /// Add a tracking event for a product.
-    /// `caller` must be the product owner or an address in `authorized_actors`.
+    ///
+    /// Appends a new [`TrackingEvent`] to the product's event log. The event
+    /// log is stored as a `Vec<TrackingEvent>` and grows with each call.
+    ///
+    /// # Parameters
+    /// - `env` — Soroban execution environment.
+    /// - `product_id` — ID of the product to record the event against.
+    /// - `caller` — Address of the supply-chain participant submitting the
+    ///   event. Must be the product owner or an address in
+    ///   `authorized_actors`.
+    /// - `location` — Free-form location string (e.g. `"Port of Hamburg"`).
+    /// - `event_type` — Supply-chain stage. Recommended values: `"HARVEST"`,
+    ///   `"PROCESSING"`, `"SHIPPING"`, `"RETAIL"`. Not validated by the
+    ///   contract.
+    /// - `metadata` — Arbitrary JSON string with stage-specific data.
+    ///
+    /// # Returns
+    /// The newly created [`TrackingEvent`] struct.
+    ///
+    /// # Authorization
+    /// Requires `caller.require_auth()`. The authorization check is performed
+    /// *after* verifying that `caller` is the owner or an authorized actor, so
+    /// unauthorized addresses are rejected before any auth overhead is incurred.
+    ///
+    /// # Panics
+    /// - `"product not found"` — if `product_id` is not registered.
+    /// - `"caller is not authorized"` — if `caller` is neither the product
+    ///   owner nor in `authorized_actors`.
+    ///
+    /// # Emitted Events
+    /// Publishes an `("event_added", product_id, event_type)` event with the
+    /// [`TrackingEvent`] struct as the event body.
     pub fn add_tracking_event(
         env: Env,
         product_id: String,
@@ -134,13 +275,26 @@ impl SupplyLinkContract {
         // Emit event
         env.events().publish(
             (Symbol::new(&env, "event_added"), product_id, event_type),
-            event.clone()
+            event.clone(),
         );
 
         event
     }
 
-    /// Get product details.
+    /// Retrieve a product by its ID.
+    ///
+    /// # Parameters
+    /// - `env` — Soroban execution environment.
+    /// - `id` — The product ID to look up.
+    ///
+    /// # Returns
+    /// The [`Product`] struct stored under `id`.
+    ///
+    /// # Authorization
+    /// None — this is a read-only function.
+    ///
+    /// # Panics
+    /// - `"product not found"` — if no product with `id` is registered.
     pub fn get_product(env: Env, id: String) -> Product {
         env.storage()
             .persistent()
@@ -148,7 +302,23 @@ impl SupplyLinkContract {
             .expect("product not found")
     }
 
-    /// Get all tracking events for a product.
+    /// Retrieve all tracking events for a product.
+    ///
+    /// Returns events in insertion order (oldest first).
+    ///
+    /// # Parameters
+    /// - `env` — Soroban execution environment.
+    /// - `product_id` — The product ID whose events to retrieve.
+    ///
+    /// # Returns
+    /// A `Vec<TrackingEvent>` containing every event recorded for the product.
+    /// Returns an empty vector if the product has no events or does not exist.
+    ///
+    /// # Authorization
+    /// None — this is a read-only function.
+    ///
+    /// # Panics
+    /// Does not panic.
     pub fn get_tracking_events(env: Env, product_id: String) -> Vec<TrackingEvent> {
         env.storage()
             .persistent()
@@ -156,15 +326,45 @@ impl SupplyLinkContract {
             .unwrap_or_else(|| Vec::new(&env))
     }
 
-    /// Returns true if a product with the given id is registered, false otherwise.
+    /// Check whether a product ID is registered.
+    ///
+    /// Useful for pre-flight checks before calling functions that panic on
+    /// unknown IDs.
+    ///
+    /// # Parameters
+    /// - `env` — Soroban execution environment.
+    /// - `id` — The product ID to check.
+    ///
+    /// # Returns
+    /// `true` if a product with `id` exists in storage, `false` otherwise.
+    ///
+    /// # Authorization
+    /// None — this is a read-only function.
+    ///
+    /// # Panics
+    /// Does not panic.
     pub fn product_exists(env: Env, id: String) -> bool {
-        env.storage()
-            .persistent()
-            .has(&DataKey::Product(id))
+        env.storage().persistent().has(&DataKey::Product(id))
     }
 
-    /// Returns the number of tracking events recorded for `product_id`.
-    /// Returns 0 if the product has no events or does not exist.
+    /// Return the number of tracking events recorded for a product.
+    ///
+    /// Equivalent to `get_tracking_events(product_id).len()` but cheaper
+    /// because it avoids deserialising the full event vector.
+    ///
+    /// # Parameters
+    /// - `env` — Soroban execution environment.
+    /// - `product_id` — The product ID to query.
+    ///
+    /// # Returns
+    /// The number of events as a `u32`. Returns `0` if the product has no
+    /// events or does not exist.
+    ///
+    /// # Authorization
+    /// None — this is a read-only function.
+    ///
+    /// # Panics
+    /// Does not panic.
     pub fn get_events_count(env: Env, product_id: String) -> u32 {
         env.storage()
             .persistent()
@@ -173,7 +373,30 @@ impl SupplyLinkContract {
             .unwrap_or(0)
     }
 
-    /// Transfer product ownership.
+    /// Transfer product ownership to a new address.
+    ///
+    /// Updates the `owner` field of the [`Product`] in storage. The previous
+    /// owner loses all owner-gated privileges immediately. The new owner gains
+    /// them immediately.
+    ///
+    /// # Parameters
+    /// - `env` — Soroban execution environment.
+    /// - `product_id` — ID of the product to transfer.
+    /// - `new_owner` — Stellar address of the incoming owner.
+    ///
+    /// # Returns
+    /// `true` on success.
+    ///
+    /// # Authorization
+    /// Requires the *current* `product.owner.require_auth()`. The transaction
+    /// must be signed by the current owner.
+    ///
+    /// # Panics
+    /// - `"product not found"` — if `product_id` is not registered.
+    ///
+    /// # Emitted Events
+    /// Publishes an `("ownership_transferred", product_id)` event with
+    /// `new_owner` as the event body.
     pub fn transfer_ownership(env: Env, product_id: String, new_owner: Address) -> bool {
         let mut product: Product = env
             .storage()
@@ -186,17 +409,40 @@ impl SupplyLinkContract {
         env.storage()
             .persistent()
             .set(&DataKey::Product(product_id.clone()), &product);
-        
+
         // Emit event
         env.events().publish(
             (Symbol::new(&env, "ownership_transferred"), product_id),
-            new_owner
+            new_owner,
         );
-        
+
         true
     }
 
-    /// Authorize an actor to add events for a product.
+    /// Grant an address permission to add tracking events for a product.
+    ///
+    /// Appends `actor` to `product.authorized_actors`. Duplicate entries are
+    /// not deduplicated by the contract — callers should check
+    /// [`Self::get_authorized_actors`] before calling if deduplication matters.
+    ///
+    /// # Parameters
+    /// - `env` — Soroban execution environment.
+    /// - `product_id` — ID of the product to update.
+    /// - `actor` — Stellar address to authorise.
+    ///
+    /// # Returns
+    /// `true` on success.
+    ///
+    /// # Authorization
+    /// Requires `product.owner.require_auth()`. Only the current product owner
+    /// may grant actor permissions.
+    ///
+    /// # Panics
+    /// - `"product not found"` — if `product_id` is not registered.
+    ///
+    /// # Emitted Events
+    /// Publishes an `("actor_authorized", product_id)` event with `actor` as
+    /// the event body.
     pub fn add_authorized_actor(env: Env, product_id: String, actor: Address) -> bool {
         let mut product: Product = env
             .storage()
@@ -209,19 +455,40 @@ impl SupplyLinkContract {
         env.storage()
             .persistent()
             .set(&DataKey::Product(product_id.clone()), &product);
-        
+
         // Emit event
         env.events().publish(
             (Symbol::new(&env, "actor_authorized"), product_id),
-            actor
+            actor,
         );
-        
+
         true
     }
 
-    /// Remove an authorized actor from a product.
-    /// Only the product owner may call this.
-    /// Returns true if the actor was removed, false if they were not in the list.
+    /// Revoke an address's permission to add tracking events for a product.
+    ///
+    /// Rebuilds `authorized_actors` without the first occurrence of `actor`.
+    /// If `actor` appears multiple times (due to duplicate `add_authorized_actor`
+    /// calls), only the first occurrence is removed.
+    ///
+    /// # Parameters
+    /// - `env` — Soroban execution environment.
+    /// - `product_id` — ID of the product to update.
+    /// - `actor` — Stellar address to revoke.
+    ///
+    /// # Returns
+    /// `true` if `actor` was found and removed, `false` if `actor` was not in
+    /// the authorized list.
+    ///
+    /// # Authorization
+    /// Requires `product.owner.require_auth()`. Only the current product owner
+    /// may revoke actor permissions.
+    ///
+    /// # Panics
+    /// - `"product not found"` — if `product_id` is not registered.
+    ///
+    /// # Emitted Events
+    /// Does not emit an event (removal is not currently announced on-chain).
     pub fn remove_authorized_actor(env: Env, product_id: String, actor: Address) -> bool {
         let mut product: Product = env
             .storage()
@@ -230,7 +497,7 @@ impl SupplyLinkContract {
             .expect("product not found");
 
         product.owner.require_auth();
-        
+
         // Find and remove the actor
         let mut found = false;
         let mut new_actors = Vec::new(&env);
@@ -242,18 +509,40 @@ impl SupplyLinkContract {
                 found = true;
             }
         }
-        
+
         product.authorized_actors = new_actors;
         env.storage()
             .persistent()
             .set(&DataKey::Product(product_id), &product);
-        
+
         found
     }
 
-    /// Update product metadata (name and origin).
-    /// Only the product owner may call this.
-    /// Does not allow changing id, owner, or timestamp.
+    /// Update the mutable metadata fields of a product.
+    ///
+    /// Only `name` and `origin` can be changed. The `id`, `owner`,
+    /// `timestamp`, and `authorized_actors` fields are immutable through this
+    /// function.
+    ///
+    /// # Parameters
+    /// - `env` — Soroban execution environment.
+    /// - `product_id` — ID of the product to update.
+    /// - `name` — New human-readable product name.
+    /// - `origin` — New origin string.
+    ///
+    /// # Returns
+    /// The updated [`Product`] struct.
+    ///
+    /// # Authorization
+    /// Requires `product.owner.require_auth()`. Only the current product owner
+    /// may update metadata.
+    ///
+    /// # Panics
+    /// - `"product not found"` — if `product_id` is not registered.
+    ///
+    /// # Emitted Events
+    /// Publishes a `("product_updated", product_id)` event with the updated
+    /// [`Product`] struct as the event body.
     pub fn update_product_metadata(
         env: Env,
         product_id: String,
@@ -267,25 +556,38 @@ impl SupplyLinkContract {
             .expect("product not found");
 
         product.owner.require_auth();
-        
+
         product.name = name;
         product.origin = origin;
-        
+
         env.storage()
             .persistent()
             .set(&DataKey::Product(product_id.clone()), &product);
-        
+
         // Emit event
         env.events().publish(
             (Symbol::new(&env, "product_updated"), product_id),
-            product.clone()
+            product.clone(),
         );
-        
+
         product
     }
 
-    /// Get the list of authorized actors for a product.
-    /// Returns an empty vec for unknown product IDs.
+    /// Return the list of addresses authorised to add events for a product.
+    ///
+    /// # Parameters
+    /// - `env` — Soroban execution environment.
+    /// - `product_id` — ID of the product to query.
+    ///
+    /// # Returns
+    /// A `Vec<Address>` of authorized actors. Returns an empty vector if the
+    /// product does not exist or has no authorized actors.
+    ///
+    /// # Authorization
+    /// None — this is a read-only function.
+    ///
+    /// # Panics
+    /// Does not panic.
     pub fn get_authorized_actors(env: Env, product_id: String) -> Vec<Address> {
         env.storage()
             .persistent()
@@ -294,7 +596,22 @@ impl SupplyLinkContract {
             .unwrap_or_else(|| Vec::new(&env))
     }
 
-    /// Get the total number of registered products.
+    /// Return the total number of products registered on this contract.
+    ///
+    /// The count is a monotonically increasing counter; it is never decremented
+    /// even if products were to be removed (which is not currently supported).
+    ///
+    /// # Parameters
+    /// - `env` — Soroban execution environment.
+    ///
+    /// # Returns
+    /// A `u64` count. Returns `0` if no products have been registered.
+    ///
+    /// # Authorization
+    /// None — this is a read-only function.
+    ///
+    /// # Panics
+    /// Does not panic.
     pub fn get_product_count(env: Env) -> u64 {
         env.storage()
             .persistent()
@@ -302,772 +619,55 @@ impl SupplyLinkContract {
             .unwrap_or(0)
     }
 
-    /// List products with pagination.
-    /// Returns a vector of product IDs from offset to offset + limit.
+    /// Return a paginated slice of product IDs in registration order.
+    ///
+    /// Uses the [`DataKey::ProductIndex`] mapping to look up IDs by their
+    /// sequential insertion index, enabling efficient pagination without
+    /// iterating all storage keys.
+    ///
+    /// # Parameters
+    /// - `env` — Soroban execution environment.
+    /// - `offset` — Zero-based index of the first product to return.
+    /// - `limit` — Maximum number of product IDs to return.
+    ///
+    /// # Returns
+    /// A `Vec<String>` of product IDs. Returns an empty vector if `offset` is
+    /// beyond the total count or no products are registered.
+    ///
+    /// # Authorization
+    /// None — this is a read-only function.
+    ///
+    /// # Panics
+    /// Does not panic.
+    ///
+    /// # Example
+    /// ```text
+    /// // Fetch the first page of 10 products
+    /// list_products(env, 0, 10)
+    ///
+    /// // Fetch the second page
+    /// list_products(env, 10, 10)
+    /// ```
     pub fn list_products(env: Env, offset: u64, limit: u64) -> Vec<String> {
         let count: u64 = env
             .storage()
             .persistent()
             .get(&DataKey::ProductCount)
             .unwrap_or(0);
-        
+
         let mut products = Vec::new(&env);
         let end = core::cmp::min(offset + limit, count);
-        
+
         for i in offset..end {
-            if let Some(product_id) = env.storage().persistent().get::<DataKey, String>(&DataKey::ProductIndex(i)) {
+            if let Some(product_id) =
+                env.storage()
+                    .persistent()
+                    .get::<DataKey, String>(&DataKey::ProductIndex(i))
+            {
                 products.push_back(product_id);
             }
         }
-        
+
         products
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use proptest::prelude::*;
-    use soroban_sdk::{testutils::Address as _, Env};
-
-    fn setup() -> (Env, soroban_sdk::Address, soroban_sdk::Address, String) {
-        let env = Env::default();
-        env.mock_all_auths();
-        let contract_id = env.register(SupplyLinkContract, ());
-        let owner = soroban_sdk::Address::generate(&env);
-        let product_id = String::from_str(&env, "prod-001");
-        let client = SupplyLinkContractClient::new(&env, &contract_id);
-        client.register_product(
-            &product_id,
-            &String::from_str(&env, "Widget"),
-            &String::from_str(&env, "Factory A"),
-            &owner,
-        );
-        (env, contract_id, owner, product_id)
-    }
-
-    fn add_event(env: &Env, contract_id: &soroban_sdk::Address, product_id: &String, caller: &soroban_sdk::Address) {
-        let client = SupplyLinkContractClient::new(env, contract_id);
-        client.add_tracking_event(
-            product_id,
-            caller,
-            &String::from_str(env, "Warehouse"),
-            &String::from_str(env, "SHIPPING"),
-            &String::from_str(env, "{}"),
-        );
-    }
-
-    /// Req 3.1 — unknown product_id returns 0
-    #[test]
-    fn test_unknown_product_returns_zero() {
-        let env = Env::default();
-        let contract_id = env.register(SupplyLinkContract, ());
-        let client = SupplyLinkContractClient::new(&env, &contract_id);
-        let unknown = String::from_str(&env, "does-not-exist");
-        assert_eq!(client.get_events_count(&unknown), 0);
-    }
-
-    /// Req 3.2 — registered product with no events returns 0
-    #[test]
-    fn test_registered_product_no_events_returns_zero() {
-        let (env, contract_id, _owner, product_id) = setup();
-        let client = SupplyLinkContractClient::new(&env, &contract_id);
-        assert_eq!(client.get_events_count(&product_id), 0);
-    }
-
-    /// Req 3.3 — one add_tracking_event call → count == 1
-    #[test]
-    fn test_one_event_returns_one() {
-        let (env, contract_id, owner, product_id) = setup();
-        add_event(&env, &contract_id, &product_id, &owner);
-        let client = SupplyLinkContractClient::new(&env, &contract_id);
-        assert_eq!(client.get_events_count(&product_id), 1);
-    }
-
-    /// Req 3.4 — multiple add_tracking_event calls → correct count
-    #[test]
-    fn test_multiple_events_returns_correct_count() {
-        let (env, contract_id, owner, product_id) = setup();
-        for _ in 0..5 {
-            add_event(&env, &contract_id, &product_id, &owner);
-        }
-        let client = SupplyLinkContractClient::new(&env, &contract_id);
-        assert_eq!(client.get_events_count(&product_id), 5);
-    }
-
-    /// Req 3.5 — get_events_count == get_tracking_events(...).len()
-    #[test]
-    fn test_count_equals_vec_len() {
-        let (env, contract_id, owner, product_id) = setup();
-        for _ in 0..3 {
-            add_event(&env, &contract_id, &product_id, &owner);
-        }
-        let client = SupplyLinkContractClient::new(&env, &contract_id);
-        let count = client.get_events_count(&product_id);
-        let events = client.get_tracking_events(&product_id);
-        assert_eq!(count, events.len());
-    }
-
-    // ── Property-based tests ─────────────────────────────────────────────────
-
-    /// Property 1: Count equals number of added events
-    /// Validates: Requirements 1.1, 1.2, 3.2, 3.3, 3.4
-    proptest! {
-        #![proptest_config(ProptestConfig::with_cases(100))]
-        #[test]
-        fn prop_count_equals_n_events(
-            product_id_str in "[a-z]{1,20}",
-            n in 0usize..=50,
-        ) {
-            let env = Env::default();
-            env.mock_all_auths();
-            let contract_id = env.register(SupplyLinkContract, ());
-            let client = SupplyLinkContractClient::new(&env, &contract_id);
-            let owner = soroban_sdk::Address::generate(&env);
-            let product_id = String::from_str(&env, &product_id_str);
-
-            client.register_product(
-                &product_id,
-                &String::from_str(&env, "Widget"),
-                &String::from_str(&env, "Origin"),
-                &owner,
-            );
-
-            for _ in 0..n {
-                client.add_tracking_event(
-                    &product_id,
-                    &owner,
-                    &String::from_str(&env, "Warehouse"),
-                    &String::from_str(&env, "SHIPPING"),
-                    &String::from_str(&env, "{}"),
-                );
-            }
-
-            prop_assert_eq!(client.get_events_count(&product_id), n as u32);
-        }
-    }
-
-    /// Property 2: Unknown product returns 0
-    /// Validates: Requirements 1.3, 3.1
-    proptest! {
-        #![proptest_config(ProptestConfig::with_cases(100))]
-        #[test]
-        fn prop_unknown_product_returns_zero(
-            product_id_str in "[a-z]{1,20}",
-        ) {
-            let env = Env::default();
-            let contract_id = env.register(SupplyLinkContract, ());
-            let client = SupplyLinkContractClient::new(&env, &contract_id);
-            let product_id = String::from_str(&env, &product_id_str);
-
-            prop_assert_eq!(client.get_events_count(&product_id), 0);
-        }
-    }
-
-    /// Property 3: Add-then-count increments by one
-    /// Validates: Requirements 2.1
-    proptest! {
-        #![proptest_config(ProptestConfig::with_cases(100))]
-        #[test]
-        fn prop_add_increments_count(
-            product_id_str in "[a-z]{1,20}",
-            n in 0usize..=50,
-        ) {
-            let env = Env::default();
-            env.mock_all_auths();
-            let contract_id = env.register(SupplyLinkContract, ());
-            let client = SupplyLinkContractClient::new(&env, &contract_id);
-            let owner = soroban_sdk::Address::generate(&env);
-            let product_id = String::from_str(&env, &product_id_str);
-
-            client.register_product(
-                &product_id,
-                &String::from_str(&env, "Widget"),
-                &String::from_str(&env, "Origin"),
-                &owner,
-            );
-
-            // Add N events to establish a baseline
-            for _ in 0..n {
-                client.add_tracking_event(
-                    &product_id,
-                    &owner,
-                    &String::from_str(&env, "Warehouse"),
-                    &String::from_str(&env, "SHIPPING"),
-                    &String::from_str(&env, "{}"),
-                );
-            }
-
-            let count_before = client.get_events_count(&product_id);
-
-            // Add one more event
-            client.add_tracking_event(
-                &product_id,
-                &owner,
-                &String::from_str(&env, "Warehouse"),
-                &String::from_str(&env, "SHIPPING"),
-                &String::from_str(&env, "{}"),
-            );
-
-            let count_after = client.get_events_count(&product_id);
-            prop_assert_eq!(count_after, count_before + 1);
-        }
-    }
-
-    // ── product_exists unit tests ────────────────────────────────────────────
-
-    /// Req 1.2, 1.3 — unknown product returns false
-    #[test]
-    fn test_product_exists_returns_false_for_unknown() {
-        let env = Env::default();
-        let contract_id = env.register(SupplyLinkContract, ());
-        let client = SupplyLinkContractClient::new(&env, &contract_id);
-        let id = String::from_str(&env, "does-not-exist");
-        assert!(!client.product_exists(&id));
-    }
-
-    /// Req 1.1 — registered product returns true
-    #[test]
-    fn test_product_exists_returns_true_after_register() {
-        let (env, contract_id, _owner, product_id) = setup();
-        let client = SupplyLinkContractClient::new(&env, &contract_id);
-        assert!(client.product_exists(&product_id));
-    }
-
-    // ── product_exists property-based tests ──────────────────────────────────
-
-    /// Property: exists iff registered
-    /// Validates: Requirements 1.1, 1.2, 1.3
-    proptest! {
-        #![proptest_config(ProptestConfig::with_cases(100))]
-        #[test]
-        fn prop_exists_iff_registered(product_id_str in "[a-z]{1,20}") {
-            let env = Env::default();
-            env.mock_all_auths();
-            let contract_id = env.register(SupplyLinkContract, ());
-            let client = SupplyLinkContractClient::new(&env, &contract_id);
-            let owner = soroban_sdk::Address::generate(&env);
-            let product_id = String::from_str(&env, &product_id_str);
-
-            prop_assert!(!client.product_exists(&product_id));
-
-            client.register_product(
-                &product_id,
-                &String::from_str(&env, "Widget"),
-                &String::from_str(&env, "Origin"),
-                &owner,
-            );
-
-            prop_assert!(client.product_exists(&product_id));
-        }
-    }
-
-    /// Property: unregistered product always returns false
-    /// Validates: Requirements 1.2, 1.3
-    proptest! {
-        #![proptest_config(ProptestConfig::with_cases(100))]
-        #[test]
-        fn prop_exists_false_before_register(product_id_str in "[a-z]{1,20}") {
-            let env = Env::default();
-            let contract_id = env.register(SupplyLinkContract, ());
-            let client = SupplyLinkContractClient::new(&env, &contract_id);
-            let product_id = String::from_str(&env, &product_id_str);
-            prop_assert!(!client.product_exists(&product_id));
-        }
-    }
-
-    /// Property 4: Count equals vec length (consistency invariant)
-    /// Validates: Requirements 2.2, 3.5
-    proptest! {
-        #![proptest_config(ProptestConfig::with_cases(100))]
-        #[test]
-        fn prop_count_equals_vec_len(
-            product_id_str in "[a-z]{1,20}",
-            n in 0usize..=50,
-        ) {
-            let env = Env::default();
-            env.mock_all_auths();
-            let contract_id = env.register(SupplyLinkContract, ());
-            let client = SupplyLinkContractClient::new(&env, &contract_id);
-            let owner = soroban_sdk::Address::generate(&env);
-            let product_id = String::from_str(&env, &product_id_str);
-
-            client.register_product(
-                &product_id,
-                &String::from_str(&env, "Widget"),
-                &String::from_str(&env, "Origin"),
-                &owner,
-            );
-
-            for _ in 0..n {
-                client.add_tracking_event(
-                    &product_id,
-                    &owner,
-                    &String::from_str(&env, "Warehouse"),
-                    &String::from_str(&env, "SHIPPING"),
-                    &String::from_str(&env, "{}"),
-                );
-            }
-
-            let count = client.get_events_count(&product_id);
-            let events = client.get_tracking_events(&product_id);
-            prop_assert_eq!(count, events.len());
-        }
-    }
-
-    // ── authorized-actor auth tests ──────────────────────────────────────────
-
-    /// Req: an authorized actor (not the owner) can add an event
-    #[test]
-    fn test_authorized_actor_can_add_event() {
-        let env = Env::default();
-        env.mock_all_auths();
-        let contract_id = env.register(SupplyLinkContract, ());
-        let client = SupplyLinkContractClient::new(&env, &contract_id);
-        let owner = soroban_sdk::Address::generate(&env);
-        let actor = soroban_sdk::Address::generate(&env);
-        let product_id = String::from_str(&env, "prod-actor-test");
-
-        client.register_product(
-            &product_id,
-            &String::from_str(&env, "Widget"),
-            &String::from_str(&env, "Factory"),
-            &owner,
-        );
-        client.add_authorized_actor(&product_id, &actor);
-
-        // Actor (not owner) submits an event — must succeed
-        let event = client.add_tracking_event(
-            &product_id,
-            &actor,
-            &String::from_str(&env, "Warehouse"),
-            &String::from_str(&env, "SHIPPING"),
-            &String::from_str(&env, "{}"),
-        );
-        assert_eq!(event.actor, actor);
-        assert_eq!(client.get_events_count(&product_id), 1);
-    }
-
-    /// Req: an address that is neither owner nor authorized actor is rejected
-    #[test]
-    #[should_panic(expected = "caller is not authorized")]
-    fn test_unauthorized_caller_is_rejected() {
-        let env = Env::default();
-        env.mock_all_auths();
-        let contract_id = env.register(SupplyLinkContract, ());
-        let client = SupplyLinkContractClient::new(&env, &contract_id);
-        let owner = soroban_sdk::Address::generate(&env);
-        let stranger = soroban_sdk::Address::generate(&env);
-        let product_id = String::from_str(&env, "prod-unauth-test");
-
-        client.register_product(
-            &product_id,
-            &String::from_str(&env, "Widget"),
-            &String::from_str(&env, "Factory"),
-            &owner,
-        );
-
-        env.as_contract(&contract_id, || {
-            SupplyLinkContract::add_tracking_event(
-                env.clone(),
-                product_id.clone(),
-                stranger.clone(),
-                String::from_str(&env, "Warehouse"),
-                String::from_str(&env, "SHIPPING"),
-                String::from_str(&env, "{}"),
-            );
-        });
-    }
-
-    // ── remove_authorized_actor tests ──────────────────────────────────────────
-
-    /// Test successful removal of an authorized actor
-    #[test]
-    fn test_remove_authorized_actor_success() {
-        let env = Env::default();
-        env.mock_all_auths();
-        let contract_id = env.register(SupplyLinkContract, ());
-        let client = SupplyLinkContractClient::new(&env, &contract_id);
-        let owner = soroban_sdk::Address::generate(&env);
-        let actor = soroban_sdk::Address::generate(&env);
-        let product_id = String::from_str(&env, "prod-remove-test");
-
-        client.register_product(
-            &product_id,
-            &String::from_str(&env, "Widget"),
-            &String::from_str(&env, "Factory"),
-            &owner,
-        );
-        client.add_authorized_actor(&product_id, &actor);
-        
-        // Verify actor was added
-        let product = client.get_product(&product_id);
-        assert_eq!(product.authorized_actors.len(), 1);
-        
-        // Remove the actor
-        let result = client.remove_authorized_actor(&product_id, &actor);
-        assert!(result);
-        
-        // Verify actor was removed
-        let product = client.get_product(&product_id);
-        assert_eq!(product.authorized_actors.len(), 0);
-    }
-
-    /// Test removal of a non-existent actor returns false
-    #[test]
-    fn test_remove_nonexistent_actor_returns_false() {
-        let env = Env::default();
-        env.mock_all_auths();
-        let contract_id = env.register(SupplyLinkContract, ());
-        let client = SupplyLinkContractClient::new(&env, &contract_id);
-        let owner = soroban_sdk::Address::generate(&env);
-        let actor = soroban_sdk::Address::generate(&env);
-        let non_existent_actor = soroban_sdk::Address::generate(&env);
-        let product_id = String::from_str(&env, "prod-remove-fail");
-
-        client.register_product(
-            &product_id,
-            &String::from_str(&env, "Widget"),
-            &String::from_str(&env, "Factory"),
-            &owner,
-        );
-        client.add_authorized_actor(&product_id, &actor);
-        
-        // Try to remove an actor that was never added
-        let result = client.remove_authorized_actor(&product_id, &non_existent_actor);
-        assert!(!result);
-        
-        // Verify original actor is still there
-        let product = client.get_product(&product_id);
-        assert_eq!(product.authorized_actors.len(), 1);
-    }
-
-    /// Test that non-owner cannot remove authorized actors
-    #[test]
-    #[should_panic(expected = "Auth")]
-    fn test_unauthorized_caller_cannot_remove_actor() {
-        let env = Env::default();
-        let contract_id = env.register(SupplyLinkContract, ());
-        let client = SupplyLinkContractClient::new(&env, &contract_id);
-        let owner = soroban_sdk::Address::generate(&env);
-        let actor = soroban_sdk::Address::generate(&env);
-        let unauthorized_caller = soroban_sdk::Address::generate(&env);
-        let product_id = String::from_str(&env, "prod-unauth-remove");
-
-        // Register product without mock_all_auths
-        env.as_contract(&contract_id, || {
-            SupplyLinkContract::register_product(
-                env.clone(),
-                product_id.clone(),
-                String::from_str(&env, "Widget"),
-                String::from_str(&env, "Factory"),
-                owner.clone(),
-            );
-            SupplyLinkContract::add_authorized_actor(
-                env.clone(),
-                product_id.clone(),
-                actor.clone(),
-            );
-        });
-        
-        // Try to remove as unauthorized caller (should fail)
-        env.as_contract(&contract_id, || {
-            SupplyLinkContract::remove_authorized_actor(
-                env.clone(),
-                product_id.clone(),
-                actor.clone(),
-            );
-        });
-    }
-
-    // ── get_product_count and list_products tests ──────────────────────────────
-
-    /// Test product count starts at 0
-    #[test]
-    fn test_product_count_initial_zero() {
-        let env = Env::default();
-        let contract_id = env.register(SupplyLinkContract, ());
-        let client = SupplyLinkContractClient::new(&env, &contract_id);
-        assert_eq!(client.get_product_count(), 0);
-    }
-
-    /// Test product count increments on registration
-    #[test]
-    fn test_product_count_increments() {
-        let env = Env::default();
-        env.mock_all_auths();
-        let contract_id = env.register(SupplyLinkContract, ());
-        let client = SupplyLinkContractClient::new(&env, &contract_id);
-        let owner = soroban_sdk::Address::generate(&env);
-
-        assert_eq!(client.get_product_count(), 0);
-        
-        client.register_product(
-            &String::from_str(&env, "prod-1"),
-            &String::from_str(&env, "Widget 1"),
-            &String::from_str(&env, "Factory A"),
-            &owner,
-        );
-        assert_eq!(client.get_product_count(), 1);
-        
-        client.register_product(
-            &String::from_str(&env, "prod-2"),
-            &String::from_str(&env, "Widget 2"),
-            &String::from_str(&env, "Factory B"),
-            &owner,
-        );
-        assert_eq!(client.get_product_count(), 2);
-    }
-
-    /// Test list_products returns all products
-    #[test]
-    fn test_list_products_returns_all() {
-        let env = Env::default();
-        env.mock_all_auths();
-        let contract_id = env.register(SupplyLinkContract, ());
-        let client = SupplyLinkContractClient::new(&env, &contract_id);
-        let owner = soroban_sdk::Address::generate(&env);
-
-        let id1 = String::from_str(&env, "prod-1");
-        let id2 = String::from_str(&env, "prod-2");
-        let id3 = String::from_str(&env, "prod-3");
-
-        client.register_product(&id1, &String::from_str(&env, "Widget 1"), &String::from_str(&env, "Factory A"), &owner);
-        client.register_product(&id2, &String::from_str(&env, "Widget 2"), &String::from_str(&env, "Factory B"), &owner);
-        client.register_product(&id3, &String::from_str(&env, "Widget 3"), &String::from_str(&env, "Factory C"), &owner);
-
-        let products = client.list_products(&0, &10);
-        assert_eq!(products.len(), 3);
-        assert_eq!(products.get(0).unwrap(), id1);
-        assert_eq!(products.get(1).unwrap(), id2);
-        assert_eq!(products.get(2).unwrap(), id3);
-    }
-
-    /// Test list_products pagination with offset
-    #[test]
-    fn test_list_products_pagination_offset() {
-        let env = Env::default();
-        env.mock_all_auths();
-        let contract_id = env.register(SupplyLinkContract, ());
-        let client = SupplyLinkContractClient::new(&env, &contract_id);
-        let owner = soroban_sdk::Address::generate(&env);
-
-        let id1 = String::from_str(&env, "prod-1");
-        let id2 = String::from_str(&env, "prod-2");
-        let id3 = String::from_str(&env, "prod-3");
-
-        client.register_product(&id1, &String::from_str(&env, "Widget 1"), &String::from_str(&env, "Factory A"), &owner);
-        client.register_product(&id2, &String::from_str(&env, "Widget 2"), &String::from_str(&env, "Factory B"), &owner);
-        client.register_product(&id3, &String::from_str(&env, "Widget 3"), &String::from_str(&env, "Factory C"), &owner);
-
-        // Get products starting from index 1
-        let products = client.list_products(&1, &10);
-        assert_eq!(products.len(), 2);
-        assert_eq!(products.get(0).unwrap(), id2);
-        assert_eq!(products.get(1).unwrap(), id3);
-    }
-
-    /// Test list_products pagination with limit
-    #[test]
-    fn test_list_products_pagination_limit() {
-        let env = Env::default();
-        env.mock_all_auths();
-        let contract_id = env.register(SupplyLinkContract, ());
-        let client = SupplyLinkContractClient::new(&env, &contract_id);
-        let owner = soroban_sdk::Address::generate(&env);
-
-        let id1 = String::from_str(&env, "prod-1");
-        let id2 = String::from_str(&env, "prod-2");
-        let id3 = String::from_str(&env, "prod-3");
-
-        client.register_product(&id1, &String::from_str(&env, "Widget 1"), &String::from_str(&env, "Factory A"), &owner);
-        client.register_product(&id2, &String::from_str(&env, "Widget 2"), &String::from_str(&env, "Factory B"), &owner);
-        client.register_product(&id3, &String::from_str(&env, "Widget 3"), &String::from_str(&env, "Factory C"), &owner);
-
-        // Get only first 2 products
-        let products = client.list_products(&0, &2);
-        assert_eq!(products.len(), 2);
-        assert_eq!(products.get(0).unwrap(), id1);
-        assert_eq!(products.get(1).unwrap(), id2);
-    }
-
-    /// Test list_products with offset beyond count returns empty
-    #[test]
-    fn test_list_products_offset_beyond_count() {
-        let env = Env::default();
-        env.mock_all_auths();
-        let contract_id = env.register(SupplyLinkContract, ());
-        let client = SupplyLinkContractClient::new(&env, &contract_id);
-        let owner = soroban_sdk::Address::generate(&env);
-
-        client.register_product(
-            &String::from_str(&env, "prod-1"),
-            &String::from_str(&env, "Widget 1"),
-            &String::from_str(&env, "Factory A"),
-            &owner,
-        );
-
-        // Offset beyond count
-        let products = client.list_products(&10, &10);
-        assert_eq!(products.len(), 0);
-    }
-
-    // ── update_product_metadata tests ─────────────────────────────────────────
-
-    /// Test successful metadata update
-    #[test]
-    fn test_update_product_metadata_success() {
-        let env = Env::default();
-        env.mock_all_auths();
-        let contract_id = env.register(SupplyLinkContract, ());
-        let client = SupplyLinkContractClient::new(&env, &contract_id);
-        let owner = soroban_sdk::Address::generate(&env);
-        let product_id = String::from_str(&env, "prod-update");
-
-        client.register_product(
-            &product_id,
-            &String::from_str(&env, "Widget"),
-            &String::from_str(&env, "Factory A"),
-            &owner,
-        );
-
-        let updated = client.update_product_metadata(
-            &product_id,
-            &String::from_str(&env, "Updated Widget"),
-            &String::from_str(&env, "Factory B"),
-        );
-
-        assert_eq!(updated.name, String::from_str(&env, "Updated Widget"));
-        assert_eq!(updated.origin, String::from_str(&env, "Factory B"));
-        assert_eq!(updated.id, product_id);
-        assert_eq!(updated.owner, owner);
-    }
-
-    /// Test that non-owner cannot update metadata
-    #[test]
-    #[should_panic(expected = "Auth")]
-    fn test_unauthorized_caller_cannot_update_metadata() {
-        let env = Env::default();
-        let contract_id = env.register(SupplyLinkContract, ());
-        let client = SupplyLinkContractClient::new(&env, &contract_id);
-        let owner = soroban_sdk::Address::generate(&env);
-        let product_id = String::from_str(&env, "prod-unauth-update");
-
-        // Register product without mock_all_auths
-        env.as_contract(&contract_id, || {
-            SupplyLinkContract::register_product(
-                env.clone(),
-                product_id.clone(),
-                String::from_str(&env, "Widget"),
-                String::from_str(&env, "Factory A"),
-                owner.clone(),
-            );
-        });
-
-        // Try to update as non-owner (should fail)
-        env.as_contract(&contract_id, || {
-            SupplyLinkContract::update_product_metadata(
-                env.clone(),
-                product_id.clone(),
-                String::from_str(&env, "Hacked Widget"),
-                String::from_str(&env, "Hacked Factory"),
-            );
-        });
-    }
-
-    /// Test that update preserves immutable fields
-    #[test]
-    fn test_update_preserves_immutable_fields() {
-        let env = Env::default();
-        env.mock_all_auths();
-        let contract_id = env.register(SupplyLinkContract, ());
-        let client = SupplyLinkContractClient::new(&env, &contract_id);
-        let owner = soroban_sdk::Address::generate(&env);
-        let product_id = String::from_str(&env, "prod-immutable");
-
-        let original = client.register_product(
-            &product_id,
-            &String::from_str(&env, "Widget"),
-            &String::from_str(&env, "Factory A"),
-            &owner,
-        );
-
-        let updated = client.update_product_metadata(
-            &product_id,
-            &String::from_str(&env, "Updated Widget"),
-            &String::from_str(&env, "Factory B"),
-        );
-
-        // Verify immutable fields are preserved
-        assert_eq!(updated.id, original.id);
-        assert_eq!(updated.owner, original.owner);
-        assert_eq!(updated.timestamp, original.timestamp);
-    }
-
-    // ── get_authorized_actors tests ──────────────────────────────────────────
-
-    /// Unknown product_id returns an empty vec
-    #[test]
-    fn test_get_authorized_actors_unknown_product_returns_empty() {
-        let env = Env::default();
-        let contract_id = env.register(SupplyLinkContract, ());
-        let client = SupplyLinkContractClient::new(&env, &contract_id);
-        let unknown = String::from_str(&env, "does-not-exist");
-        let actors = client.get_authorized_actors(&unknown);
-        assert_eq!(actors.len(), 0);
-    }
-
-    /// Single actor added → get_authorized_actors returns that actor
-    #[test]
-    fn test_get_authorized_actors_single_actor() {
-        let env = Env::default();
-        env.mock_all_auths();
-        let contract_id = env.register(SupplyLinkContract, ());
-        let client = SupplyLinkContractClient::new(&env, &contract_id);
-        let owner = soroban_sdk::Address::generate(&env);
-        let actor = soroban_sdk::Address::generate(&env);
-        let product_id = String::from_str(&env, "prod-single-actor");
-
-        client.register_product(
-            &product_id,
-            &String::from_str(&env, "Widget"),
-            &String::from_str(&env, "Factory"),
-            &owner,
-        );
-        client.add_authorized_actor(&product_id, &actor);
-
-        let actors = client.get_authorized_actors(&product_id);
-        assert_eq!(actors.len(), 1);
-        assert_eq!(actors.get(0).unwrap(), actor);
-    }
-
-    /// Multiple actors added → get_authorized_actors returns all of them in order
-    #[test]
-    fn test_get_authorized_actors_multiple_actors() {
-        let env = Env::default();
-        env.mock_all_auths();
-        let contract_id = env.register(SupplyLinkContract, ());
-        let client = SupplyLinkContractClient::new(&env, &contract_id);
-        let owner = soroban_sdk::Address::generate(&env);
-        let actor1 = soroban_sdk::Address::generate(&env);
-        let actor2 = soroban_sdk::Address::generate(&env);
-        let actor3 = soroban_sdk::Address::generate(&env);
-        let product_id = String::from_str(&env, "prod-multi-actor");
-
-        client.register_product(
-            &product_id,
-            &String::from_str(&env, "Widget"),
-            &String::from_str(&env, "Factory"),
-            &owner,
-        );
-        client.add_authorized_actor(&product_id, &actor1);
-        client.add_authorized_actor(&product_id, &actor2);
-        client.add_authorized_actor(&product_id, &actor3);
-
-        let actors = client.get_authorized_actors(&product_id);
-        assert_eq!(actors.len(), 3);
-        assert_eq!(actors.get(0).unwrap(), actor1);
-        assert_eq!(actors.get(1).unwrap(), actor2);
-        assert_eq!(actors.get(2).unwrap(), actor3);
     }
 }


### PR DESCRIPTION
Closes #81
Closes #82
## Summary

Adds visual component documentation via Storybook and documents key
architectural decisions via ADRs.

## Changes

### Storybook (#81)
- Configure Storybook 8 for Next.js (`@storybook/nextjs`) with essentials, interactions, and a11y addons
- Stories for Button (all variants), Card, Badge (all event types), WalletConnect (connected/disconnected/loading), ProductCard, EventTimeline
- Add `storybook` and `build-storybook` scripts to package.json
- Add Chromatic GitHub Actions workflow for visual regression on every PR

### ADRs (#82)
- ADR-001: Choice of Stellar/Soroban over Ethereum
- ADR-002: Next.js App Router over Pages Router
- ADR-003: Zustand over Redux/Context
- ADR-004: Freighter as the wallet provider
- Each follows the standard template: Context, Decision, Consequences


