### PR TITLE
feat: Add Share button to product verify and detail pages

### DIFF
--- a/frontend/app/(app)/products/[id]/page.tsx
+++ b/frontend/app/(app)/products/[id]/page.tsx
@@ -4,6 +4,7 @@ import { getProductById } from "@/lib/mock/products";
 import ProductQRCode from "@/components/products/ProductQRCode";
 import ProductActions from "@/components/products/ProductActions";
 import { AuthorizedActorsPanel } from "@/components/products/AuthorizedActorsPanel";
+import { ShareButton } from "@/components/ui/ShareButton";
 
 interface Props {
   params: { id: string };
@@ -23,7 +24,10 @@ export default function ProductDetailPage({ params }: Props) {
 
       <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-6 mb-8">
         <div>
-          <h1 className="text-2xl font-bold text-[var(--foreground)]">{p.name}</h1>
+          <div className="flex items-center gap-2 flex-wrap">
+            <h1 className="text-2xl font-bold text-[var(--foreground)]">{p.name}</h1>
+            <ShareButton productName={p.name} productId={p.id} />
+          </div>
           <p className="text-[var(--muted)] mt-1">Product ID: <span className="font-mono text-sm">{p.id}</span></p>
         </div>
         <ProductQRCode productId={p.id} size={160} />

--- a/frontend/app/verify/[id]/page.tsx
+++ b/frontend/app/verify/[id]/page.tsx
@@ -4,6 +4,7 @@ import { CONTRACT_ID } from "@/lib/stellar/client";
 import { EventTimeline } from "@/components/products/EventTimeline";
 import ProductQRCode from "@/components/products/ProductQRCode";
 import { ScanQRButton } from "@/components/tracking/ScanQRButton";
+import { ShareButton } from "@/components/ui/ShareButton";
 
 interface Props {
   params: { id: string };
@@ -64,7 +65,7 @@ export default async function VerifyPage({ params }: Props) {
       {/* Header */}
       <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-4 mb-6">
         <div>
-          <div className="flex items-center gap-2 mb-1">
+          <div className="flex items-center gap-2 mb-1 flex-wrap">
             <h1 className="text-2xl font-bold text-[var(--foreground)]">{product.name}</h1>
             <span
               className={`text-xs font-medium px-2 py-0.5 rounded-full ${
@@ -75,6 +76,7 @@ export default async function VerifyPage({ params }: Props) {
             >
               {product.active ? "Active" : "Inactive"}
             </span>
+            <ShareButton productName={product.name} productId={product.id} />
           </div>
           <p className="text-sm text-[var(--muted)]">Origin: {product.origin}</p>
           <p className="text-xs text-[var(--muted)] mt-0.5">Registered: {registeredAt}</p>

--- a/frontend/components/ui/ShareButton.tsx
+++ b/frontend/components/ui/ShareButton.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import { useState } from "react";
+import { Button } from "./Button";
+
+interface ShareButtonProps {
+  productName: string;
+  productId: string;
+}
+
+export function ShareButton({ productName, productId }: ShareButtonProps) {
+  const [copied, setCopied] = useState(false);
+
+  async function handleShare() {
+    const url = `${window.location.origin}/verify/${productId}`;
+    const text = `I verified ${productName} on Supply-Link — see its full journey: ${url}`;
+
+    if (navigator.share) {
+      await navigator.share({ title: `${productName} — Supply-Link`, text, url });
+    } else {
+      await navigator.clipboard.writeText(text);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    }
+  }
+
+  return (
+    <Button variant="secondary" size="sm" onClick={handleShare}>
+      {copied ? (
+        "✓ Copied!"
+      ) : (
+        <>
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="mr-1.5" aria-hidden="true">
+            <circle cx="18" cy="5" r="3" /><circle cx="6" cy="12" r="3" /><circle cx="18" cy="19" r="3" />
+            <line x1="8.59" y1="13.51" x2="15.42" y2="17.49" /><line x1="15.41" y1="6.51" x2="8.59" y2="10.49" />
+          </svg>
+          Share
+        </>
+      )}
+    </Button>
+  );
+}

--- a/frontend/components/ui/index.ts
+++ b/frontend/components/ui/index.ts
@@ -3,3 +3,4 @@ export { Card, CardHeader, CardContent, CardFooter } from "./Card";
 export { Badge } from "./Badge";
 export { Input } from "./Input";
 export { Select, SelectItem } from "./Select";
+export { ShareButton } from "./ShareButton";


### PR DESCRIPTION
Summary
  
  Adds a Share button to the product verify page (/verify/[id]) and the product detail
  page (/products/[id]), allowing users to share a product's verification link via
  native share sheet or clipboard.
  
  Changes
  
  - components/ui/ShareButton.tsx — new client component; uses Web Share API when
  available, falls back to clipboard copy with a "✓ Copied!" confirmation
  - app/verify/[id]/page.tsx — ShareButton added to the product header
  - app/(app)/products/[id]/page.tsx — ShareButton added to the product header
  - components/ui/index.ts — exports ShareButton
  
  Share text format
  
  │ I verified [Product Name] on Supply-Link — see its full journey:
  https://…/verify/[id]
  
  Tested
  
  - Web Share API path (mobile/supported browsers)
  - Clipboard fallback (desktop)

closes #96 