### PR TITLE
feat(#110): mobile-responsive audit and fixes

### DIFF
--- a/frontend/app/(app)/dashboard/page.tsx
+++ b/frontend/app/(app)/dashboard/page.tsx
@@ -33,11 +33,11 @@ export default function DashboardPage() {
   const { stats, dailyCounts, eventTypeCounts, recentEvents } = useDashboardData();
 
   return (
-    <main className="p-6 space-y-8 max-w-7xl mx-auto">
+    <main className="p-4 md:p-6 space-y-8 max-w-7xl mx-auto">
       <h1 className="text-2xl font-bold text-[var(--foreground)]">Dashboard</h1>
 
       {/* Stat cards */}
-      <div className="grid grid-cols-2 lg:grid-cols-4 gap-4">
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
         <StatCard label="Total Products" value={stats.totalProducts} icon={Package} />
         <StatCard label="Total Events" value={stats.totalEvents} icon={Activity} />
         <StatCard label="Active Products" value={stats.activeProducts} icon={CheckCircle} />
@@ -61,7 +61,7 @@ export default function DashboardPage() {
               <tr className="text-left text-[var(--muted)] border-b border-[var(--card-border)]">
                 <th className="px-5 py-3 font-medium">Product</th>
                 <th className="px-5 py-3 font-medium">Type</th>
-                <th className="px-5 py-3 font-medium">Location</th>
+                <th className="px-5 py-3 font-medium hidden sm:table-cell">Location</th>
                 <th className="px-5 py-3 font-medium">Time</th>
               </tr>
             </thead>
@@ -93,7 +93,7 @@ export default function DashboardPage() {
                         );
                       })()}
                     </td>
-                    <td className="px-5 py-3 text-[var(--foreground)]">{e.location}</td>
+                    <td className="px-5 py-3 text-[var(--foreground)] hidden sm:table-cell">{e.location}</td>
                     <td className="px-5 py-3 text-[var(--muted)]">
                       {new Date(e.timestamp).toLocaleString()}
                     </td>

--- a/frontend/app/(app)/products/page.tsx
+++ b/frontend/app/(app)/products/page.tsx
@@ -98,7 +98,7 @@ export default function ProductsPage() {
   }
 
   return (
-    <main className="p-6 md:p-8 max-w-7xl mx-auto">
+    <main className="p-4 md:p-6 lg:p-8 max-w-7xl mx-auto">
       <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4 mb-8">
         <div>
           <h1 className="text-2xl font-bold text-[var(--foreground)]">Products</h1>
@@ -106,24 +106,24 @@ export default function ProductsPage() {
             {loading ? "Loading…" : `${filtered.length} product${filtered.length !== 1 ? "s" : ""}`}
           </p>
         </div>
-        <div className="flex gap-2 self-start sm:self-auto">
+        <div className="flex flex-wrap gap-2 self-start sm:self-auto">
           {/* Refresh button — clears cache and re-fetches (#48) */}
           <button
             onClick={refresh}
             title="Refresh products"
-            className="flex items-center gap-2 px-3 py-2 border border-[var(--card-border)] bg-[var(--card)] hover:bg-[var(--muted-bg)] rounded-lg text-sm font-medium transition-colors"
+            className="flex items-center gap-2 px-3 py-2.5 border border-[var(--card-border)] bg-[var(--card)] hover:bg-[var(--muted-bg)] rounded-lg text-sm font-medium transition-colors min-h-[44px]"
           >
             <RefreshCw size={15} />
           </button>
           <button
             onClick={() => setBatchOpen(true)}
-            className="flex items-center gap-2 px-4 py-2 border border-[var(--card-border)] bg-[var(--card)] hover:bg-[var(--muted-bg)] rounded-lg text-sm font-medium transition-colors"
+            className="flex items-center gap-2 px-4 py-2.5 border border-[var(--card-border)] bg-[var(--card)] hover:bg-[var(--muted-bg)] rounded-lg text-sm font-medium transition-colors min-h-[44px]"
           >
             <Upload size={16} /> Import CSV
           </button>
           <button
             onClick={() => setRegisterOpen(true)}
-            className="flex items-center gap-2 px-4 py-2 bg-violet-600 hover:bg-violet-700 text-white rounded-lg text-sm font-medium transition-colors"
+            className="flex items-center gap-2 px-4 py-2.5 bg-violet-600 hover:bg-violet-700 text-white rounded-lg text-sm font-medium transition-colors min-h-[44px]"
           >
             <Plus size={16} /> Register New Product
           </button>

--- a/frontend/app/(app)/tracking/page.tsx
+++ b/frontend/app/(app)/tracking/page.tsx
@@ -33,7 +33,7 @@ export default function TrackingPage() {
   const selectedProduct = MOCK_PRODUCTS.find((p) => p.id === selectedId);
 
   return (
-    <div className="p-6 max-w-2xl mx-auto">
+    <div className="p-4 md:p-6 max-w-2xl mx-auto">
       <div className="flex items-center justify-between mb-6">
         <h1 className="text-2xl font-bold text-[var(--foreground)]">Tracking</h1>
         <div className="flex gap-2">
@@ -41,14 +41,14 @@ export default function TrackingPage() {
           <button
             onClick={refresh}
             title="Refresh events"
-            className="flex items-center gap-2 px-3 py-2 border border-[var(--card-border)] bg-[var(--card)] hover:bg-[var(--muted-bg)] rounded-lg text-sm transition-colors"
+            className="flex items-center gap-2 px-3 py-2.5 border border-[var(--card-border)] bg-[var(--card)] hover:bg-[var(--muted-bg)] rounded-lg text-sm transition-colors min-h-[44px]"
           >
             <RefreshCw size={15} />
           </button>
           <button
             onClick={() => setShowModal(true)}
             disabled={!selectedId}
-            className="flex items-center gap-2 px-4 py-2 text-sm rounded-md bg-[var(--primary)] text-[var(--primary-fg)] hover:opacity-90 disabled:opacity-40 transition-opacity"
+            className="flex items-center gap-2 px-4 py-2.5 text-sm rounded-md bg-[var(--primary)] text-[var(--primary-fg)] hover:opacity-90 disabled:opacity-40 transition-opacity min-h-[44px]"
           >
             <Plus size={15} />
             Add Event

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -28,3 +28,8 @@ body {
   background: var(--background);
   color: var(--foreground);
 }
+
+/* Safe area inset for bottom navigation on iOS notch/home-bar devices */
+.safe-area-inset-bottom {
+  padding-bottom: env(safe-area-inset-bottom, 0px);
+}

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -13,6 +13,12 @@ export const metadata: Metadata = {
     "Transparent, tamper-proof product tracking from origin to consumer, powered by Stellar & Soroban.",
 };
 
+export const viewport = {
+  width: "device-width",
+  initialScale: 1,
+  maximumScale: 1,
+};
+
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en" suppressHydrationWarning>

--- a/frontend/components/layouts/AppShell.tsx
+++ b/frontend/components/layouts/AppShell.tsx
@@ -14,7 +14,8 @@ export function AppShell({ children }: { children: React.ReactNode }) {
         <AppNavbar onMenuClick={() => setSidebarOpen(true)} />
         <div className="flex flex-1">
           <Sidebar open={sidebarOpen} onClose={() => setSidebarOpen(false)} />
-          <main className="flex-1 overflow-auto">
+          {/* pb-16 on mobile to clear the bottom nav bar */}
+          <main className="flex-1 overflow-auto pb-16 md:pb-0">
             {children}
           </main>
         </div>

--- a/frontend/components/layouts/Navbar.tsx
+++ b/frontend/components/layouts/Navbar.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Menu } from "lucide-react";
+// Menu icon kept for potential future use
 import { usePathname } from "next/navigation";
 import Link from "next/link";
 import { ThemeToggle } from "@/components/ThemeToggle";
@@ -35,29 +35,26 @@ export function AppNavbar({ onMenuClick }: AppNavbarProps) {
 
   return (
     <>
-      <header className="h-14 border-b border-[var(--card-border)] bg-[var(--background)] flex items-center px-4 gap-4 sticky top-0 z-40">
-        {/* Hamburger — mobile only */}
-        <button
-          onClick={onMenuClick}
-          aria-label="Open menu"
-          className="md:hidden p-1.5 rounded hover:bg-[var(--muted-bg)] text-[var(--foreground)]"
-        >
-          <Menu size={20} />
-        </button>
-
-        {/* Logo — desktop only (sidebar shows it on mobile) */}
+      <header className="h-14 border-b border-[var(--card-border)] bg-[var(--background)] flex items-center px-4 gap-3 sticky top-0 z-40">
+        {/* Logo — desktop only (bottom nav handles mobile navigation) */}
         <Link
           href="/dashboard"
-          className="hidden md:block font-semibold text-sm tracking-tight text-[var(--foreground)]"
+          className="hidden md:block font-semibold text-sm tracking-tight text-[var(--foreground)] shrink-0"
         >
           Supply-Link
         </Link>
 
-        <span className="text-sm font-medium text-[var(--foreground)] md:ml-2">{title}</span>
+        {/* Page title — mobile only */}
+        <span className="text-sm font-semibold text-[var(--foreground)] md:hidden">{title}</span>
+        {/* Spacer on desktop */}
+        <span className="hidden md:inline text-sm font-medium text-[var(--foreground)] md:ml-2">{title}</span>
 
-        <div className="ml-auto flex items-center gap-3">
+        <div className="ml-auto flex items-center gap-2">
           <NetworkBadge />
-          <WalletConnect />
+          {/* WalletConnect truncates address on small screens */}
+          <div className="max-w-[140px] sm:max-w-none overflow-hidden">
+            <WalletConnect />
+          </div>
           <ThemeToggle />
         </div>
       </header>

--- a/frontend/components/layouts/Sidebar.tsx
+++ b/frontend/components/layouts/Sidebar.tsx
@@ -18,16 +18,19 @@ interface SidebarProps {
 export function Sidebar({ open, onClose }: SidebarProps) {
   const pathname = usePathname();
 
-  const links = (
+  const isActive = (href: string) =>
+    pathname === href || pathname.startsWith(href + "/");
+
+  const sidebarLinks = (
     <nav className="flex flex-col gap-1 p-4">
       {NAV_ITEMS.map(({ href, label, icon: Icon }) => {
-        const active = pathname === href || pathname.startsWith(href + "/");
+        const active = isActive(href);
         return (
           <Link
             key={href}
             href={href}
             onClick={onClose}
-            className={`flex items-center gap-3 px-3 py-2 rounded-lg text-sm transition-colors ${
+            className={`flex items-center gap-3 px-3 py-2.5 rounded-lg text-sm transition-colors min-h-[44px] ${
               active
                 ? "bg-[var(--primary)] text-[var(--primary-fg)] font-medium"
                 : "text-[var(--muted)] hover:bg-[var(--muted-bg)] hover:text-[var(--foreground)]"
@@ -45,7 +48,7 @@ export function Sidebar({ open, onClose }: SidebarProps) {
     <>
       {/* Desktop sidebar */}
       <aside className="hidden md:flex flex-col w-56 shrink-0 border-r border-[var(--card-border)] bg-[var(--background)] min-h-screen">
-        {links}
+        {sidebarLinks}
       </aside>
 
       {/* Mobile drawer overlay */}
@@ -55,14 +58,42 @@ export function Sidebar({ open, onClose }: SidebarProps) {
           <aside className="absolute left-0 top-0 bottom-0 w-64 bg-[var(--background)] border-r border-[var(--card-border)] flex flex-col">
             <div className="flex items-center justify-between px-4 h-14 border-b border-[var(--card-border)]">
               <span className="font-semibold text-sm text-[var(--foreground)]">Supply-Link</span>
-              <button onClick={onClose} aria-label="Close menu" className="p-1 rounded hover:bg-[var(--muted-bg)]">
+              <button
+                onClick={onClose}
+                aria-label="Close menu"
+                className="p-2 rounded hover:bg-[var(--muted-bg)] min-h-[44px] min-w-[44px] flex items-center justify-center"
+              >
                 <X size={18} className="text-[var(--foreground)]" />
               </button>
             </div>
-            {links}
+            {sidebarLinks}
           </aside>
         </div>
       )}
+
+      {/* Mobile bottom navigation bar */}
+      <nav
+        className="md:hidden fixed bottom-0 left-0 right-0 z-40 bg-[var(--background)] border-t border-[var(--card-border)] flex items-center justify-around safe-area-inset-bottom"
+        aria-label="Bottom navigation"
+      >
+        {NAV_ITEMS.map(({ href, label, icon: Icon }) => {
+          const active = isActive(href);
+          return (
+            <Link
+              key={href}
+              href={href}
+              className={`flex flex-col items-center justify-center gap-1 flex-1 py-2 min-h-[56px] text-xs transition-colors ${
+                active
+                  ? "text-[var(--primary)] font-medium"
+                  : "text-[var(--muted)] hover:text-[var(--foreground)]"
+              }`}
+            >
+              <Icon size={20} />
+              <span>{label}</span>
+            </Link>
+          );
+        })}
+      </nav>
     </>
   );
 }

--- a/frontend/components/tracking/AddEventModal.tsx
+++ b/frontend/components/tracking/AddEventModal.tsx
@@ -36,11 +36,11 @@ export function AddEventModal({ productId, onClose, onAdd }: AddEventModalProps)
   }
 
   return (
-    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
-      <div className="bg-[var(--card)] border border-[var(--card-border)] rounded-xl p-6 w-full max-w-md shadow-xl">
+    <div className="fixed inset-0 bg-black/50 flex items-start sm:items-center justify-center z-50 p-4 overflow-y-auto">
+      <div className="bg-[var(--card)] border border-[var(--card-border)] rounded-xl p-5 w-full max-w-md shadow-xl my-auto">
         <div className="flex items-center justify-between mb-5">
           <h2 className="text-base font-semibold text-[var(--foreground)]">Add Tracking Event</h2>
-          <button onClick={onClose} aria-label="Close" className="p-1 rounded hover:bg-[var(--muted-bg)] text-[var(--muted)]">
+          <button onClick={onClose} aria-label="Close" className="p-2 rounded hover:bg-[var(--muted-bg)] text-[var(--muted)] min-h-[44px] min-w-[44px] flex items-center justify-center">
             <X size={16} />
           </button>
         </div>
@@ -83,11 +83,11 @@ export function AddEventModal({ productId, onClose, onAdd }: AddEventModalProps)
             {metaError && <p className="text-xs text-red-500 mt-1">{metaError}</p>}
           </div>
 
-          <div className="flex justify-end gap-3 mt-1">
-            <button type="button" onClick={onClose} className="px-4 py-2 text-sm rounded-md border border-[var(--card-border)] hover:bg-[var(--muted-bg)] text-[var(--foreground)]">
+          <div className="flex flex-col-reverse sm:flex-row justify-end gap-3 mt-1">
+            <button type="button" onClick={onClose} className="px-4 py-2.5 text-sm rounded-md border border-[var(--card-border)] hover:bg-[var(--muted-bg)] text-[var(--foreground)] min-h-[44px]">
               Cancel
             </button>
-            <button type="submit" className="px-4 py-2 text-sm rounded-md bg-[var(--primary)] text-[var(--primary-fg)] hover:opacity-90">
+            <button type="submit" className="px-4 py-2.5 text-sm rounded-md bg-[var(--primary)] text-[var(--primary-fg)] hover:opacity-90 min-h-[44px]">
               Add Event
             </button>
           </div>

--- a/frontend/components/tracking/QRScanner.tsx
+++ b/frontend/components/tracking/QRScanner.tsx
@@ -86,25 +86,25 @@ export function QRScanner({ onClose }: QRScannerProps) {
   }
 
   return (
-    <div className="fixed inset-0 bg-black/60 flex items-center justify-center z-50 p-4">
-      <div className="bg-[var(--card)] border border-[var(--card-border)] rounded-xl w-full max-w-sm shadow-xl overflow-hidden">
+    <div className="fixed inset-0 bg-black/60 flex items-start sm:items-center justify-center z-50 p-4 overflow-y-auto">
+      <div className="bg-[var(--card)] border border-[var(--card-border)] rounded-xl w-full max-w-sm shadow-xl overflow-hidden my-auto">
         {/* Header */}
         <div className="flex items-center justify-between px-4 py-3 border-b border-[var(--card-border)]">
           <div className="flex items-center gap-2 text-[var(--foreground)]">
             <QrCode size={16} />
             <span className="text-sm font-semibold">Scan QR Code</span>
           </div>
-          <button onClick={onClose} aria-label="Close scanner" className="p-1 rounded hover:bg-[var(--muted-bg)] text-[var(--muted)]">
+          <button onClick={onClose} aria-label="Close scanner" className="p-2 rounded hover:bg-[var(--muted-bg)] text-[var(--muted)] min-h-[44px] min-w-[44px] flex items-center justify-center">
             <X size={16} />
           </button>
         </div>
 
         <div className="p-4 flex flex-col gap-4">
-          {/* Camera viewfinder */}
+          {/* Camera viewfinder — aspect-square so it fills width on mobile */}
           {state !== "denied" && (
             <div
               id={containerId}
-              className="w-full rounded-lg overflow-hidden bg-black min-h-[260px]"
+              className="w-full rounded-lg overflow-hidden bg-black aspect-square"
             />
           )}
 
@@ -143,7 +143,7 @@ export function QRScanner({ onClose }: QRScannerProps) {
               />
               <button
                 onClick={handleManualSubmit}
-                className="px-3 py-2 text-sm rounded-md bg-[var(--primary)] text-[var(--primary-fg)] hover:opacity-90"
+                className="px-4 py-2 text-sm rounded-md bg-[var(--primary)] text-[var(--primary-fg)] hover:opacity-90 min-h-[44px] shrink-0"
               >
                 Go
               </button>


### PR DESCRIPTION
closes #110

- Replace mobile hamburger drawer with persistent bottom navigation bar
- Add safe-area-inset-bottom support for iOS notch/home-bar devices
- Add viewport meta tag (device-width, no zoom) to root layout
- Collapse sidebar to bottom nav on mobile (md breakpoint)
- Ensure all modals (AddEventModal, QRScanner) are scrollable on small screens
- Fix touch target sizes to min 44px across buttons and close icons
- QR scanner viewfinder uses aspect-square for proper mobile camera layout
- Reduce padding on mobile (p-4 md:p-6) across dashboard, products, tracking
- Dashboard stat cards: 1-col on mobile, 2-col sm, 4-col lg
- Hide Location column on xs screens in recent events table
- Products action buttons wrap on small screens (flex-wrap)
- Tracking and products buttons get min-h-[44px] for touch compliance