### PR TITLE
feat: public API documentation site with Swagger UI (#120)

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,6 +316,7 @@ Stellar's speed and near-zero cost make it ideal for supply chain use cases wher
 
 ## Documentation
 
+- **[API Reference](https://supply-link.vercel.app/api-docs)** — Interactive Swagger UI covering all REST API endpoints, authentication, and example request/response bodies.
 - **[User Guide — Producers](docs/user-guide-producer.md)** — Step-by-step guide for installing Freighter, funding a testnet account, registering products, adding tracking events, and sharing QR codes.
 
 ---

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1,0 +1,400 @@
+openapi: 3.0.3
+info:
+  title: Supply-Link API
+  version: 0.1.0
+  description: |
+    REST API for the Supply-Link decentralized supply chain provenance tracker.
+    Built on Stellar / Soroban smart contracts.
+
+    ## Authentication
+    Protected endpoints require an API key passed in the `X-API-Key` header.
+
+    ```
+    X-API-Key: your_api_key_here
+    ```
+servers:
+  - url: https://supply-link.vercel.app
+    description: Production
+  - url: http://localhost:3000
+    description: Local development
+
+components:
+  securitySchemes:
+    ApiKeyAuth:
+      type: apiKey
+      in: header
+      name: X-API-Key
+
+  schemas:
+    Error:
+      type: object
+      properties:
+        error:
+          type: string
+          example: "Missing required fields"
+
+    HealthResponse:
+      type: object
+      properties:
+        status:
+          type: string
+          example: ok
+        version:
+          type: string
+          example: "0.1.0"
+        network:
+          type: string
+          example: "Test SDF Network ; September 2015"
+        contractId:
+          type: string
+          example: "CBUWSKT2UGOAXK4ZREVDJV5XHSYB42PZ3CERU2ZFUTUMAZLJEHNZIECA"
+        rpcUrl:
+          type: string
+          example: "https://soroban-testnet.stellar.org"
+        contractReachable:
+          type: boolean
+          example: true
+        uptime:
+          type: integer
+          example: 3600
+        timestamp:
+          type: string
+          format: date-time
+          example: "2026-04-27T14:00:00.000Z"
+
+    Rating:
+      type: object
+      properties:
+        id:
+          type: string
+          example: "prod-abc123_GABC...XYZ_1714224000000"
+        productId:
+          type: string
+          example: "prod-abc123"
+        walletAddress:
+          type: string
+          example: "GABC...XYZ"
+        stars:
+          type: integer
+          minimum: 1
+          maximum: 5
+          example: 5
+        comment:
+          type: string
+          nullable: true
+          example: "Excellent provenance record."
+        timestamp:
+          type: integer
+          example: 1714224000000
+
+    RatingsResponse:
+      type: object
+      properties:
+        productId:
+          type: string
+          example: "prod-abc123"
+        averageRating:
+          type: number
+          example: 4.5
+        totalRatings:
+          type: integer
+          example: 12
+        recentRatings:
+          type: array
+          items:
+            $ref: "#/components/schemas/Rating"
+
+    FeeBumpRequest:
+      type: object
+      required: [innerTx]
+      properties:
+        innerTx:
+          type: string
+          description: Base64-encoded Stellar transaction XDR envelope
+          example: "AAAAAgAAAAA..."
+
+    FeeBumpResponse:
+      type: object
+      properties:
+        feeBumpTx:
+          type: string
+          description: Base64-encoded fee-bump transaction XDR
+          example: "AAAABgAAAAA..."
+        cost:
+          type: string
+          description: Fee in stroops
+          example: "200"
+        message:
+          type: string
+          example: "Fee-bump transaction created. Ready to submit to Stellar network."
+
+    UploadResponse:
+      type: object
+      properties:
+        url:
+          type: string
+          format: uri
+          example: "https://public.blob.vercel-storage.com/products/1714224000000-photo.jpg"
+
+paths:
+  /api/health:
+    get:
+      summary: Health check
+      description: Returns service status, version, Stellar RPC reachability, and uptime. Rate-limited to 10 requests per IP per 60 seconds.
+      operationId: getHealth
+      tags: [System]
+      responses:
+        "200":
+          description: Service is healthy
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/HealthResponse"
+              example:
+                status: ok
+                version: "0.1.0"
+                network: "Test SDF Network ; September 2015"
+                contractId: "CBUWSKT2UGOAXK4ZREVDJV5XHSYB42PZ3CERU2ZFUTUMAZLJEHNZIECA"
+                rpcUrl: "https://soroban-testnet.stellar.org"
+                contractReachable: true
+                uptime: 3600
+                timestamp: "2026-04-27T14:00:00.000Z"
+        "429":
+          description: Rate limit exceeded
+          headers:
+            Retry-After:
+              schema:
+                type: integer
+                example: 60
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                error: "Too many requests"
+
+  /api/ratings:
+    get:
+      summary: Get ratings for a product
+      operationId: getRatings
+      tags: [Ratings]
+      parameters:
+        - name: productId
+          in: query
+          required: true
+          schema:
+            type: string
+          example: "prod-abc123"
+      responses:
+        "200":
+          description: Ratings summary and recent reviews
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/RatingsResponse"
+              example:
+                productId: "prod-abc123"
+                averageRating: 4.5
+                totalRatings: 12
+                recentRatings:
+                  - id: "prod-abc123_GABC_1714224000000"
+                    productId: "prod-abc123"
+                    walletAddress: "GABC...XYZ"
+                    stars: 5
+                    comment: "Excellent provenance record."
+                    timestamp: 1714224000000
+        "400":
+          description: Missing productId
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                error: "Missing productId parameter"
+
+    post:
+      summary: Submit a product rating
+      description: Requires a valid Stellar wallet signature over the message field.
+      operationId: postRating
+      tags: [Ratings]
+      security:
+        - ApiKeyAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [productId, walletAddress, stars, message, signature]
+              properties:
+                productId:
+                  type: string
+                  example: "prod-abc123"
+                walletAddress:
+                  type: string
+                  description: Stellar public key (G… 56 chars)
+                  example: "GABC...XYZ"
+                stars:
+                  type: integer
+                  minimum: 1
+                  maximum: 5
+                  example: 5
+                comment:
+                  type: string
+                  maxLength: 500
+                  example: "Excellent provenance record."
+                message:
+                  type: string
+                  description: Arbitrary message that was signed
+                  example: "rate:prod-abc123:5"
+                signature:
+                  type: string
+                  description: Ed25519 signature of message by walletAddress
+                  example: "abc123..."
+      responses:
+        "201":
+          description: Rating created
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Rating"
+        "400":
+          description: Validation error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Invalid wallet signature
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                error: "Invalid signature"
+
+  /api/v1/fee-bump:
+    post:
+      summary: Create a fee-bump transaction
+      description: |
+        Wraps a user's Stellar transaction in a fee-bump transaction paid by
+        the app's account, enabling gasless verification for consumers without XLM.
+      operationId: createFeeBump
+      tags: [Stellar]
+      security:
+        - ApiKeyAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/FeeBumpRequest"
+            example:
+              innerTx: "AAAAAgAAAAA..."
+      responses:
+        "200":
+          description: Fee-bump transaction ready to submit
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/FeeBumpResponse"
+              example:
+                feeBumpTx: "AAAABgAAAAA..."
+                cost: "200"
+                message: "Fee-bump transaction created. Ready to submit to Stellar network."
+        "400":
+          description: Invalid or missing innerTx
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              examples:
+                missing:
+                  value:
+                    error: "Missing or invalid 'innerTx' parameter"
+                invalid_xdr:
+                  value:
+                    error: "Invalid transaction XDR"
+        "500":
+          description: Fee-bump account not configured
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                error: "Fee-bump account not configured"
+
+  /api/v1/upload:
+    post:
+      summary: Upload a product image
+      description: Accepts JPEG, PNG, WebP, or GIF up to 5 MB. Returns a public CDN URL.
+      operationId: uploadImage
+      tags: [Products]
+      security:
+        - ApiKeyAuth: []
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required: [file]
+              properties:
+                file:
+                  type: string
+                  format: binary
+      responses:
+        "200":
+          description: Upload successful
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UploadResponse"
+              example:
+                url: "https://public.blob.vercel-storage.com/products/1714224000000-photo.jpg"
+        "400":
+          description: Validation error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              examples:
+                no_file:
+                  value:
+                    error: "No file provided"
+                bad_type:
+                  value:
+                    error: "Invalid file type. Allowed: JPEG, PNG, WebP, GIF"
+                too_large:
+                  value:
+                    error: "File too large. Maximum size is 5 MB"
+
+  /api/v1/products/{id}/badge.png:
+    get:
+      summary: Get a shareable SVG badge for a product
+      description: Returns an SVG badge with the product name, origin, verification date, and a QR code link.
+      operationId: getProductBadge
+      tags: [Products]
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+          example: "prod-abc123"
+      responses:
+        "200":
+          description: SVG badge
+          content:
+            image/svg+xml:
+              schema:
+                type: string
+                format: binary
+        "404":
+          description: Product not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                error: "Product not found"

--- a/frontend/app/[locale]/page.tsx
+++ b/frontend/app/[locale]/page.tsx
@@ -157,6 +157,9 @@ export default function HomePage() {
             <a href="https://github.com" target="_blank" rel="noreferrer" className="flex items-center gap-1.5 hover:text-[var(--foreground)] transition-colors">
               <Github size={15} /> GitHub
             </a>
+            <Link href="/api-docs" className="flex items-center gap-1.5 hover:text-[var(--foreground)] transition-colors">
+              <BookOpen size={15} /> API Docs
+            </Link>
             <a href="https://developers.stellar.org/docs/smart-contracts" target="_blank" rel="noreferrer" className="flex items-center gap-1.5 hover:text-[var(--foreground)] transition-colors">
               <BookOpen size={15} /> Docs
             </a>

--- a/frontend/app/api-docs/page.tsx
+++ b/frontend/app/api-docs/page.tsx
@@ -1,0 +1,14 @@
+"use client";
+
+import dynamic from "next/dynamic";
+import "swagger-ui-react/swagger-ui.css";
+
+const SwaggerUI = dynamic(() => import("swagger-ui-react"), { ssr: false });
+
+export default function ApiDocsPage() {
+  return (
+    <main className="min-h-screen bg-white">
+      <SwaggerUI url="/api/openapi" />
+    </main>
+  );
+}

--- a/frontend/app/api/openapi/route.ts
+++ b/frontend/app/api/openapi/route.ts
@@ -1,0 +1,20 @@
+import { NextRequest, NextResponse } from "next/server";
+import { readFileSync } from "fs";
+import { join } from "path";
+import { parse } from "yaml";
+import { withCors, handleOptions } from "@/lib/api/cors";
+
+export function OPTIONS(request: NextRequest) {
+  return handleOptions(request);
+}
+
+export function GET(request: NextRequest) {
+  const yamlPath = join(process.cwd(), "..", "docs", "openapi.yaml");
+  const spec = parse(readFileSync(yamlPath, "utf8"));
+  return withCors(
+    request,
+    NextResponse.json(spec, {
+      headers: { "Cache-Control": "public, max-age=3600" },
+    })
+  );
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -45,6 +45,8 @@
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.5.0",
     "tailwindcss-animate": "^1.0.7",
+    "swagger-ui-react": "5.21.0",
+    "yaml": "^2.7.1",
     "zod": "^4.3.6",
     "zustand": "^5.0.8"
   },
@@ -68,6 +70,7 @@
     "@types/qrcode": "^1.5.6",
     "@types/react": "^19",
     "@types/react-dom": "^19",
+    "@types/swagger-ui-react": "^4.18.3",
     "@typescript-eslint/eslint-plugin": "^8.59.0",
     "@typescript-eslint/parser": "^8.59.0",
     "eslint": "^10",


### PR DESCRIPTION
## Summary

Closes #120.

### What's added

**`docs/openapi.yaml`** — OpenAPI 3.0 spec covering all REST API endpoints:
- `GET /api/health` — service status, rate limit docs
- `GET /api/ratings` — product ratings
- `POST /api/ratings` — submit a rating (wallet signature auth)
- `POST /api/v1/fee-bump` — wrap a Stellar tx in a fee-bump
- `POST /api/v1/upload` — upload a product image
- `GET /api/v1/products/{id}/badge.png` — shareable SVG badge

Includes `ApiKeyAuth` security scheme (X-API-Key header) and example request/response bodies for every endpoint.

**`app/api/openapi/route.ts`** — Serves the YAML spec as JSON at `/api/openapi` (with CORS).

**`app/api-docs/page.tsx`** — Swagger UI at `/api-docs`, dynamically imported (no SSR) to avoid browser-API issues.

**`package.json`** — Added `swagger-ui-react@5.21.0` and `yaml@^2.7.1`.

**README + landing page footer** — Both now link to `/api-docs`.