### PR TITLE
Add anti-replay nonce support for privileged operations

### DIFF
--- a/docs/NONCE_LIFECYCLE.md
+++ b/docs/NONCE_LIFECYCLE.md
@@ -1,0 +1,271 @@
+# Nonce Lifecycle and Anti-Replay Protection
+
+## Overview
+
+The Supply-Link smart contract implements nonce-based anti-replay protection for privileged operations. This mechanism prevents replay attacks where a valid signed transaction could be resubmitted maliciously to repeat an action.
+
+## Nonce Model
+
+### Storage
+
+Each actor (Stellar address) has an independent nonce counter stored in persistent contract storage under `DataKey::ActorNonce(Address)`. Nonces start at 0 and increment sequentially with each privileged operation.
+
+### Scope
+
+Nonces are scoped per actor address, not per product or operation type. This means:
+- Each address maintains a single nonce counter across all operations
+- Operations on different products by the same actor share the same nonce sequence
+- Different actors have independent nonce counters
+
+## Protected Operations
+
+The following privileged operations enforce nonce validation:
+
+1. **transfer_ownership** - Transferring product ownership to a new address
+2. **add_authorized_actor** - Granting event submission permissions
+3. **remove_authorized_actor** - Revoking event submission permissions
+4. **approve_event** - Approving a pending multi-signature event
+5. **reject_event** - Rejecting a pending multi-signature event
+
+## Nonce Progression Rules
+
+### Sequential Requirement
+
+Nonces must be used in strict sequential order starting from 0. The contract validates that the provided nonce matches the current stored nonce for the actor before executing the operation.
+
+**Valid sequence:**
+```
+Operation 1: nonce=0 → stored nonce becomes 1
+Operation 2: nonce=1 → stored nonce becomes 2
+Operation 3: nonce=2 → stored nonce becomes 3
+```
+
+**Invalid sequences:**
+```
+Operation 1: nonce=0 → stored nonce becomes 1
+Operation 2: nonce=0 → REJECTED (stale nonce)
+
+Operation 1: nonce=5 → REJECTED (future nonce, expected 0)
+
+Operation 1: nonce=0 → stored nonce becomes 1
+Operation 2: nonce=1 → stored nonce becomes 2
+Operation 3: nonce=1 → REJECTED (stale nonce)
+```
+
+### Atomic Validation
+
+Nonce validation and increment occur atomically within the same transaction:
+1. Transaction signature is verified via `require_auth()`
+2. Current nonce is retrieved from storage
+3. Provided nonce is compared against current nonce
+4. If match: nonce is incremented and operation proceeds
+5. If mismatch: transaction panics with "invalid nonce"
+
+## Client Responsibilities
+
+### Querying Current Nonce
+
+Before submitting a privileged operation, clients must query the current nonce for the signing actor:
+
+```rust
+let current_nonce = client.get_nonce(&actor_address);
+```
+
+### Submitting Operations
+
+Include the current nonce when calling protected operations:
+
+```rust
+client.transfer_ownership(
+    &product_id,
+    &new_owner,
+    &current_nonce  // Must match actor's current nonce
+);
+```
+
+### Handling Nonce Failures
+
+If a transaction fails with "invalid nonce":
+1. Re-query the current nonce using `get_nonce()`
+2. Verify no concurrent operations are in progress
+3. Resubmit with the updated nonce value
+
+### Concurrent Operations
+
+Clients performing multiple operations concurrently must serialize nonce-protected operations or implement optimistic retry logic:
+
+**Sequential approach (recommended):**
+```rust
+let nonce = client.get_nonce(&owner);
+client.add_authorized_actor(&product_id, &actor1, &nonce);
+
+let nonce = client.get_nonce(&owner);
+client.add_authorized_actor(&product_id, &actor2, &nonce);
+```
+
+**Optimistic retry approach:**
+```rust
+loop {
+    let nonce = client.get_nonce(&owner);
+    match client.try_add_authorized_actor(&product_id, &actor, &nonce) {
+        Ok(_) => break,
+        Err(e) if e.contains("invalid nonce") => continue,
+        Err(e) => return Err(e),
+    }
+}
+```
+
+## Security Considerations
+
+### Replay Attack Prevention
+
+The nonce mechanism prevents:
+- **Exact replay**: Resubmitting a previously executed transaction
+- **Cross-product replay**: Using a transaction from one product on another
+- **Delayed replay**: Executing a captured transaction at a later time
+
+### Nonce Exhaustion
+
+Nonces are stored as `u64`, providing 2^64 possible values per actor. At 1 operation per second, this allows ~584 billion years of operations before exhaustion.
+
+### Front-Running
+
+Nonce protection does not prevent front-running attacks where an attacker observes a pending transaction and submits their own transaction with a higher fee. Applications requiring front-running protection should implement additional mechanisms such as commit-reveal schemes.
+
+### Nonce Gaps
+
+The contract does not allow nonce gaps. If a transaction with nonce N fails, subsequent transactions must still use nonce N (not N+1). This prevents accidental nonce desynchronization.
+
+## Read-Only Operations
+
+The following operations do not require nonces as they are read-only:
+- `get_product`
+- `get_tracking_events`
+- `product_exists`
+- `get_events_count`
+- `get_authorized_actors`
+- `get_product_count`
+- `list_products`
+- `get_pending_events`
+- `get_nonce`
+
+## Non-Protected Write Operations
+
+The following write operations do not enforce nonce validation:
+- `register_product` - Initial registration has no replay risk
+- `add_tracking_event` - Event timestamps provide natural replay protection
+- `update_product_metadata` - Lower sensitivity operation
+
+These operations still require transaction signature authorization but do not increment or validate nonces.
+
+## Migration and Compatibility
+
+### Existing Deployments
+
+For contracts deployed before nonce support:
+- All actor nonces start at 0
+- First privileged operation must use nonce=0
+- No migration or initialization required
+
+### Client Updates
+
+Clients must be updated to:
+1. Query nonces before privileged operations
+2. Include nonce parameter in operation calls
+3. Handle "invalid nonce" errors appropriately
+
+### Backward Compatibility
+
+The nonce parameter is a breaking change to the contract interface. Existing clients calling privileged operations without the nonce parameter will fail at the contract invocation level due to parameter mismatch.
+
+## Testing
+
+The contract includes comprehensive nonce tests covering:
+- Initial nonce value (0)
+- Nonce increment on successful operations
+- Rejection of stale nonces (already used)
+- Rejection of future nonces (not yet valid)
+- Rejection of duplicate nonces
+- Rejection of out-of-order nonces
+- Nonce progression across multiple operations
+- Nonce isolation between different actors
+
+Run tests with:
+```bash
+cd smart-contract/contracts
+cargo test
+```
+
+## Example Workflows
+
+### Single Operation
+
+```rust
+// Query current nonce
+let nonce = client.get_nonce(&owner);
+
+// Execute operation with nonce
+client.transfer_ownership(&product_id, &new_owner, &nonce);
+
+// Nonce is now incremented to nonce + 1
+```
+
+### Multiple Sequential Operations
+
+```rust
+let mut nonce = client.get_nonce(&owner);
+
+client.add_authorized_actor(&product_id, &actor1, &nonce);
+nonce += 1;
+
+client.add_authorized_actor(&product_id, &actor2, &nonce);
+nonce += 1;
+
+client.transfer_ownership(&product_id, &new_owner, &nonce);
+```
+
+### Multi-Signature Approval
+
+```rust
+// First approver
+let nonce1 = client.get_nonce(&approver1);
+client.approve_event(&product_id, &event_index, &approver1, &nonce1);
+
+// Second approver (independent nonce)
+let nonce2 = client.get_nonce(&approver2);
+client.approve_event(&product_id, &event_index, &approver2, &nonce2);
+```
+
+## API Reference
+
+### get_nonce
+
+```rust
+pub fn get_nonce(env: Env, actor: Address) -> u64
+```
+
+Returns the current nonce value for the specified actor address. Returns 0 if the actor has never performed a nonce-protected operation.
+
+**Parameters:**
+- `env`: Soroban execution environment
+- `actor`: Address to query nonce for
+
+**Returns:** Current nonce value as u64
+
+**Authorization:** None (read-only)
+
+### Protected Operation Signatures
+
+All protected operations now include a `nonce: u64` parameter:
+
+```rust
+pub fn transfer_ownership(env: Env, product_id: String, new_owner: Address, nonce: u64) -> bool
+pub fn add_authorized_actor(env: Env, product_id: String, actor: Address, nonce: u64) -> bool
+pub fn remove_authorized_actor(env: Env, product_id: String, actor: Address, nonce: u64) -> bool
+pub fn approve_event(env: Env, product_id: String, event_index: u32, approver: Address, nonce: u64) -> bool
+pub fn reject_event(env: Env, product_id: String, event_index: u32, rejector: Address, nonce: u64) -> bool
+```
+
+## Support
+
+For questions or issues related to nonce handling, please refer to the test suite in `smart-contract/contracts/src/tests.rs` for concrete examples of correct usage patterns.

--- a/smart-contract/contracts/src/lib.rs
+++ b/smart-contract/contracts/src/lib.rs
@@ -1,6 +1,8 @@
 #![no_std]
 use soroban_sdk::{contract, contractimpl, contracttype, Address, Env, String, Vec, Symbol};
 
+mod tests;
+
 // ── Data models ──────────────────────────────────────────────────────────────
 
 /// Represents a product registered on the Supply-Link blockchain.
@@ -125,6 +127,8 @@ pub enum DataKey {
     /// Key for the index-to-ID mapping used by pagination.
     /// The inner `u64` is the zero-based insertion index.
     ProductIndex(u64),
+    /// Key for actor nonce tracking. The inner `Address` is the actor address.
+    ActorNonce(Address),
 }
 
 // ── Contract ─────────────────────────────────────────────────────────────────
@@ -459,7 +463,7 @@ impl SupplyLinkContract {
     /// # Emitted Events
     /// Publishes an `("ownership_transferred", product_id)` event with
     /// `new_owner` as the event body.
-    pub fn transfer_ownership(env: Env, product_id: String, new_owner: Address) -> bool {
+    pub fn transfer_ownership(env: Env, product_id: String, new_owner: Address, nonce: u64) -> bool {
         let mut product: Product = env
             .storage()
             .persistent()
@@ -467,12 +471,13 @@ impl SupplyLinkContract {
             .expect("product not found");
 
         product.owner.require_auth();
+        Self::validate_and_increment_nonce(&env, &product.owner, nonce);
+        
         product.owner = new_owner.clone();
         env.storage()
             .persistent()
             .set(&DataKey::Product(product_id.clone()), &product);
 
-        // Emit event
         env.events().publish(
             (Symbol::new(&env, "ownership_transferred"), product_id),
             new_owner,
@@ -505,7 +510,7 @@ impl SupplyLinkContract {
     /// # Emitted Events
     /// Publishes an `("actor_authorized", product_id)` event with `actor` as
     /// the event body.
-    pub fn add_authorized_actor(env: Env, product_id: String, actor: Address) -> bool {
+    pub fn add_authorized_actor(env: Env, product_id: String, actor: Address, nonce: u64) -> bool {
         let mut product: Product = env
             .storage()
             .persistent()
@@ -513,12 +518,13 @@ impl SupplyLinkContract {
             .expect("product not found");
 
         product.owner.require_auth();
+        Self::validate_and_increment_nonce(&env, &product.owner, nonce);
+        
         product.authorized_actors.push_back(actor.clone());
         env.storage()
             .persistent()
             .set(&DataKey::Product(product_id.clone()), &product);
 
-        // Emit event
         env.events().publish(
             (Symbol::new(&env, "actor_authorized"), product_id),
             actor,
@@ -551,7 +557,7 @@ impl SupplyLinkContract {
     ///
     /// # Emitted Events
     /// Does not emit an event (removal is not currently announced on-chain).
-    pub fn remove_authorized_actor(env: Env, product_id: String, actor: Address) -> bool {
+    pub fn remove_authorized_actor(env: Env, product_id: String, actor: Address, nonce: u64) -> bool {
         let mut product: Product = env
             .storage()
             .persistent()
@@ -559,8 +565,8 @@ impl SupplyLinkContract {
             .expect("product not found");
 
         product.owner.require_auth();
+        Self::validate_and_increment_nonce(&env, &product.owner, nonce);
 
-        // Find and remove the actor
         let mut found = false;
         let mut new_actors = Vec::new(&env);
         for i in 0..product.authorized_actors.len() {
@@ -763,6 +769,7 @@ impl SupplyLinkContract {
         product_id: String,
         event_index: u32,
         approver: Address,
+        nonce: u64,
     ) -> bool {
         let product: Product = env
             .storage()
@@ -776,6 +783,7 @@ impl SupplyLinkContract {
             panic!("approver is not authorized");
         }
         approver.require_auth();
+        Self::validate_and_increment_nonce(&env, &approver, nonce);
 
         let mut pending: Vec<PendingEvent> = env
             .storage()
@@ -783,22 +791,19 @@ impl SupplyLinkContract {
             .get(&DataKey::PendingEvents(product_id.clone()))
             .expect("no pending events");
 
-        if event_index as usize >= pending.len() {
+        if event_index >= pending.len() {
             panic!("event index out of bounds");
         }
 
-        let mut pending_event = pending.get(event_index as usize).unwrap().clone();
+        let mut pending_event = pending.get(event_index).unwrap().clone();
 
-        // Check if approver already approved
         if !pending_event.approvals.contains(&approver) {
             pending_event.approvals.push_back(approver.clone());
         }
 
-        // Check if we have enough approvals
         let is_finalized = pending_event.approvals.len() as u32 >= pending_event.required_signatures;
 
         if is_finalized {
-            // Move event to finalized events
             let mut events: Vec<TrackingEvent> = env
                 .storage()
                 .persistent()
@@ -810,8 +815,7 @@ impl SupplyLinkContract {
                 .persistent()
                 .set(&DataKey::Events(product_id.clone()), &events);
 
-            // Remove from pending
-            pending.remove(event_index as usize);
+            pending.remove(event_index);
             if pending.len() > 0 {
                 env.storage()
                     .persistent()
@@ -822,7 +826,6 @@ impl SupplyLinkContract {
                     .remove(&DataKey::PendingEvents(product_id.clone()));
             }
 
-            // Emit finalized event
             env.events().publish(
                 (
                     Symbol::new(&env, "event_finalized"),
@@ -834,8 +837,7 @@ impl SupplyLinkContract {
 
             true
         } else {
-            // Update pending event with new approval
-            pending.set(event_index as usize, pending_event);
+            pending.set(event_index, pending_event);
             env.storage()
                 .persistent()
                 .set(&DataKey::PendingEvents(product_id), &pending);
@@ -869,6 +871,7 @@ impl SupplyLinkContract {
         product_id: String,
         event_index: u32,
         rejector: Address,
+        nonce: u64,
     ) -> bool {
         let product: Product = env
             .storage()
@@ -880,6 +883,7 @@ impl SupplyLinkContract {
             panic!("only owner can reject");
         }
         rejector.require_auth();
+        Self::validate_and_increment_nonce(&env, &rejector, nonce);
 
         let mut pending: Vec<PendingEvent> = env
             .storage()
@@ -887,14 +891,13 @@ impl SupplyLinkContract {
             .get(&DataKey::PendingEvents(product_id.clone()))
             .expect("no pending events");
 
-        if event_index as usize >= pending.len() {
+        if event_index >= pending.len() {
             panic!("event index out of bounds");
         }
 
-        let rejected_event = pending.get(event_index as usize).unwrap().clone();
+        let rejected_event = pending.get(event_index).unwrap().clone();
 
-        // Remove from pending
-        pending.remove(event_index as usize);
+        pending.remove(event_index);
         if pending.len() > 0 {
             env.storage()
                 .persistent()
@@ -905,7 +908,6 @@ impl SupplyLinkContract {
                 .remove(&DataKey::PendingEvents(product_id.clone()));
         }
 
-        // Emit rejection event
         env.events().publish(
             (Symbol::new(&env, "event_rejected"), product_id),
             rejected_event.event,
@@ -932,5 +934,28 @@ impl SupplyLinkContract {
             .persistent()
             .get(&DataKey::PendingEvents(product_id))
             .unwrap_or_else(|| Vec::new(&env))
+    }
+
+    pub fn get_nonce(env: Env, actor: Address) -> u64 {
+        env.storage()
+            .persistent()
+            .get(&DataKey::ActorNonce(actor))
+            .unwrap_or(0)
+    }
+
+    fn validate_and_increment_nonce(env: &Env, actor: &Address, provided_nonce: u64) {
+        let current_nonce: u64 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::ActorNonce(actor.clone()))
+            .unwrap_or(0);
+
+        if provided_nonce != current_nonce {
+            panic!("invalid nonce");
+        }
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::ActorNonce(actor.clone()), &(current_nonce + 1));
     }
 }

--- a/smart-contract/contracts/src/tests.rs
+++ b/smart-contract/contracts/src/tests.rs
@@ -1,0 +1,407 @@
+#![cfg(test)]
+use super::*;
+use soroban_sdk::{testutils::Address as _, Address, Env, String};
+
+#[test]
+fn test_nonce_starts_at_zero() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, SupplyLinkContract);
+    let client = SupplyLinkContractClient::new(&env, &contract_id);
+    
+    let actor = Address::generate(&env);
+    
+    assert_eq!(client.get_nonce(&actor), 0);
+}
+
+#[test]
+fn test_transfer_ownership_increments_nonce() {
+    let env = Env::default();
+    env.mock_all_auths();
+    
+    let contract_id = env.register_contract(None, SupplyLinkContract);
+    let client = SupplyLinkContractClient::new(&env, &contract_id);
+    
+    let owner = Address::generate(&env);
+    let new_owner = Address::generate(&env);
+    
+    client.register_product(
+        &String::from_str(&env, "prod1"),
+        &String::from_str(&env, "Product 1"),
+        &String::from_str(&env, "Origin"),
+        &owner,
+        &1,
+    );
+    
+    assert_eq!(client.get_nonce(&owner), 0);
+    
+    client.transfer_ownership(
+        &String::from_str(&env, "prod1"),
+        &new_owner,
+        &0,
+    );
+    
+    assert_eq!(client.get_nonce(&owner), 1);
+}
+
+#[test]
+#[should_panic(expected = "invalid nonce")]
+fn test_transfer_ownership_rejects_stale_nonce() {
+    let env = Env::default();
+    env.mock_all_auths();
+    
+    let contract_id = env.register_contract(None, SupplyLinkContract);
+    let client = SupplyLinkContractClient::new(&env, &contract_id);
+    
+    let owner = Address::generate(&env);
+    let actor = Address::generate(&env);
+    
+    client.register_product(
+        &String::from_str(&env, "prod1"),
+        &String::from_str(&env, "Product 1"),
+        &String::from_str(&env, "Origin"),
+        &owner,
+        &1,
+    );
+    
+    client.add_authorized_actor(
+        &String::from_str(&env, "prod1"),
+        &actor,
+        &0,
+    );
+    
+    client.remove_authorized_actor(
+        &String::from_str(&env, "prod1"),
+        &actor,
+        &0,
+    );
+}
+
+#[test]
+#[should_panic(expected = "invalid nonce")]
+fn test_transfer_ownership_rejects_future_nonce() {
+    let env = Env::default();
+    env.mock_all_auths();
+    
+    let contract_id = env.register_contract(None, SupplyLinkContract);
+    let client = SupplyLinkContractClient::new(&env, &contract_id);
+    
+    let owner = Address::generate(&env);
+    let new_owner = Address::generate(&env);
+    
+    client.register_product(
+        &String::from_str(&env, "prod1"),
+        &String::from_str(&env, "Product 1"),
+        &String::from_str(&env, "Origin"),
+        &owner,
+        &1,
+    );
+    
+    client.transfer_ownership(
+        &String::from_str(&env, "prod1"),
+        &new_owner,
+        &5,
+    );
+}
+
+#[test]
+fn test_add_authorized_actor_increments_nonce() {
+    let env = Env::default();
+    env.mock_all_auths();
+    
+    let contract_id = env.register_contract(None, SupplyLinkContract);
+    let client = SupplyLinkContractClient::new(&env, &contract_id);
+    
+    let owner = Address::generate(&env);
+    let actor = Address::generate(&env);
+    
+    client.register_product(
+        &String::from_str(&env, "prod1"),
+        &String::from_str(&env, "Product 1"),
+        &String::from_str(&env, "Origin"),
+        &owner,
+        &1,
+    );
+    
+    assert_eq!(client.get_nonce(&owner), 0);
+    
+    client.add_authorized_actor(
+        &String::from_str(&env, "prod1"),
+        &actor,
+        &0,
+    );
+    
+    assert_eq!(client.get_nonce(&owner), 1);
+}
+
+#[test]
+#[should_panic(expected = "invalid nonce")]
+fn test_add_authorized_actor_rejects_duplicate_nonce() {
+    let env = Env::default();
+    env.mock_all_auths();
+    
+    let contract_id = env.register_contract(None, SupplyLinkContract);
+    let client = SupplyLinkContractClient::new(&env, &contract_id);
+    
+    let owner = Address::generate(&env);
+    let actor1 = Address::generate(&env);
+    let actor2 = Address::generate(&env);
+    
+    client.register_product(
+        &String::from_str(&env, "prod1"),
+        &String::from_str(&env, "Product 1"),
+        &String::from_str(&env, "Origin"),
+        &owner,
+        &1,
+    );
+    
+    client.add_authorized_actor(
+        &String::from_str(&env, "prod1"),
+        &actor1,
+        &0,
+    );
+    
+    client.add_authorized_actor(
+        &String::from_str(&env, "prod1"),
+        &actor2,
+        &0,
+    );
+}
+
+#[test]
+fn test_remove_authorized_actor_increments_nonce() {
+    let env = Env::default();
+    env.mock_all_auths();
+    
+    let contract_id = env.register_contract(None, SupplyLinkContract);
+    let client = SupplyLinkContractClient::new(&env, &contract_id);
+    
+    let owner = Address::generate(&env);
+    let actor = Address::generate(&env);
+    
+    client.register_product(
+        &String::from_str(&env, "prod1"),
+        &String::from_str(&env, "Product 1"),
+        &String::from_str(&env, "Origin"),
+        &owner,
+        &1,
+    );
+    
+    client.add_authorized_actor(
+        &String::from_str(&env, "prod1"),
+        &actor,
+        &0,
+    );
+    
+    assert_eq!(client.get_nonce(&owner), 1);
+    
+    client.remove_authorized_actor(
+        &String::from_str(&env, "prod1"),
+        &actor,
+        &1,
+    );
+    
+    assert_eq!(client.get_nonce(&owner), 2);
+}
+
+#[test]
+fn test_approve_event_increments_nonce() {
+    let env = Env::default();
+    env.mock_all_auths();
+    
+    let contract_id = env.register_contract(None, SupplyLinkContract);
+    let client = SupplyLinkContractClient::new(&env, &contract_id);
+    
+    let owner = Address::generate(&env);
+    let actor = Address::generate(&env);
+    
+    client.register_product(
+        &String::from_str(&env, "prod1"),
+        &String::from_str(&env, "Product 1"),
+        &String::from_str(&env, "Origin"),
+        &owner,
+        &2,
+    );
+    
+    client.add_tracking_event(
+        &String::from_str(&env, "prod1"),
+        &owner,
+        &String::from_str(&env, "Location"),
+        &String::from_str(&env, "HARVEST"),
+        &String::from_str(&env, "{}"),
+    );
+    
+    assert_eq!(client.get_nonce(&owner), 0);
+    
+    client.approve_event(
+        &String::from_str(&env, "prod1"),
+        &0,
+        &owner,
+        &0,
+    );
+    
+    assert_eq!(client.get_nonce(&owner), 1);
+}
+
+#[test]
+#[should_panic(expected = "invalid nonce")]
+fn test_approve_event_rejects_out_of_order_nonce() {
+    let env = Env::default();
+    env.mock_all_auths();
+    
+    let contract_id = env.register_contract(None, SupplyLinkContract);
+    let client = SupplyLinkContractClient::new(&env, &contract_id);
+    
+    let owner = Address::generate(&env);
+    
+    client.register_product(
+        &String::from_str(&env, "prod1"),
+        &String::from_str(&env, "Product 1"),
+        &String::from_str(&env, "Origin"),
+        &owner,
+        &2,
+    );
+    
+    client.add_tracking_event(
+        &String::from_str(&env, "prod1"),
+        &owner,
+        &String::from_str(&env, "Location"),
+        &String::from_str(&env, "HARVEST"),
+        &String::from_str(&env, "{}"),
+    );
+    
+    client.approve_event(
+        &String::from_str(&env, "prod1"),
+        &0,
+        &owner,
+        &1,
+    );
+}
+
+#[test]
+fn test_reject_event_increments_nonce() {
+    let env = Env::default();
+    env.mock_all_auths();
+    
+    let contract_id = env.register_contract(None, SupplyLinkContract);
+    let client = SupplyLinkContractClient::new(&env, &contract_id);
+    
+    let owner = Address::generate(&env);
+    
+    client.register_product(
+        &String::from_str(&env, "prod1"),
+        &String::from_str(&env, "Product 1"),
+        &String::from_str(&env, "Origin"),
+        &owner,
+        &2,
+    );
+    
+    client.add_tracking_event(
+        &String::from_str(&env, "prod1"),
+        &owner,
+        &String::from_str(&env, "Location"),
+        &String::from_str(&env, "HARVEST"),
+        &String::from_str(&env, "{}"),
+    );
+    
+    assert_eq!(client.get_nonce(&owner), 0);
+    
+    client.reject_event(
+        &String::from_str(&env, "prod1"),
+        &0,
+        &owner,
+        &0,
+    );
+    
+    assert_eq!(client.get_nonce(&owner), 1);
+}
+
+#[test]
+fn test_nonce_progression_multiple_operations() {
+    let env = Env::default();
+    env.mock_all_auths();
+    
+    let contract_id = env.register_contract(None, SupplyLinkContract);
+    let client = SupplyLinkContractClient::new(&env, &contract_id);
+    
+    let owner = Address::generate(&env);
+    let actor = Address::generate(&env);
+    let new_owner = Address::generate(&env);
+    
+    client.register_product(
+        &String::from_str(&env, "prod1"),
+        &String::from_str(&env, "Product 1"),
+        &String::from_str(&env, "Origin"),
+        &owner,
+        &1,
+    );
+    
+    assert_eq!(client.get_nonce(&owner), 0);
+    
+    client.add_authorized_actor(
+        &String::from_str(&env, "prod1"),
+        &actor,
+        &0,
+    );
+    assert_eq!(client.get_nonce(&owner), 1);
+    
+    client.remove_authorized_actor(
+        &String::from_str(&env, "prod1"),
+        &actor,
+        &1,
+    );
+    assert_eq!(client.get_nonce(&owner), 2);
+    
+    client.transfer_ownership(
+        &String::from_str(&env, "prod1"),
+        &new_owner,
+        &2,
+    );
+    assert_eq!(client.get_nonce(&owner), 3);
+}
+
+#[test]
+fn test_nonce_isolated_per_actor() {
+    let env = Env::default();
+    env.mock_all_auths();
+    
+    let contract_id = env.register_contract(None, SupplyLinkContract);
+    let client = SupplyLinkContractClient::new(&env, &contract_id);
+    
+    let owner1 = Address::generate(&env);
+    let owner2 = Address::generate(&env);
+    let new_owner = Address::generate(&env);
+    
+    client.register_product(
+        &String::from_str(&env, "prod1"),
+        &String::from_str(&env, "Product 1"),
+        &String::from_str(&env, "Origin"),
+        &owner1,
+        &1,
+    );
+    
+    client.register_product(
+        &String::from_str(&env, "prod2"),
+        &String::from_str(&env, "Product 2"),
+        &String::from_str(&env, "Origin"),
+        &owner2,
+        &1,
+    );
+    
+    client.transfer_ownership(
+        &String::from_str(&env, "prod1"),
+        &new_owner,
+        &0,
+    );
+    
+    assert_eq!(client.get_nonce(&owner1), 1);
+    assert_eq!(client.get_nonce(&owner2), 0);
+    
+    client.transfer_ownership(
+        &String::from_str(&env, "prod2"),
+        &new_owner,
+        &0,
+    );
+    
+    assert_eq!(client.get_nonce(&owner1), 1);
+    assert_eq!(client.get_nonce(&owner2), 1);
+}


### PR DESCRIPTION
- Add ActorNonce storage key for per-actor nonce tracking
- Implement get_nonce() public read function
- Add validate_and_increment_nonce() internal helper
- Update privileged operations to require nonce parameter:
  * transfer_ownership
  * add_authorized_actor
  * remove_authorized_actor
  * approve_event
  * reject_event
- Add comprehensive test suite covering:
  * Initial nonce values
  * Nonce increment on operations
  * Stale nonce rejection
  * Future nonce rejection
  * Duplicate nonce rejection
  * Out-of-order nonce rejection
  * Multi-operation nonce progression
  * Per-actor nonce isolation
- Add NONCE_LIFECYCLE.md documentation

fixes #333