### PR TITLE
feat: backend hardening — health probes, secret rotation, config parity, contract errors

### DIFF
--- a/docs/CONTRACT_ERRORS.md
+++ b/docs/CONTRACT_ERRORS.md
@@ -1,0 +1,88 @@
+# Contract Error Codes
+
+Supply-Link uses a `#[contracterror]` enum to expose stable, machine-readable error codes from the Soroban smart contract. Clients should map these numeric codes to localised messages rather than matching on strings.
+
+## Error Catalog
+
+| Code | Rust Variant | TS Key | HTTP Status | Trigger |
+|------|-------------|--------|-------------|---------|
+| `1` | `Error::ProductNotFound` | `PRODUCT_NOT_FOUND` | 404 | Product ID not registered on-chain |
+| `2` | `Error::NotAuthorized` | `NOT_AUTHORIZED` | 403 | Caller is not the owner or an authorized actor |
+| `3` | `Error::ApproverNotAuthorized` | `APPROVER_NOT_AUTHORIZED` | 403 | Approver is not the owner or an authorized actor |
+| `4` | `Error::OwnerOnly` | `OWNER_ONLY` | 403 | Action requires the product owner; a non-owner attempted it |
+| `5` | `Error::NoPendingEvents` | `NO_PENDING_EVENTS` | 404 | No pending events exist in the approval queue |
+| `6` | `Error::EventIndexOutOfBounds` | `EVENT_INDEX_OUT_OF_BOUNDS` | 400 | Supplied event index exceeds the pending-events queue length |
+
+## Functions That Can Return Each Error
+
+| Function | Possible Error Codes |
+|----------|---------------------|
+| `get_product` | `1` |
+| `add_tracking_event` | `1`, `2` |
+| `transfer_ownership` | `1` |
+| `add_authorized_actor` | `1` |
+| `remove_authorized_actor` | `1` |
+| `update_product_metadata` | `1` |
+| `approve_event` | `1`, `3`, `5`, `6` |
+| `reject_event` | `1`, `4`, `5`, `6` |
+| `register_product` | _(none — panics only on auth failure, which is a host error)_ |
+| `product_exists`, `get_tracking_events`, `get_events_count`, `get_authorized_actors`, `get_product_count`, `list_products`, `get_pending_events` | _(none — read-only, never error)_ |
+
+## How Errors Are Encoded
+
+Soroban encodes `#[contracterror]` variants as `ScError::Contract(u32)` in the invocation result. The numeric discriminant is the stable identifier — it will not change across contract upgrades.
+
+When using `@stellar/stellar-sdk`, a failed invocation throws an object that contains the error code. Use `extractContractErrorCode` from `lib/stellar/contract-errors.ts` to extract it:
+
+```ts
+import { mapContractError } from "@/lib/stellar/contract-errors";
+
+try {
+  await client.get_product({ id: productId });
+} catch (err) {
+  const mapped = mapContractError(err);
+  if (mapped) {
+    // mapped.code    → 1
+    // mapped.key     → "PRODUCT_NOT_FOUND"
+    // mapped.message → "The requested product does not exist on-chain."
+    // mapped.httpStatus → 404
+    return NextResponse.json({ error: mapped.key }, { status: mapped.httpStatus });
+  }
+  throw err; // re-throw unexpected errors
+}
+```
+
+## Recommended Client Behaviour
+
+| Code | Recommended Action |
+|------|--------------------|
+| `1` (ProductNotFound) | Show "Product not found" UI state; do not retry |
+| `2` (NotAuthorized) | Prompt user to connect the correct wallet; do not retry |
+| `3` (ApproverNotAuthorized) | Inform user they are not an authorized approver |
+| `4` (OwnerOnly) | Inform user only the product owner can perform this action |
+| `5` (NoPendingEvents) | Refresh the pending-events list; the queue may have been cleared |
+| `6` (EventIndexOutOfBounds) | Refresh the pending-events list; the index is stale |
+
+## Internationalisation
+
+The `message` field in `MappedContractError` is a default English fallback. In the UI, use `mapped.key` as the i18n lookup key:
+
+```ts
+// messages/en.json
+{
+  "contractErrors": {
+    "PRODUCT_NOT_FOUND": "Product not found.",
+    "NOT_AUTHORIZED": "You are not authorised to perform this action.",
+    ...
+  }
+}
+```
+
+## Adding New Error Codes
+
+1. Add a new variant to the `Error` enum in `smart-contract/contracts/src/lib.rs` with the next sequential `u32` discriminant.
+2. Add the corresponding entry to `ContractErrorCode` and `ERROR_MAP` in `frontend/lib/stellar/contract-errors.ts`.
+3. Add a row to the catalog table above.
+4. Add a test in `frontend/lib/__tests__/contract-errors.test.ts` and a Rust test in `smart-contract/contracts/src/lib.rs`.
+
+**Never reuse or renumber existing discriminants.** Existing on-chain transactions and client code depend on the stability of these values.

--- a/docs/HEALTH_ENDPOINT.md
+++ b/docs/HEALTH_ENDPOINT.md
@@ -1,0 +1,100 @@
+# Health Endpoint
+
+Supply-Link exposes a single health endpoint at `GET /api/health` that supports both liveness and readiness semantics.
+
+## Response Shape
+
+```json
+{
+  "liveness": "ok",
+  "readiness": "ok | degraded | down",
+  "version": "0.1.0",
+  "network": "Test SDF Network ; September 2015",
+  "contractId": "C...",
+  "uptime": 3600,
+  "timestamp": "2026-04-27T21:00:00.000Z",
+  "dependencies": {
+    "rpc":  { "status": "ok",       "latencyMs": 42 },
+    "blob": { "status": "degraded", "latencyMs": 0,  "error": "BLOB_READ_WRITE_TOKEN not set" },
+    "kv":   { "status": "degraded", "latencyMs": 0,  "error": "KV_REST_API_URL or KV_REST_API_TOKEN not set" },
+    "env":  { "status": "ok",       "latencyMs": 0 }
+  }
+}
+```
+
+## Status Values
+
+| Value      | Meaning                                      |
+|------------|----------------------------------------------|
+| `ok`       | Dependency is healthy                        |
+| `degraded` | Dependency is reachable but not fully healthy, or optional config is missing |
+| `down`     | Dependency is unreachable                    |
+
+## HTTP Status Codes
+
+| Condition                          | HTTP Status |
+|------------------------------------|-------------|
+| `readiness` is `ok` or `degraded`  | `200`       |
+| `readiness` is `down`              | `503`       |
+| Rate limit exceeded                | `429`       |
+
+**Readiness** is determined by the RPC probe and env config probe. Blob and KV are optional dependencies — their failure degrades the response but does not affect the HTTP status code.
+
+**Liveness** is always `ok` if the process is running and the handler is reachable.
+
+## Probe Timeouts
+
+| Probe | Timeout |
+|-------|---------|
+| RPC   | 4 000 ms |
+| Blob  | 3 000 ms |
+| KV    | 3 000 ms |
+| Env   | synchronous (no I/O) |
+
+## Deployment: Health-Based Routing
+
+### Vercel
+
+Vercel does not natively support health-check-based traffic routing, but you can use the endpoint for:
+
+- **Deployment checks**: Add a post-deployment smoke test in CI that `curl`s `/api/health` and asserts `readiness !== "down"`.
+- **Uptime monitoring**: Point an external monitor (e.g. Better Uptime, Checkly) at `/api/health` and alert on non-200 responses.
+
+### Docker / Kubernetes
+
+Use the endpoint as a readiness probe:
+
+```yaml
+readinessProbe:
+  httpGet:
+    path: /api/health
+    port: 3000
+  initialDelaySeconds: 5
+  periodSeconds: 10
+  failureThreshold: 3
+
+livenessProbe:
+  httpGet:
+    path: /api/health
+    port: 3000
+  initialDelaySeconds: 15
+  periodSeconds: 30
+```
+
+A `503` response will cause Kubernetes to remove the pod from the load balancer until the dependency recovers.
+
+### Expected Behavior
+
+- On a fresh deployment with no KV or Blob tokens configured, `readiness` will be `ok` and blob/kv will show `degraded` — this is expected and does not block traffic.
+- If the Soroban RPC is unreachable, `readiness` becomes `down` and the endpoint returns `503`.
+- The endpoint is rate-limited to 10 requests per IP per 60 seconds to prevent abuse.
+
+## Required Environment Variables
+
+| Variable                      | Required | Description                          |
+|-------------------------------|----------|--------------------------------------|
+| `NEXT_PUBLIC_CONTRACT_ID`     | Yes      | Soroban contract address             |
+| `NEXT_PUBLIC_STELLAR_NETWORK` | Yes      | `testnet` or `mainnet`               |
+| `BLOB_READ_WRITE_TOKEN`       | No       | Vercel Blob token (blob probe)       |
+| `KV_REST_API_URL`             | No       | Vercel KV / Upstash REST URL         |
+| `KV_REST_API_TOKEN`           | No       | Vercel KV / Upstash REST token       |

--- a/docs/NETWORK_CONFIG_PARITY.md
+++ b/docs/NETWORK_CONFIG_PARITY.md
@@ -1,0 +1,116 @@
+# Network Configuration Parity
+
+Supply-Link validates that contract ID, network passphrase, and RPC endpoint are internally consistent at runtime. Mismatches are reported as configuration drift and surfaced in health diagnostics.
+
+## Environment Matrix
+
+| Setting | Testnet | Mainnet |
+|---------|---------|---------|
+| `NEXT_PUBLIC_STELLAR_NETWORK` | `testnet` | `mainnet` |
+| `NEXT_PUBLIC_NETWORK_PASSPHRASE` | `Test SDF Network ; September 2015` | `Public Global Stellar Network ; September 2015` |
+| `NEXT_PUBLIC_RPC_URL` (hostname) | `soroban-testnet.stellar.org` | `soroban-mainnet.stellar.org` |
+| `NEXT_PUBLIC_CONTRACT_ID` | 56-char Stellar contract address (`C…`) | 56-char Stellar contract address (`C…`) |
+
+All four settings must be internally consistent. Mixing values from different rows (e.g. testnet network with mainnet RPC) is detected as drift.
+
+## What Is Checked
+
+`lib/network-config.ts` runs these checks via `checkNetworkConfig()`:
+
+1. **Network value** — `NEXT_PUBLIC_STELLAR_NETWORK` must be `testnet` or `mainnet`.
+2. **Contract ID format** — must match `/^C[A-Z2-7]{55}$/` (56-char Stellar contract address).
+3. **RPC hostname** — if `NEXT_PUBLIC_RPC_URL` is set, its hostname must be in the allowed list for the declared network.
+4. **Passphrase match** — if `NEXT_PUBLIC_NETWORK_PASSPHRASE` is set, it must equal the expected value for the declared network.
+5. **Cross-environment contamination** — if the passphrase matches the *other* network's expected value, a contamination warning is raised.
+
+## Health Diagnostics
+
+`GET /api/health` includes a `dependencies.config` probe:
+
+```json
+{
+  "dependencies": {
+    "config": {
+      "status": "ok",
+      "latencyMs": 0,
+      "effectiveConfig": {
+        "network": "testnet",
+        "rpcHostname": "soroban-testnet.stellar.org",
+        "contractIdPrefix": "CBUWSKT2",
+        "passphraseMatch": true
+      }
+    }
+  }
+}
+```
+
+When drift is detected:
+
+```json
+{
+  "dependencies": {
+    "config": {
+      "status": "degraded",
+      "latencyMs": 0,
+      "error": "Configuration drift: 1 issue(s) detected",
+      "drifts": [
+        "NEXT_PUBLIC_RPC_URL hostname 'soroban-mainnet.stellar.org' is not in the allowed list for testnet: [soroban-testnet.stellar.org]"
+      ],
+      "effectiveConfig": { ... }
+    }
+  }
+}
+```
+
+The `effectiveConfig` object never exposes full contract IDs or passphrases — only the first 8 characters of the contract ID and a boolean for passphrase match.
+
+## Startup Guard
+
+Call `assertNetworkConfig()` in server-only initialization code to fail fast:
+
+```ts
+import { assertNetworkConfig } from "@/lib/network-config";
+assertNetworkConfig(); // throws if any drift is detected
+```
+
+This is appropriate in API route module scope or in a custom Next.js server entry point. It is **not** called automatically on every request — use the health probe for periodic drift detection.
+
+## Detected Drift: Remediation Steps
+
+### Unknown or missing `NEXT_PUBLIC_STELLAR_NETWORK`
+
+Set the variable to `testnet` or `mainnet` in your deployment environment and redeploy.
+
+### Invalid contract ID format
+
+Verify the contract address was copied correctly from the deployment output. It must be exactly 56 characters starting with `C`. Re-run `bash scripts/deploy.sh` if needed and copy the output address.
+
+### RPC hostname mismatch
+
+Ensure `NEXT_PUBLIC_RPC_URL` (if set) matches the declared network:
+- Testnet: `https://soroban-testnet.stellar.org`
+- Mainnet: `https://soroban-mainnet.stellar.org`
+
+If you are using a private RPC node, add its hostname to `NETWORK_MATRIX` in `lib/network-config.ts`.
+
+### Passphrase mismatch / cross-environment contamination
+
+This usually means environment variables from one deployment were copied into another. Audit all `NEXT_PUBLIC_*` variables in your deployment platform and ensure they all belong to the same row of the environment matrix above.
+
+After correcting the values, redeploy and confirm `GET /api/health` returns `dependencies.config.status: "ok"`.
+
+## Adding a New Environment
+
+To add a `staging` environment:
+
+1. Add an entry to `NETWORK_MATRIX` in `lib/network-config.ts`:
+   ```ts
+   staging: {
+     passphrase: "...",
+     rpcHostnames: ["soroban-staging.example.com"],
+     contractIdPattern: /^C[A-Z2-7]{55}$/,
+   }
+   ```
+2. Update the `NetworkEnv` type to include `"staging"`.
+3. Add the new row to the environment matrix table above.
+4. Add test fixtures in `lib/__tests__/network-config.test.ts`.

--- a/docs/SECRET_ROTATION_RUNBOOK.md
+++ b/docs/SECRET_ROTATION_RUNBOOK.md
@@ -1,0 +1,107 @@
+# Secret Rotation Runbook
+
+## Secret Inventory
+
+| Secret | Env Var | Criticality | Format | Used By |
+|--------|---------|-------------|--------|---------|
+| Fee-bump signing key | `STELLAR_FEE_BUMP_SECRET` | **Critical** | 56-char Stellar secret key (`S…`) | `/api/v1/fee-bump` |
+| Vercel Blob token | `BLOB_READ_WRITE_TOKEN` | Optional | Opaque string ≥ 10 chars | `/api/v1/upload`, health probe |
+| Vercel KV URL | `KV_REST_API_URL` | Optional | `https://` URL | `/api/ratings`, health probe |
+| Vercel KV token | `KV_REST_API_TOKEN` | Optional | Opaque string ≥ 10 chars | `/api/ratings`, health probe |
+
+**Critical** secrets cause endpoint failures (`503`) when missing or invalid.  
+**Optional** secrets cause degraded health probe status but do not block traffic.
+
+---
+
+## Runtime Validation
+
+All secrets are validated via `lib/secrets.ts`:
+
+- `validateSecrets()` — returns per-secret status without throwing; safe to call at startup or in health checks.
+- `requireSecret(key)` — throws `SecretMissingError` or `SecretInvalidError`; error messages never contain the secret value.
+- `redactSecrets(str)` — scrubs known secret values from log strings before they reach any logging sink.
+
+Endpoints that require a critical secret call `requireSecret()` and return `503` on failure, never `500` with a raw error.
+
+---
+
+## Scheduled Rotation (every 90 days)
+
+### Fee-bump keypair (`STELLAR_FEE_BUMP_SECRET`)
+
+1. **Generate** a new Stellar keypair on an air-gapped machine or via Stellar CLI:
+   ```bash
+   stellar keys generate --global fee-bump-new --network testnet
+   stellar keys fund fee-bump-new --network testnet
+   ```
+2. **Fund** the new account with enough XLM to cover fee-bump operations (minimum 1 XLM).
+3. **Stage** the new secret in your secrets manager (Vercel env, AWS Secrets Manager, etc.) under a staging slot — do **not** replace the live value yet.
+4. **Deploy** a canary or preview environment pointing at the new key and verify `/api/v1/fee-bump` returns `200`.
+5. **Swap** — update `STELLAR_FEE_BUMP_SECRET` in production to the new value and redeploy.
+6. **Verify** — call `GET /api/health` and confirm `dependencies.rpc.status` is `ok`; submit a test fee-bump transaction.
+7. **Drain** the old account — transfer remaining XLM to the new account.
+8. **Revoke** the old keypair from your secrets manager.
+9. **Record** the rotation date in this document.
+
+### Vercel Blob / KV tokens
+
+1. Generate a new token in the Vercel dashboard.
+2. Update the env var in Vercel project settings.
+3. Trigger a redeployment.
+4. Verify `GET /api/health` shows `blob.status: ok` and `kv.status: ok`.
+5. Revoke the old token in the Vercel dashboard.
+
+---
+
+## Emergency Rotation (key compromise suspected)
+
+1. **Immediately revoke** the compromised key:
+   - Stellar keypair: the key cannot be revoked on-chain, but you can drain the account and stop using it.
+   - Vercel tokens: revoke instantly in the Vercel dashboard.
+2. **Generate and deploy** a replacement following steps 1–6 of the scheduled rotation above, skipping the 90-day wait.
+3. **Audit** recent transactions from the compromised fee-bump account on [Stellar Expert](https://stellar.expert) or [Horizon](https://horizon-testnet.stellar.org).
+4. **Notify** stakeholders if any unauthorized transactions are found.
+5. **Post-mortem** — document how the key was exposed and add controls to prevent recurrence.
+
+---
+
+## Rollback
+
+If a rotation causes a production incident:
+
+1. Re-set the previous secret value in your secrets manager.
+2. Redeploy (Vercel: use "Instant Rollback" or re-promote the previous deployment).
+3. Confirm `GET /api/health` returns `200` with `readiness: ok`.
+4. Investigate the new key before retrying rotation.
+
+---
+
+## Rotation Drill (quarterly)
+
+Run this checklist in a staging environment every quarter to keep the procedure fresh:
+
+- [ ] Generate a new fee-bump keypair
+- [ ] Update `STELLAR_FEE_BUMP_SECRET` in staging
+- [ ] Confirm `GET /api/health` → `readiness: ok`
+- [ ] Submit a test fee-bump transaction → `200`
+- [ ] Simulate missing secret: unset `STELLAR_FEE_BUMP_SECRET`, confirm endpoint returns `503`
+- [ ] Simulate invalid secret: set a malformed value, confirm endpoint returns `503`
+- [ ] Restore correct secret, confirm recovery
+- [ ] Record drill date below
+
+### Drill Log
+
+| Date | Operator | Outcome |
+|------|----------|---------|
+| _(first drill pending)_ | | |
+
+---
+
+## Verification Checklist After Any Rotation
+
+- [ ] `GET /api/health` returns `200` with `readiness: ok`
+- [ ] `dependencies.rpc.status` is `ok`
+- [ ] Fee-bump endpoint accepts a valid inner transaction
+- [ ] No secret values appear in application logs
+- [ ] Old credentials are revoked / drained

--- a/frontend/app/api/health/__tests__/route.test.ts
+++ b/frontend/app/api/health/__tests__/route.test.ts
@@ -1,85 +1,195 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
-// Mock the stellar client so tests don't make real network calls
 vi.mock("@/lib/stellar/client", () => ({
   CONTRACT_ID: "CTEST1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890ABCDE",
   NETWORK_PASSPHRASE: "Test SDF Network ; September 2015",
   RPC_URL: "https://soroban-testnet.stellar.org",
 }));
 
-// Mock package.json version
 vi.mock("@/package.json", () => ({ version: "0.1.0" }));
 
-// Mock fetch to control contractReachable
 const mockFetch = vi.fn();
 global.fetch = mockFetch;
 
-describe("GET /api/health", () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
+// Helper: build a minimal NextRequest-like object
+function makeRequest(ip = "127.0.0.1") {
+  return {
+    headers: { get: (h: string) => (h === "x-forwarded-for" ? ip : null) },
+  } as unknown as import("next/server").NextRequest;
+}
+
+describe("probeRpc", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("returns ok when RPC responds 200", async () => {
+    mockFetch.mockResolvedValueOnce({ ok: true });
+    const { probeRpc } = await import("../route");
+    const result = await probeRpc("https://soroban-testnet.stellar.org");
+    expect(result.status).toBe("ok");
+    expect(result.latencyMs).toBeGreaterThanOrEqual(0);
   });
 
-  it("returns status ok with all required fields", async () => {
+  it("returns degraded when RPC responds non-ok", async () => {
+    mockFetch.mockResolvedValueOnce({ ok: false });
+    const { probeRpc } = await import("../route");
+    const result = await probeRpc("https://soroban-testnet.stellar.org");
+    expect(result.status).toBe("degraded");
+  });
+
+  it("returns down when RPC throws", async () => {
+    mockFetch.mockRejectedValueOnce(new Error("timeout"));
+    const { probeRpc } = await import("../route");
+    const result = await probeRpc("https://soroban-testnet.stellar.org");
+    expect(result.status).toBe("down");
+    expect(result.error).toBeDefined();
+  });
+});
+
+describe("probeBlob", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("returns degraded when BLOB_READ_WRITE_TOKEN is missing", async () => {
+    delete process.env.BLOB_READ_WRITE_TOKEN;
+    const { probeBlob } = await import("../route");
+    const result = await probeBlob();
+    expect(result.status).toBe("degraded");
+    expect(result.error).toMatch(/BLOB_READ_WRITE_TOKEN/);
+  });
+
+  it("returns ok when blob endpoint is reachable", async () => {
+    process.env.BLOB_READ_WRITE_TOKEN = "test-token";
+    mockFetch.mockResolvedValueOnce({ status: 200 });
+    const { probeBlob } = await import("../route");
+    const result = await probeBlob();
+    expect(result.status).toBe("ok");
+    delete process.env.BLOB_READ_WRITE_TOKEN;
+  });
+
+  it("returns down when blob endpoint throws", async () => {
+    process.env.BLOB_READ_WRITE_TOKEN = "test-token";
+    mockFetch.mockRejectedValueOnce(new Error("network error"));
+    const { probeBlob } = await import("../route");
+    const result = await probeBlob();
+    expect(result.status).toBe("down");
+    delete process.env.BLOB_READ_WRITE_TOKEN;
+  });
+});
+
+describe("probeKv", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("returns degraded when KV env vars are missing", async () => {
+    delete process.env.KV_REST_API_URL;
+    delete process.env.KV_REST_API_TOKEN;
+    const { probeKv } = await import("../route");
+    const result = await probeKv();
+    expect(result.status).toBe("degraded");
+    expect(result.error).toMatch(/KV_REST_API/);
+  });
+
+  it("returns ok when KV ping succeeds", async () => {
+    process.env.KV_REST_API_URL = "https://kv.example.com";
+    process.env.KV_REST_API_TOKEN = "kv-token";
     mockFetch.mockResolvedValueOnce({ ok: true });
+    const { probeKv } = await import("../route");
+    const result = await probeKv();
+    expect(result.status).toBe("ok");
+    delete process.env.KV_REST_API_URL;
+    delete process.env.KV_REST_API_TOKEN;
+  });
+
+  it("returns down when KV ping throws", async () => {
+    process.env.KV_REST_API_URL = "https://kv.example.com";
+    process.env.KV_REST_API_TOKEN = "kv-token";
+    mockFetch.mockRejectedValueOnce(new Error("refused"));
+    const { probeKv } = await import("../route");
+    const result = await probeKv();
+    expect(result.status).toBe("down");
+    delete process.env.KV_REST_API_URL;
+    delete process.env.KV_REST_API_TOKEN;
+  });
+});
+
+describe("probeEnvConfig", () => {
+  it("returns ok when required env vars are present", async () => {
+    process.env.NEXT_PUBLIC_CONTRACT_ID = "CTEST";
+    process.env.NEXT_PUBLIC_STELLAR_NETWORK = "testnet";
+    const { probeEnvConfig } = await import("../route");
+    expect(probeEnvConfig().status).toBe("ok");
+  });
+
+  it("returns degraded when a required env var is missing", async () => {
+    const saved = process.env.NEXT_PUBLIC_CONTRACT_ID;
+    delete process.env.NEXT_PUBLIC_CONTRACT_ID;
+    const { probeEnvConfig } = await import("../route");
+    const result = probeEnvConfig();
+    expect(result.status).toBe("degraded");
+    expect(result.error).toMatch(/NEXT_PUBLIC_CONTRACT_ID/);
+    process.env.NEXT_PUBLIC_CONTRACT_ID = saved;
+  });
+});
+
+describe("GET /api/health", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("returns liveness ok and readiness ok when all probes pass", async () => {
+    process.env.NEXT_PUBLIC_CONTRACT_ID = "CTEST";
+    process.env.NEXT_PUBLIC_STELLAR_NETWORK = "testnet";
+    // rpc probe + blob probe (no token → degraded, but blob is non-critical)
+    mockFetch.mockResolvedValueOnce({ ok: true }); // rpc
+    // blob has no token → no fetch call
+    // kv has no token → no fetch call
 
     const { GET } = await import("../route");
-    const response = await GET();
-    const body = await response.json();
+    const res = await GET(makeRequest());
+    const body = await res.json();
 
-    expect(response.status).toBe(200);
-    expect(body.status).toBe("ok");
-    expect(body.version).toBe("0.1.0");
-    expect(body.contractId).toBe("CTEST1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890ABCDE");
-    expect(body.network).toBe("Test SDF Network ; September 2015");
-    expect(body.rpcUrl).toBe("https://soroban-testnet.stellar.org");
+    expect(res.status).toBe(200);
+    expect(body.liveness).toBe("ok");
+    expect(body.readiness).toBe("ok");
+    expect(body.dependencies.rpc.status).toBe("ok");
+    expect(body.dependencies.env.status).toBe("ok");
     expect(typeof body.uptime).toBe("number");
     expect(typeof body.timestamp).toBe("string");
   });
 
-  it("returns contractReachable: true when RPC responds ok", async () => {
+  it("returns 503 when RPC is down", async () => {
+    process.env.NEXT_PUBLIC_CONTRACT_ID = "CTEST";
+    process.env.NEXT_PUBLIC_STELLAR_NETWORK = "testnet";
+    mockFetch.mockRejectedValueOnce(new Error("timeout")); // rpc down
+
+    const { GET } = await import("../route");
+    const res = await GET(makeRequest());
+    const body = await res.json();
+
+    expect(res.status).toBe(503);
+    expect(body.readiness).toBe("down");
+    expect(body.dependencies.rpc.status).toBe("down");
+  });
+
+  it("includes per-dependency latency in response", async () => {
+    process.env.NEXT_PUBLIC_CONTRACT_ID = "CTEST";
+    process.env.NEXT_PUBLIC_STELLAR_NETWORK = "testnet";
     mockFetch.mockResolvedValueOnce({ ok: true });
 
     const { GET } = await import("../route");
-    const body = await (await GET()).json();
+    const body = await (await GET(makeRequest())).json();
 
-    expect(body.contractReachable).toBe(true);
+    expect(typeof body.dependencies.rpc.latencyMs).toBe("number");
+    expect(typeof body.dependencies.blob.latencyMs).toBe("number");
+    expect(typeof body.dependencies.kv.latencyMs).toBe("number");
+    expect(typeof body.dependencies.env.latencyMs).toBe("number");
   });
 
-  it("returns contractReachable: false when RPC fails", async () => {
-    mockFetch.mockRejectedValueOnce(new Error("network error"));
-
-    // Re-import to get fresh module (fetch mock changes)
-    vi.resetModules();
-    vi.mock("@/lib/stellar/client", () => ({
-      CONTRACT_ID: "CTEST1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890ABCDE",
-      NETWORK_PASSPHRASE: "Test SDF Network ; September 2015",
-      RPC_URL: "https://soroban-testnet.stellar.org",
-    }));
-    vi.mock("@/package.json", () => ({ version: "0.1.0" }));
-
+  it("returns 429 when rate limited", async () => {
     const { GET } = await import("../route");
-    const body = await (await GET()).json();
-
-    expect(body.contractReachable).toBe(false);
-  });
-
-  it("timestamp is a valid ISO 8601 string", async () => {
-    mockFetch.mockResolvedValueOnce({ ok: true });
-
-    const { GET } = await import("../route");
-    const body = await (await GET()).json();
-
-    expect(() => new Date(body.timestamp)).not.toThrow();
-    expect(new Date(body.timestamp).toISOString()).toBe(body.timestamp);
-  });
-
-  it("uptime is a non-negative integer", async () => {
-    mockFetch.mockResolvedValueOnce({ ok: true });
-
-    const { GET } = await import("../route");
-    const body = await (await GET()).json();
-
-    expect(body.uptime).toBeGreaterThanOrEqual(0);
-    expect(Number.isInteger(body.uptime)).toBe(true);
+    // Exhaust the rate limit for a unique IP
+    const ip = "10.0.0.99";
+    for (let i = 0; i < 10; i++) {
+      mockFetch.mockResolvedValue({ ok: true });
+      await GET(makeRequest(ip));
+    }
+    const res = await GET(makeRequest(ip));
+    expect(res.status).toBe(429);
   });
 });

--- a/frontend/app/api/health/route.ts
+++ b/frontend/app/api/health/route.ts
@@ -5,7 +5,7 @@ import { withCors, handleOptions } from "@/lib/api/cors";
 
 const startedAt = Date.now();
 
-// In-memory rate limiter: max 10 requests per IP per 60 seconds
+// ── Rate limiter ──────────────────────────────────────────────────────────────
 const rateLimitMap = new Map<string, number[]>();
 const RATE_LIMIT = 10;
 const WINDOW_MS = 60_000;
@@ -19,19 +19,96 @@ function isRateLimited(ip: string): boolean {
   return false;
 }
 
-async function pingRpc(url: string): Promise<boolean> {
+// ── Probe types ───────────────────────────────────────────────────────────────
+export type ProbeStatus = "ok" | "degraded" | "down";
+
+export interface ProbeResult {
+  status: ProbeStatus;
+  latencyMs: number;
+  error?: string;
+}
+
+// ── Individual probes ─────────────────────────────────────────────────────────
+
+/** Ping the Soroban RPC with a bounded timeout. */
+export async function probeRpc(url: string, timeoutMs = 4000): Promise<ProbeResult> {
+  const start = Date.now();
   try {
     const res = await fetch(url, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "getHealth", params: [] }),
-      signal: AbortSignal.timeout(4000),
+      signal: AbortSignal.timeout(timeoutMs),
     });
-    return res.ok;
-  } catch {
-    return false;
+    return { status: res.ok ? "ok" : "degraded", latencyMs: Date.now() - start };
+  } catch (e) {
+    return { status: "down", latencyMs: Date.now() - start, error: String(e) };
   }
 }
+
+/**
+ * Probe Vercel Blob by issuing a HEAD request to the blob store endpoint.
+ * Requires BLOB_READ_WRITE_TOKEN in the environment.
+ */
+export async function probeBlob(timeoutMs = 3000): Promise<ProbeResult> {
+  const start = Date.now();
+  const token = process.env.BLOB_READ_WRITE_TOKEN;
+  if (!token) {
+    return { status: "degraded", latencyMs: 0, error: "BLOB_READ_WRITE_TOKEN not set" };
+  }
+  try {
+    const res = await fetch("https://blob.vercel-storage.com", {
+      method: "HEAD",
+      headers: { Authorization: `Bearer ${token}` },
+      signal: AbortSignal.timeout(timeoutMs),
+    });
+    // 200 or 405 both indicate the service is reachable
+    const ok = res.status < 500;
+    return { status: ok ? "ok" : "degraded", latencyMs: Date.now() - start };
+  } catch (e) {
+    return { status: "down", latencyMs: Date.now() - start, error: String(e) };
+  }
+}
+
+/**
+ * Probe KV store (Vercel KV / Upstash Redis) via a lightweight PING.
+ * Requires KV_REST_API_URL and KV_REST_API_TOKEN in the environment.
+ */
+export async function probeKv(timeoutMs = 3000): Promise<ProbeResult> {
+  const start = Date.now();
+  const url = process.env.KV_REST_API_URL;
+  const token = process.env.KV_REST_API_TOKEN;
+  if (!url || !token) {
+    return { status: "degraded", latencyMs: 0, error: "KV_REST_API_URL or KV_REST_API_TOKEN not set" };
+  }
+  try {
+    const res = await fetch(`${url}/ping`, {
+      headers: { Authorization: `Bearer ${token}` },
+      signal: AbortSignal.timeout(timeoutMs),
+    });
+    return { status: res.ok ? "ok" : "degraded", latencyMs: Date.now() - start };
+  } catch (e) {
+    return { status: "down", latencyMs: Date.now() - start, error: String(e) };
+  }
+}
+
+/** Validate that required environment variables are present. */
+export function probeEnvConfig(): ProbeResult {
+  const required = ["NEXT_PUBLIC_CONTRACT_ID", "NEXT_PUBLIC_STELLAR_NETWORK"];
+  const missing = required.filter((k) => !process.env[k]);
+  if (missing.length === 0) return { status: "ok", latencyMs: 0 };
+  return { status: "degraded", latencyMs: 0, error: `Missing env vars: ${missing.join(", ")}` };
+}
+
+// ── Aggregate helpers ─────────────────────────────────────────────────────────
+
+function worstStatus(...statuses: ProbeStatus[]): ProbeStatus {
+  if (statuses.includes("down")) return "down";
+  if (statuses.includes("degraded")) return "degraded";
+  return "ok";
+}
+
+// ── Route handlers ────────────────────────────────────────────────────────────
 
 export function OPTIONS(request: NextRequest) {
   return handleOptions(request);
@@ -53,19 +130,36 @@ export async function GET(request: NextRequest) {
     );
   }
 
-  const contractReachable = await pingRpc(RPC_URL);
+  // Run all readiness probes in parallel
+  const [rpc, blob, kv] = await Promise.all([
+    probeRpc(RPC_URL),
+    probeBlob(),
+    probeKv(),
+  ]);
+  const env = probeEnvConfig();
+
+  // Liveness: the process is alive (always ok if we reach here)
+  const liveness: ProbeStatus = "ok";
+
+  // Readiness: all critical dependencies must be ok/degraded (not down)
+  const readiness: ProbeStatus = worstStatus(rpc.status, env.status);
+
+  const httpStatus = readiness === "down" ? 503 : 200;
 
   return withCors(
     request,
-    NextResponse.json({
-      status: "ok",
-      version,
-      network: NETWORK_PASSPHRASE,
-      contractId: CONTRACT_ID,
-      rpcUrl: RPC_URL,
-      contractReachable,
-      uptime: Math.floor((Date.now() - startedAt) / 1000),
-      timestamp: new Date().toISOString(),
-    })
+    NextResponse.json(
+      {
+        liveness,
+        readiness,
+        version,
+        network: NETWORK_PASSPHRASE,
+        contractId: CONTRACT_ID,
+        uptime: Math.floor((Date.now() - startedAt) / 1000),
+        timestamp: new Date().toISOString(),
+        dependencies: { rpc, blob, kv, env },
+      },
+      { status: httpStatus }
+    )
   );
 }

--- a/frontend/app/api/health/route.ts
+++ b/frontend/app/api/health/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { CONTRACT_ID, NETWORK_PASSPHRASE, RPC_URL } from "@/lib/stellar/client";
 import { version } from "@/package.json";
 import { withCors, handleOptions } from "@/lib/api/cors";
+import { checkNetworkConfig } from "@/lib/network-config";
 
 const startedAt = Date.now();
 
@@ -100,6 +101,21 @@ export function probeEnvConfig(): ProbeResult {
   return { status: "degraded", latencyMs: 0, error: `Missing env vars: ${missing.join(", ")}` };
 }
 
+/** Validate network/contract configuration parity against the expected matrix. */
+export function probeNetworkConfig(): ProbeResult & { effectiveConfig?: object; drifts?: string[] } {
+  const result = checkNetworkConfig();
+  if (result.valid) {
+    return { status: "ok", latencyMs: 0, effectiveConfig: result.effectiveConfig };
+  }
+  return {
+    status: "degraded",
+    latencyMs: 0,
+    error: `Configuration drift: ${result.drifts.length} issue(s) detected`,
+    drifts: result.drifts,
+    effectiveConfig: result.effectiveConfig,
+  };
+}
+
 // ── Aggregate helpers ─────────────────────────────────────────────────────────
 
 function worstStatus(...statuses: ProbeStatus[]): ProbeStatus {
@@ -137,12 +153,13 @@ export async function GET(request: NextRequest) {
     probeKv(),
   ]);
   const env = probeEnvConfig();
+  const config = probeNetworkConfig();
 
   // Liveness: the process is alive (always ok if we reach here)
   const liveness: ProbeStatus = "ok";
 
-  // Readiness: all critical dependencies must be ok/degraded (not down)
-  const readiness: ProbeStatus = worstStatus(rpc.status, env.status);
+  // Readiness: RPC, env, and config parity must not be down
+  const readiness: ProbeStatus = worstStatus(rpc.status, env.status, config.status);
 
   const httpStatus = readiness === "down" ? 503 : 200;
 
@@ -157,7 +174,7 @@ export async function GET(request: NextRequest) {
         contractId: CONTRACT_ID,
         uptime: Math.floor((Date.now() - startedAt) / 1000),
         timestamp: new Date().toISOString(),
-        dependencies: { rpc, blob, kv, env },
+        dependencies: { rpc, blob, kv, env, config },
       },
       { status: httpStatus }
     )

--- a/frontend/app/api/v1/fee-bump/route.ts
+++ b/frontend/app/api/v1/fee-bump/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { Keypair, TransactionBuilder, Networks, BASE_FEE } from "@stellar/base";
 import { withCors, handleOptions } from "@/lib/api/cors";
+import { requireSecret, SecretMissingError, SecretInvalidError, redactSecrets } from "@/lib/secrets";
 
 export function OPTIONS(request: NextRequest) {
   return handleOptions(request);
@@ -9,6 +10,7 @@ export function OPTIONS(request: NextRequest) {
 export async function POST(request: NextRequest) {
   const respond = (body: unknown, init?: ResponseInit) =>
     withCors(request, NextResponse.json(body, init));
+
   try {
     const body = await request.json();
     const { innerTx } = body;
@@ -17,15 +19,20 @@ export async function POST(request: NextRequest) {
       return respond({ error: "Missing or invalid 'innerTx' parameter" }, { status: 400 });
     }
 
-    // Get the fee-bump account from environment
-    const feeBumpSecret = process.env.STELLAR_FEE_BUMP_SECRET;
-    if (!feeBumpSecret) {
-      return respond({ error: "Fee-bump account not configured" }, { status: 500 });
+    // Validated accessor — throws SecretMissingError / SecretInvalidError
+    // without leaking the value into the error message
+    let feeBumpKeypair: Keypair;
+    try {
+      feeBumpKeypair = Keypair.fromSecret(requireSecret("STELLAR_FEE_BUMP_SECRET"));
+    } catch (e) {
+      if (e instanceof SecretMissingError || e instanceof SecretInvalidError) {
+        // Safe: e.message never contains the secret value
+        console.error("Fee-bump secret error:", e.message);
+        return respond({ error: "Fee-bump account not configured" }, { status: 503 });
+      }
+      throw e;
     }
 
-    const feeBumpKeypair = Keypair.fromSecret(feeBumpSecret);
-
-    // Parse the inner transaction
     let innerTransaction;
     try {
       innerTransaction = TransactionBuilder.fromXDR(innerTx, Networks.TESTNET_NETWORK_PASSPHRASE);
@@ -33,8 +40,6 @@ export async function POST(request: NextRequest) {
       return respond({ error: "Invalid transaction XDR" }, { status: 400 });
     }
 
-    // Create fee-bump transaction
-    // Fee: base fee (100 stroops) * (1 + number of operations)
     const operationCount = innerTransaction.operations.length;
     const feeBumpFee = BASE_FEE * (1 + operationCount);
 
@@ -49,7 +54,6 @@ export async function POST(request: NextRequest) {
       .addOperation(innerTransaction.operations[0])
       .build();
 
-    // Sign with fee-bump account
     feeBumpTx.sign(feeBumpKeypair);
 
     return respond({
@@ -58,7 +62,9 @@ export async function POST(request: NextRequest) {
       message: "Fee-bump transaction created. Ready to submit to Stellar network.",
     });
   } catch (error) {
-    console.error("Fee-bump error:", error);
+    // Redact any secret values that may have leaked into the error string
+    const safeMessage = redactSecrets(String(error));
+    console.error("Fee-bump error:", safeMessage);
     return respond({ error: "Failed to create fee-bump transaction" }, { status: 500 });
   }
 }

--- a/frontend/lib/__tests__/contract-errors.test.ts
+++ b/frontend/lib/__tests__/contract-errors.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from "vitest";
+import {
+  ContractErrorCode,
+  extractContractErrorCode,
+  mapContractError,
+} from "@/lib/stellar/contract-errors";
+
+describe("extractContractErrorCode", () => {
+  it("extracts code from { code: number } shape", () => {
+    expect(extractContractErrorCode({ code: 1 })).toBe(ContractErrorCode.ProductNotFound);
+  });
+
+  it("extracts code from { result: { code: number } } shape", () => {
+    expect(extractContractErrorCode({ result: { code: 2 } })).toBe(ContractErrorCode.NotAuthorized);
+  });
+
+  it("returns null for unknown code", () => {
+    expect(extractContractErrorCode({ code: 999 })).toBeNull();
+  });
+
+  it("returns null for non-object", () => {
+    expect(extractContractErrorCode("error string")).toBeNull();
+    expect(extractContractErrorCode(null)).toBeNull();
+  });
+});
+
+describe("mapContractError", () => {
+  it("maps ProductNotFound (1) correctly", () => {
+    const mapped = mapContractError({ code: 1 });
+    expect(mapped?.key).toBe("PRODUCT_NOT_FOUND");
+    expect(mapped?.httpStatus).toBe(404);
+  });
+
+  it("maps NotAuthorized (2) correctly", () => {
+    const mapped = mapContractError({ code: 2 });
+    expect(mapped?.key).toBe("NOT_AUTHORIZED");
+    expect(mapped?.httpStatus).toBe(403);
+  });
+
+  it("maps ApproverNotAuthorized (3) correctly", () => {
+    const mapped = mapContractError({ code: 3 });
+    expect(mapped?.key).toBe("APPROVER_NOT_AUTHORIZED");
+    expect(mapped?.httpStatus).toBe(403);
+  });
+
+  it("maps OwnerOnly (4) correctly", () => {
+    const mapped = mapContractError({ code: 4 });
+    expect(mapped?.key).toBe("OWNER_ONLY");
+    expect(mapped?.httpStatus).toBe(403);
+  });
+
+  it("maps NoPendingEvents (5) correctly", () => {
+    const mapped = mapContractError({ code: 5 });
+    expect(mapped?.key).toBe("NO_PENDING_EVENTS");
+    expect(mapped?.httpStatus).toBe(404);
+  });
+
+  it("maps EventIndexOutOfBounds (6) correctly", () => {
+    const mapped = mapContractError({ code: 6 });
+    expect(mapped?.key).toBe("EVENT_INDEX_OUT_OF_BOUNDS");
+    expect(mapped?.httpStatus).toBe(400);
+  });
+
+  it("returns null for unrecognised error", () => {
+    expect(mapContractError({ code: 42 })).toBeNull();
+    expect(mapContractError("not an error object")).toBeNull();
+  });
+
+  it("every mapped error has a non-empty message", () => {
+    for (let code = 1; code <= 6; code++) {
+      const mapped = mapContractError({ code });
+      expect(mapped?.message.length).toBeGreaterThan(0);
+    }
+  });
+});

--- a/frontend/lib/__tests__/network-config.test.ts
+++ b/frontend/lib/__tests__/network-config.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect } from "vitest";
+import {
+  checkNetworkConfig,
+  assertNetworkConfig,
+  NETWORK_MATRIX,
+} from "@/lib/network-config";
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+const VALID_CONTRACT = "CBUWSKT2UGOAXK4ZREVDJV5XHSYB42PZ3CERU2ZFUTUMAZLJEHNZIECA";
+
+const TESTNET_OK: NodeJS.ProcessEnv = {
+  NEXT_PUBLIC_STELLAR_NETWORK: "testnet",
+  NEXT_PUBLIC_CONTRACT_ID: VALID_CONTRACT,
+};
+
+const MAINNET_OK: NodeJS.ProcessEnv = {
+  NEXT_PUBLIC_STELLAR_NETWORK: "mainnet",
+  NEXT_PUBLIC_CONTRACT_ID: VALID_CONTRACT,
+};
+
+// ── Valid configurations ──────────────────────────────────────────────────────
+
+describe("checkNetworkConfig — valid", () => {
+  it("passes for a minimal valid testnet config", () => {
+    const result = checkNetworkConfig(TESTNET_OK);
+    expect(result.valid).toBe(true);
+    expect(result.drifts).toHaveLength(0);
+    expect(result.effectiveConfig.network).toBe("testnet");
+  });
+
+  it("passes for a minimal valid mainnet config", () => {
+    const result = checkNetworkConfig(MAINNET_OK);
+    expect(result.valid).toBe(true);
+    expect(result.effectiveConfig.network).toBe("mainnet");
+  });
+
+  it("passes when RPC URL matches the expected testnet hostname", () => {
+    const result = checkNetworkConfig({
+      ...TESTNET_OK,
+      NEXT_PUBLIC_RPC_URL: "https://soroban-testnet.stellar.org",
+    });
+    expect(result.valid).toBe(true);
+  });
+
+  it("passes when explicit passphrase matches the matrix", () => {
+    const result = checkNetworkConfig({
+      ...TESTNET_OK,
+      NEXT_PUBLIC_NETWORK_PASSPHRASE: NETWORK_MATRIX.testnet.passphrase,
+    });
+    expect(result.valid).toBe(true);
+  });
+});
+
+// ── Missing / unknown network ─────────────────────────────────────────────────
+
+describe("checkNetworkConfig — unknown network", () => {
+  it("reports drift when NEXT_PUBLIC_STELLAR_NETWORK is missing", () => {
+    const result = checkNetworkConfig({ NEXT_PUBLIC_CONTRACT_ID: VALID_CONTRACT });
+    expect(result.valid).toBe(false);
+    expect(result.drifts[0]).toMatch(/NEXT_PUBLIC_STELLAR_NETWORK/);
+  });
+
+  it("reports drift when NEXT_PUBLIC_STELLAR_NETWORK is an unknown value", () => {
+    const result = checkNetworkConfig({
+      NEXT_PUBLIC_STELLAR_NETWORK: "staging",
+      NEXT_PUBLIC_CONTRACT_ID: VALID_CONTRACT,
+    });
+    expect(result.valid).toBe(false);
+    expect(result.drifts[0]).toMatch(/staging/);
+  });
+});
+
+// ── Contract ID drift ─────────────────────────────────────────────────────────
+
+describe("checkNetworkConfig — contract ID", () => {
+  it("reports drift when contract ID is missing", () => {
+    const result = checkNetworkConfig({ NEXT_PUBLIC_STELLAR_NETWORK: "testnet" });
+    expect(result.valid).toBe(false);
+    expect(result.drifts.some((d) => d.includes("NEXT_PUBLIC_CONTRACT_ID"))).toBe(true);
+  });
+
+  it("reports drift when contract ID has wrong format", () => {
+    const result = checkNetworkConfig({
+      NEXT_PUBLIC_STELLAR_NETWORK: "testnet",
+      NEXT_PUBLIC_CONTRACT_ID: "not-a-contract-id",
+    });
+    expect(result.valid).toBe(false);
+    expect(result.drifts.some((d) => d.includes("invalid format"))).toBe(true);
+  });
+
+  it("effectiveConfig exposes only the first 8 chars of contract ID", () => {
+    const result = checkNetworkConfig(TESTNET_OK);
+    expect(result.effectiveConfig.contractIdPrefix).toBe(VALID_CONTRACT.slice(0, 8));
+    expect(result.effectiveConfig.contractIdPrefix).not.toBe(VALID_CONTRACT);
+  });
+});
+
+// ── RPC hostname drift ────────────────────────────────────────────────────────
+
+describe("checkNetworkConfig — RPC hostname", () => {
+  it("reports drift when testnet config points at mainnet RPC", () => {
+    const result = checkNetworkConfig({
+      ...TESTNET_OK,
+      NEXT_PUBLIC_RPC_URL: "https://soroban-mainnet.stellar.org",
+    });
+    expect(result.valid).toBe(false);
+    expect(result.drifts.some((d) => d.includes("soroban-mainnet.stellar.org"))).toBe(true);
+  });
+
+  it("reports drift when mainnet config points at testnet RPC", () => {
+    const result = checkNetworkConfig({
+      ...MAINNET_OK,
+      NEXT_PUBLIC_RPC_URL: "https://soroban-testnet.stellar.org",
+    });
+    expect(result.valid).toBe(false);
+    expect(result.drifts.some((d) => d.includes("soroban-testnet.stellar.org"))).toBe(true);
+  });
+});
+
+// ── Passphrase drift / cross-environment contamination ───────────────────────
+
+describe("checkNetworkConfig — passphrase", () => {
+  it("reports drift when passphrase does not match the declared network", () => {
+    const result = checkNetworkConfig({
+      ...TESTNET_OK,
+      NEXT_PUBLIC_NETWORK_PASSPHRASE: "Wrong passphrase",
+    });
+    expect(result.valid).toBe(false);
+    expect(result.drifts.some((d) => d.includes("NEXT_PUBLIC_NETWORK_PASSPHRASE"))).toBe(true);
+  });
+
+  it("reports cross-environment contamination when testnet env has mainnet passphrase", () => {
+    const result = checkNetworkConfig({
+      ...TESTNET_OK,
+      NEXT_PUBLIC_NETWORK_PASSPHRASE: NETWORK_MATRIX.mainnet.passphrase,
+    });
+    expect(result.valid).toBe(false);
+    expect(result.drifts.some((d) => d.includes("contamination"))).toBe(true);
+  });
+});
+
+// ── assertNetworkConfig ───────────────────────────────────────────────────────
+
+describe("assertNetworkConfig", () => {
+  it("does not throw for a valid config", () => {
+    expect(() => assertNetworkConfig(TESTNET_OK)).not.toThrow();
+  });
+
+  it("throws with drift details for an invalid config", () => {
+    expect(() => assertNetworkConfig({})).toThrow(/drift detected/);
+  });
+
+  it("thrown error lists the specific drift", () => {
+    try {
+      assertNetworkConfig({ NEXT_PUBLIC_STELLAR_NETWORK: "testnet" });
+    } catch (e) {
+      expect(String(e)).toMatch(/NEXT_PUBLIC_CONTRACT_ID/);
+    }
+  });
+});

--- a/frontend/lib/__tests__/secrets.test.ts
+++ b/frontend/lib/__tests__/secrets.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import {
+  validateSecrets,
+  areCriticalSecretsValid,
+  requireSecret,
+  SecretMissingError,
+  SecretInvalidError,
+  redactSecrets,
+} from "@/lib/secrets";
+
+// A valid 56-char Stellar secret key (S + 55 base32 chars)
+const VALID_STELLAR_SECRET = "SCZANGBA5TNPQX2VALUV3SQNZT3LJYI3LBFCEQOARH5WQTXUJZKOLTA";
+
+describe("validateSecrets", () => {
+  it("marks critical secret as invalid when missing", () => {
+    const results = validateSecrets({});
+    const feeBump = results.find((r) => r.key === "STELLAR_FEE_BUMP_SECRET")!;
+    expect(feeBump.present).toBe(false);
+    expect(feeBump.valid).toBe(false);
+    expect(feeBump.criticality).toBe("critical");
+  });
+
+  it("marks critical secret as valid when correctly formatted", () => {
+    const results = validateSecrets({ STELLAR_FEE_BUMP_SECRET: VALID_STELLAR_SECRET });
+    const feeBump = results.find((r) => r.key === "STELLAR_FEE_BUMP_SECRET")!;
+    expect(feeBump.valid).toBe(true);
+    expect(feeBump.reason).toBeUndefined();
+  });
+
+  it("marks critical secret as invalid when format is wrong", () => {
+    const results = validateSecrets({ STELLAR_FEE_BUMP_SECRET: "not-a-stellar-key" });
+    const feeBump = results.find((r) => r.key === "STELLAR_FEE_BUMP_SECRET")!;
+    expect(feeBump.present).toBe(true);
+    expect(feeBump.valid).toBe(false);
+    expect(feeBump.reason).toMatch(/56-character/);
+  });
+
+  it("marks optional secrets as optional criticality", () => {
+    const results = validateSecrets({});
+    const blob = results.find((r) => r.key === "BLOB_READ_WRITE_TOKEN")!;
+    expect(blob.criticality).toBe("optional");
+  });
+
+  it("validates KV_REST_API_URL must be https", () => {
+    const results = validateSecrets({ KV_REST_API_URL: "http://insecure.example.com" });
+    const kv = results.find((r) => r.key === "KV_REST_API_URL")!;
+    expect(kv.valid).toBe(false);
+    expect(kv.reason).toMatch(/https/);
+  });
+});
+
+describe("areCriticalSecretsValid", () => {
+  it("returns false when critical secret is missing", () => {
+    expect(areCriticalSecretsValid({})).toBe(false);
+  });
+
+  it("returns false when critical secret has invalid format", () => {
+    expect(areCriticalSecretsValid({ STELLAR_FEE_BUMP_SECRET: "SBAD" })).toBe(false);
+  });
+
+  it("returns true when all critical secrets are valid", () => {
+    expect(areCriticalSecretsValid({ STELLAR_FEE_BUMP_SECRET: VALID_STELLAR_SECRET })).toBe(true);
+  });
+});
+
+describe("requireSecret", () => {
+  it("throws SecretMissingError when env var is absent", () => {
+    expect(() => requireSecret("STELLAR_FEE_BUMP_SECRET", {})).toThrow(SecretMissingError);
+  });
+
+  it("throws SecretInvalidError when format is wrong", () => {
+    expect(() =>
+      requireSecret("STELLAR_FEE_BUMP_SECRET", { STELLAR_FEE_BUMP_SECRET: "SBAD" })
+    ).toThrow(SecretInvalidError);
+  });
+
+  it("error message does not contain the secret value", () => {
+    const badValue = "SBADVALUE_THAT_SHOULD_NOT_APPEAR_IN_ERROR_MESSAGE_EVER";
+    try {
+      requireSecret("STELLAR_FEE_BUMP_SECRET", { STELLAR_FEE_BUMP_SECRET: badValue });
+    } catch (e) {
+      expect(String(e)).not.toContain(badValue);
+    }
+  });
+
+  it("returns the value when valid", () => {
+    const value = requireSecret("STELLAR_FEE_BUMP_SECRET", {
+      STELLAR_FEE_BUMP_SECRET: VALID_STELLAR_SECRET,
+    });
+    expect(value).toBe(VALID_STELLAR_SECRET);
+  });
+
+  it("returns value for unregistered key without format validation", () => {
+    const value = requireSecret("SOME_UNKNOWN_KEY", { SOME_UNKNOWN_KEY: "anything" });
+    expect(value).toBe("anything");
+  });
+});
+
+describe("redactSecrets", () => {
+  const env = { STELLAR_FEE_BUMP_SECRET: VALID_STELLAR_SECRET };
+
+  it("replaces secret value with [REDACTED]", () => {
+    const log = `Error: key=${VALID_STELLAR_SECRET} failed`;
+    expect(redactSecrets(log, env)).toBe("Error: key=[REDACTED] failed");
+  });
+
+  it("leaves strings without secrets unchanged", () => {
+    const log = "Normal log message with no secrets";
+    expect(redactSecrets(log, env)).toBe(log);
+  });
+
+  it("redacts multiple occurrences", () => {
+    const log = `${VALID_STELLAR_SECRET} and again ${VALID_STELLAR_SECRET}`;
+    expect(redactSecrets(log, env)).toBe("[REDACTED] and again [REDACTED]");
+  });
+
+  it("does not redact when env has no matching secrets", () => {
+    const log = "some log";
+    expect(redactSecrets(log, {})).toBe("some log");
+  });
+});

--- a/frontend/lib/network-config.ts
+++ b/frontend/lib/network-config.ts
@@ -1,0 +1,147 @@
+/**
+ * Network configuration parity checks for Supply-Link.
+ *
+ * Defines the expected configuration matrix per environment and validates
+ * that the runtime environment matches it. Used at startup and in health
+ * diagnostics to detect drift early.
+ */
+
+// ── Configuration matrix ──────────────────────────────────────────────────────
+
+export type NetworkEnv = "testnet" | "mainnet";
+
+interface NetworkMatrix {
+  passphrase: string;
+  /** Allowed RPC hostnames for this environment */
+  rpcHostnames: string[];
+  /** Contract ID must start with 'C' and be 56 chars (Stellar contract address) */
+  contractIdPattern: RegExp;
+}
+
+export const NETWORK_MATRIX: Record<NetworkEnv, NetworkMatrix> = {
+  testnet: {
+    passphrase: "Test SDF Network ; September 2015",
+    rpcHostnames: ["soroban-testnet.stellar.org"],
+    contractIdPattern: /^C[A-Z2-7]{55}$/,
+  },
+  mainnet: {
+    passphrase: "Public Global Stellar Network ; September 2015",
+    rpcHostnames: ["soroban-mainnet.stellar.org"],
+    contractIdPattern: /^C[A-Z2-7]{55}$/,
+  },
+};
+
+// ── Parity check result ───────────────────────────────────────────────────────
+
+export interface ConfigCheckResult {
+  valid: boolean;
+  /** Detected drifts — each entry describes a mismatch without leaking secret values */
+  drifts: string[];
+  /** Safe summary of effective config (no secret values) */
+  effectiveConfig: {
+    network: string;
+    rpcHostname: string;
+    contractIdPrefix: string; // first 8 chars only
+    passphraseMatch: boolean;
+  };
+}
+
+// ── Core validator ────────────────────────────────────────────────────────────
+
+export function checkNetworkConfig(env: NodeJS.ProcessEnv = process.env): ConfigCheckResult {
+  const drifts: string[] = [];
+
+  const network = env.NEXT_PUBLIC_STELLAR_NETWORK as NetworkEnv | undefined;
+  const contractId = env.NEXT_PUBLIC_CONTRACT_ID ?? "";
+  const rpcUrl = env.NEXT_PUBLIC_RPC_URL ?? "";
+  const passphrase = env.NEXT_PUBLIC_NETWORK_PASSPHRASE ?? "";
+
+  // 1. Network must be a known value
+  if (!network || !(network in NETWORK_MATRIX)) {
+    drifts.push(
+      `NEXT_PUBLIC_STELLAR_NETWORK is '${network ?? "unset"}'; expected 'testnet' or 'mainnet'`
+    );
+    return {
+      valid: false,
+      drifts,
+      effectiveConfig: {
+        network: network ?? "unset",
+        rpcHostname: safeHostname(rpcUrl),
+        contractIdPrefix: contractId.slice(0, 8) || "(unset)",
+        passphraseMatch: false,
+      },
+    };
+  }
+
+  const matrix = NETWORK_MATRIX[network];
+
+  // 2. Contract ID format
+  if (!contractId) {
+    drifts.push("NEXT_PUBLIC_CONTRACT_ID is not set");
+  } else if (!matrix.contractIdPattern.test(contractId)) {
+    drifts.push(
+      `NEXT_PUBLIC_CONTRACT_ID has invalid format for ${network} (expected 56-char Stellar contract address starting with 'C')`
+    );
+  }
+
+  // 3. RPC hostname must belong to the expected environment
+  const rpcHostname = safeHostname(rpcUrl);
+  if (rpcUrl && !matrix.rpcHostnames.some((h) => rpcHostname === h || rpcHostname.endsWith(`.${h}`))) {
+    drifts.push(
+      `NEXT_PUBLIC_RPC_URL hostname '${rpcHostname}' is not in the allowed list for ${network}: [${matrix.rpcHostnames.join(", ")}]`
+    );
+  }
+
+  // 4. Network passphrase must match (if explicitly set)
+  const passphraseMatch = !passphrase || passphrase === matrix.passphrase;
+  if (!passphraseMatch) {
+    drifts.push(
+      `NEXT_PUBLIC_NETWORK_PASSPHRASE does not match expected value for ${network}`
+    );
+  }
+
+  // 5. Cross-environment contamination: mainnet contract on testnet or vice-versa
+  //    Heuristic: if network is testnet but passphrase looks like mainnet (or vice-versa)
+  const otherNetwork: NetworkEnv = network === "testnet" ? "mainnet" : "testnet";
+  if (passphrase && passphrase === NETWORK_MATRIX[otherNetwork].passphrase) {
+    drifts.push(
+      `NEXT_PUBLIC_NETWORK_PASSPHRASE matches ${otherNetwork} but NEXT_PUBLIC_STELLAR_NETWORK is ${network} — possible environment contamination`
+    );
+  }
+
+  return {
+    valid: drifts.length === 0,
+    drifts,
+    effectiveConfig: {
+      network,
+      rpcHostname: rpcHostname || "(default)",
+      contractIdPrefix: contractId.slice(0, 8) || "(unset)",
+      passphraseMatch,
+    },
+  };
+}
+
+// ── Startup guard ─────────────────────────────────────────────────────────────
+
+/**
+ * Throws if the network configuration is invalid.
+ * Call once at module load time in server-only code paths.
+ */
+export function assertNetworkConfig(env: NodeJS.ProcessEnv = process.env): void {
+  const result = checkNetworkConfig(env);
+  if (!result.valid) {
+    throw new Error(
+      `[Supply-Link] Network configuration drift detected:\n${result.drifts.map((d) => `  • ${d}`).join("\n")}`
+    );
+  }
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function safeHostname(url: string): string {
+  try {
+    return new URL(url).hostname;
+  } catch {
+    return url; // not a valid URL; return as-is for drift reporting
+  }
+}

--- a/frontend/lib/secrets.ts
+++ b/frontend/lib/secrets.ts
@@ -1,0 +1,163 @@
+/**
+ * Centralised secret management for Supply-Link backend.
+ *
+ * Responsibilities:
+ *  - Inventory and classify all backend secrets
+ *  - Validate presence and format at load time
+ *  - Provide a safe accessor that never leaks values into errors/logs
+ *  - Redact secret values from arbitrary strings (for logging)
+ */
+
+// ── Secret registry ───────────────────────────────────────────────────────────
+
+export type SecretCriticality = "critical" | "optional";
+
+interface SecretSpec {
+  /** Environment variable name */
+  key: string;
+  criticality: SecretCriticality;
+  /** Returns null if valid, an error message string if invalid */
+  validate?: (value: string) => string | null;
+}
+
+/** Stellar secret key: starts with 'S', 56 chars, base32 alphabet */
+function validateStellarSecret(value: string): string | null {
+  if (!/^S[A-Z2-7]{55}$/.test(value)) {
+    return "must be a 56-character Stellar secret key starting with 'S'";
+  }
+  return null;
+}
+
+/** Non-empty string with minimum length */
+function minLength(n: number) {
+  return (value: string): string | null =>
+    value.length >= n ? null : `must be at least ${n} characters`;
+}
+
+export const SECRET_REGISTRY: SecretSpec[] = [
+  {
+    key: "STELLAR_FEE_BUMP_SECRET",
+    criticality: "critical",
+    validate: validateStellarSecret,
+  },
+  {
+    key: "BLOB_READ_WRITE_TOKEN",
+    criticality: "optional",
+    validate: minLength(10),
+  },
+  {
+    key: "KV_REST_API_URL",
+    criticality: "optional",
+    validate: (v) => (v.startsWith("https://") ? null : "must be an https:// URL"),
+  },
+  {
+    key: "KV_REST_API_TOKEN",
+    criticality: "optional",
+    validate: minLength(10),
+  },
+];
+
+// ── Validation result ─────────────────────────────────────────────────────────
+
+export interface SecretValidationResult {
+  key: string;
+  criticality: SecretCriticality;
+  present: boolean;
+  valid: boolean;
+  /** Human-readable reason — never contains the secret value */
+  reason?: string;
+}
+
+export function validateSecrets(
+  env: NodeJS.ProcessEnv = process.env
+): SecretValidationResult[] {
+  return SECRET_REGISTRY.map((spec) => {
+    const value = env[spec.key];
+    if (!value) {
+      return {
+        key: spec.key,
+        criticality: spec.criticality,
+        present: false,
+        valid: false,
+        reason: "not set",
+      };
+    }
+    const formatError = spec.validate?.(value) ?? null;
+    return {
+      key: spec.key,
+      criticality: spec.criticality,
+      present: true,
+      valid: formatError === null,
+      reason: formatError ?? undefined,
+    };
+  });
+}
+
+/** Returns true only if all critical secrets are present and valid. */
+export function areCriticalSecretsValid(
+  env: NodeJS.ProcessEnv = process.env
+): boolean {
+  return validateSecrets(env)
+    .filter((r) => r.criticality === "critical")
+    .every((r) => r.valid);
+}
+
+// ── Safe accessor ─────────────────────────────────────────────────────────────
+
+export class SecretMissingError extends Error {
+  constructor(public readonly key: string) {
+    super(`Required secret '${key}' is not configured`);
+    this.name = "SecretMissingError";
+  }
+}
+
+export class SecretInvalidError extends Error {
+  constructor(
+    public readonly key: string,
+    reason: string
+  ) {
+    // reason describes the format problem, never the value
+    super(`Secret '${key}' failed validation: ${reason}`);
+    this.name = "SecretInvalidError";
+  }
+}
+
+/**
+ * Retrieve a secret from the environment, throwing typed errors on failure.
+ * Never includes the secret value in thrown errors.
+ */
+export function requireSecret(
+  key: string,
+  env: NodeJS.ProcessEnv = process.env
+): string {
+  const spec = SECRET_REGISTRY.find((s) => s.key === key);
+  const value = env[key];
+  if (!value) throw new SecretMissingError(key);
+  if (spec?.validate) {
+    const err = spec.validate(value);
+    if (err) throw new SecretInvalidError(key, err);
+  }
+  return value;
+}
+
+// ── Log redaction ─────────────────────────────────────────────────────────────
+
+/**
+ * Replace any known secret values in a string with '[REDACTED]'.
+ * Call this before passing strings to console.error / logging services.
+ */
+export function redactSecrets(
+  input: string,
+  env: NodeJS.ProcessEnv = process.env
+): string {
+  let result = input;
+  for (const spec of SECRET_REGISTRY) {
+    const value = env[spec.key];
+    if (value && value.length >= 8) {
+      // Escape special regex chars in the secret value
+      const escaped = value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+      result = result.replace(new RegExp(escaped, "g"), "[REDACTED]");
+    }
+  }
+  return result;
+}

--- a/frontend/lib/stellar/contract-errors.ts
+++ b/frontend/lib/stellar/contract-errors.ts
@@ -1,0 +1,98 @@
+/**
+ * Stable error codes emitted by the Supply-Link Soroban contract.
+ *
+ * These map 1-to-1 to the `#[contracterror]` enum in the Rust contract.
+ * Use these constants for deterministic error handling instead of string matching.
+ */
+export const ContractErrorCode = {
+  ProductNotFound:       1,
+  NotAuthorized:         2,
+  ApproverNotAuthorized: 3,
+  OwnerOnly:             4,
+  NoPendingEvents:       5,
+  EventIndexOutOfBounds: 6,
+} as const;
+
+export type ContractErrorCode = typeof ContractErrorCode[keyof typeof ContractErrorCode];
+
+export interface MappedContractError {
+  code: ContractErrorCode;
+  /** Stable machine-readable key */
+  key: string;
+  /** Default English message — replace with i18n lookup in UI */
+  message: string;
+  /** Suggested HTTP status for API responses */
+  httpStatus: number;
+}
+
+const ERROR_MAP: Record<ContractErrorCode, MappedContractError> = {
+  [ContractErrorCode.ProductNotFound]: {
+    code: ContractErrorCode.ProductNotFound,
+    key: "PRODUCT_NOT_FOUND",
+    message: "The requested product does not exist on-chain.",
+    httpStatus: 404,
+  },
+  [ContractErrorCode.NotAuthorized]: {
+    code: ContractErrorCode.NotAuthorized,
+    key: "NOT_AUTHORIZED",
+    message: "You are not authorized to perform this action on this product.",
+    httpStatus: 403,
+  },
+  [ContractErrorCode.ApproverNotAuthorized]: {
+    code: ContractErrorCode.ApproverNotAuthorized,
+    key: "APPROVER_NOT_AUTHORIZED",
+    message: "The approver is not the product owner or an authorized actor.",
+    httpStatus: 403,
+  },
+  [ContractErrorCode.OwnerOnly]: {
+    code: ContractErrorCode.OwnerOnly,
+    key: "OWNER_ONLY",
+    message: "Only the product owner can perform this action.",
+    httpStatus: 403,
+  },
+  [ContractErrorCode.NoPendingEvents]: {
+    code: ContractErrorCode.NoPendingEvents,
+    key: "NO_PENDING_EVENTS",
+    message: "There are no pending events in the approval queue for this product.",
+    httpStatus: 404,
+  },
+  [ContractErrorCode.EventIndexOutOfBounds]: {
+    code: ContractErrorCode.EventIndexOutOfBounds,
+    key: "EVENT_INDEX_OUT_OF_BOUNDS",
+    message: "The supplied event index exceeds the pending-events queue length.",
+    httpStatus: 400,
+  },
+};
+
+/**
+ * Extract the numeric error code from a Soroban invocation error.
+ *
+ * Soroban encodes contract errors as `Error(Contract, <code>)` in the
+ * diagnostic events and as a numeric value in the result XDR.
+ * This function handles the common shapes returned by the Stellar SDK.
+ */
+export function extractContractErrorCode(error: unknown): ContractErrorCode | null {
+  if (typeof error !== "object" || error === null) return null;
+
+  // Shape from @stellar/stellar-sdk: { code: number } or { result: { code: number } }
+  const e = error as Record<string, unknown>;
+
+  const code =
+    typeof e["code"] === "number"
+      ? e["code"]
+      : typeof (e["result"] as Record<string, unknown>)?.["code"] === "number"
+        ? (e["result"] as Record<string, unknown>)["code"]
+        : null;
+
+  if (code === null) return null;
+  return (code in ERROR_MAP) ? (code as ContractErrorCode) : null;
+}
+
+/**
+ * Map a raw contract invocation error to a structured `MappedContractError`.
+ * Returns `null` if the error is not a recognised contract error code.
+ */
+export function mapContractError(error: unknown): MappedContractError | null {
+  const code = extractContractErrorCode(error);
+  return code !== null ? ERROR_MAP[code] : null;
+}

--- a/smart-contract/contracts/src/lib.rs
+++ b/smart-contract/contracts/src/lib.rs
@@ -1,5 +1,34 @@
 #![no_std]
-use soroban_sdk::{contract, contractimpl, contracttype, Address, Env, String, Vec, Symbol};
+use soroban_sdk::{contract, contractimpl, contracttype, contracterror, Address, Env, String, Vec, Symbol};
+
+// ── Error catalog ─────────────────────────────────────────────────────────────
+
+/// Stable, machine-readable error codes for all Supply-Link contract failures.
+///
+/// Each variant maps to a unique `u32` discriminant that is embedded in the
+/// Soroban invocation result and can be decoded deterministically by clients.
+///
+/// # Client mapping
+/// Frontend and backend adapters should map these codes to localised messages
+/// rather than relying on string matching. See `docs/CONTRACT_ERRORS.md` for
+/// the full client-behaviour guide.
+#[contracterror]
+#[derive(Copy, Clone, Debug, PartialEq)]
+#[repr(u32)]
+pub enum Error {
+    /// The requested product ID is not registered on-chain. Code: 1
+    ProductNotFound       = 1,
+    /// The caller is neither the product owner nor an authorized actor. Code: 2
+    NotAuthorized         = 2,
+    /// The approver is not the product owner or an authorized actor. Code: 3
+    ApproverNotAuthorized = 3,
+    /// Only the product owner may perform this action. Code: 4
+    OwnerOnly             = 4,
+    /// There are no pending events in the approval queue. Code: 5
+    NoPendingEvents       = 5,
+    /// The supplied event index exceeds the pending-events queue length. Code: 6
+    EventIndexOutOfBounds = 6,
+}
 
 // ── Data models ──────────────────────────────────────────────────────────────
 
@@ -266,18 +295,17 @@ impl SupplyLinkContract {
         location: String,
         event_type: String,
         metadata: String,
-    ) -> TrackingEvent {
+    ) -> Result<TrackingEvent, Error> {
         let product: Product = env
             .storage()
             .persistent()
             .get(&DataKey::Product(product_id.clone()))
-            .expect("product not found");
+            .ok_or(Error::ProductNotFound)?;
 
-        // Verify caller is owner or an authorized actor before requiring auth
         let is_owner = product.owner == caller;
         let is_actor = product.authorized_actors.contains(&caller);
         if !is_owner && !is_actor {
-            panic!("caller is not authorized");
+            return Err(Error::NotAuthorized);
         }
         caller.require_auth();
 
@@ -340,28 +368,21 @@ impl SupplyLinkContract {
             );
         }
 
-        event
+        Ok(event)
     }
 
     /// Retrieve a product by its ID.
     ///
-    /// # Parameters
-    /// - `env` — Soroban execution environment.
-    /// - `id` — The product ID to look up.
-    ///
     /// # Returns
     /// The [`Product`] struct stored under `id`.
     ///
-    /// # Authorization
-    /// None — this is a read-only function.
-    ///
-    /// # Panics
-    /// - `"product not found"` — if no product with `id` is registered.
-    pub fn get_product(env: Env, id: String) -> Product {
+    /// # Errors
+    /// - [`Error::ProductNotFound`] — if no product with `id` is registered.
+    pub fn get_product(env: Env, id: String) -> Result<Product, Error> {
         env.storage()
             .persistent()
             .get(&DataKey::Product(id))
-            .expect("product not found")
+            .ok_or(Error::ProductNotFound)
     }
 
     /// Retrieve all tracking events for a product.
@@ -459,12 +480,12 @@ impl SupplyLinkContract {
     /// # Emitted Events
     /// Publishes an `("ownership_transferred", product_id)` event with
     /// `new_owner` as the event body.
-    pub fn transfer_ownership(env: Env, product_id: String, new_owner: Address) -> bool {
+    pub fn transfer_ownership(env: Env, product_id: String, new_owner: Address) -> Result<bool, Error> {
         let mut product: Product = env
             .storage()
             .persistent()
             .get(&DataKey::Product(product_id.clone()))
-            .expect("product not found");
+            .ok_or(Error::ProductNotFound)?;
 
         product.owner.require_auth();
         product.owner = new_owner.clone();
@@ -472,13 +493,12 @@ impl SupplyLinkContract {
             .persistent()
             .set(&DataKey::Product(product_id.clone()), &product);
 
-        // Emit event
         env.events().publish(
             (Symbol::new(&env, "ownership_transferred"), product_id),
             new_owner,
         );
 
-        true
+        Ok(true)
     }
 
     /// Grant an address permission to add tracking events for a product.
@@ -505,12 +525,12 @@ impl SupplyLinkContract {
     /// # Emitted Events
     /// Publishes an `("actor_authorized", product_id)` event with `actor` as
     /// the event body.
-    pub fn add_authorized_actor(env: Env, product_id: String, actor: Address) -> bool {
+    pub fn add_authorized_actor(env: Env, product_id: String, actor: Address) -> Result<bool, Error> {
         let mut product: Product = env
             .storage()
             .persistent()
             .get(&DataKey::Product(product_id.clone()))
-            .expect("product not found");
+            .ok_or(Error::ProductNotFound)?;
 
         product.owner.require_auth();
         product.authorized_actors.push_back(actor.clone());
@@ -518,13 +538,12 @@ impl SupplyLinkContract {
             .persistent()
             .set(&DataKey::Product(product_id.clone()), &product);
 
-        // Emit event
         env.events().publish(
             (Symbol::new(&env, "actor_authorized"), product_id),
             actor,
         );
 
-        true
+        Ok(true)
     }
 
     /// Revoke an address's permission to add tracking events for a product.
@@ -551,16 +570,15 @@ impl SupplyLinkContract {
     ///
     /// # Emitted Events
     /// Does not emit an event (removal is not currently announced on-chain).
-    pub fn remove_authorized_actor(env: Env, product_id: String, actor: Address) -> bool {
+    pub fn remove_authorized_actor(env: Env, product_id: String, actor: Address) -> Result<bool, Error> {
         let mut product: Product = env
             .storage()
             .persistent()
             .get(&DataKey::Product(product_id.clone()))
-            .expect("product not found");
+            .ok_or(Error::ProductNotFound)?;
 
         product.owner.require_auth();
 
-        // Find and remove the actor
         let mut found = false;
         let mut new_actors = Vec::new(&env);
         for i in 0..product.authorized_actors.len() {
@@ -577,7 +595,7 @@ impl SupplyLinkContract {
             .persistent()
             .set(&DataKey::Product(product_id), &product);
 
-        found
+        Ok(found)
     }
 
     /// Update the mutable metadata fields of a product.
@@ -610,12 +628,12 @@ impl SupplyLinkContract {
         product_id: String,
         name: String,
         origin: String,
-    ) -> Product {
+    ) -> Result<Product, Error> {
         let mut product: Product = env
             .storage()
             .persistent()
             .get(&DataKey::Product(product_id.clone()))
-            .expect("product not found");
+            .ok_or(Error::ProductNotFound)?;
 
         product.owner.require_auth();
 
@@ -626,13 +644,12 @@ impl SupplyLinkContract {
             .persistent()
             .set(&DataKey::Product(product_id.clone()), &product);
 
-        // Emit event
         env.events().publish(
             (Symbol::new(&env, "product_updated"), product_id),
             product.clone(),
         );
 
-        product
+        Ok(product)
     }
 
     /// Return the list of addresses authorised to add events for a product.
@@ -763,17 +780,17 @@ impl SupplyLinkContract {
         product_id: String,
         event_index: u32,
         approver: Address,
-    ) -> bool {
+    ) -> Result<bool, Error> {
         let product: Product = env
             .storage()
             .persistent()
             .get(&DataKey::Product(product_id.clone()))
-            .expect("product not found");
+            .ok_or(Error::ProductNotFound)?;
 
         let is_owner = product.owner == approver;
         let is_actor = product.authorized_actors.contains(&approver);
         if !is_owner && !is_actor {
-            panic!("approver is not authorized");
+            return Err(Error::ApproverNotAuthorized);
         }
         approver.require_auth();
 
@@ -781,10 +798,10 @@ impl SupplyLinkContract {
             .storage()
             .persistent()
             .get(&DataKey::PendingEvents(product_id.clone()))
-            .expect("no pending events");
+            .ok_or(Error::NoPendingEvents)?;
 
         if event_index as usize >= pending.len() {
-            panic!("event index out of bounds");
+            return Err(Error::EventIndexOutOfBounds);
         }
 
         let mut pending_event = pending.get(event_index as usize).unwrap().clone();
@@ -832,14 +849,14 @@ impl SupplyLinkContract {
                 pending_event.event,
             );
 
-            true
+            Ok(true)
         } else {
             // Update pending event with new approval
             pending.set(event_index as usize, pending_event);
             env.storage()
                 .persistent()
                 .set(&DataKey::PendingEvents(product_id), &pending);
-            false
+            Ok(false)
         }
     }
 
@@ -869,15 +886,15 @@ impl SupplyLinkContract {
         product_id: String,
         event_index: u32,
         rejector: Address,
-    ) -> bool {
+    ) -> Result<bool, Error> {
         let product: Product = env
             .storage()
             .persistent()
             .get(&DataKey::Product(product_id.clone()))
-            .expect("product not found");
+            .ok_or(Error::ProductNotFound)?;
 
         if product.owner != rejector {
-            panic!("only owner can reject");
+            return Err(Error::OwnerOnly);
         }
         rejector.require_auth();
 
@@ -885,15 +902,14 @@ impl SupplyLinkContract {
             .storage()
             .persistent()
             .get(&DataKey::PendingEvents(product_id.clone()))
-            .expect("no pending events");
+            .ok_or(Error::NoPendingEvents)?;
 
         if event_index as usize >= pending.len() {
-            panic!("event index out of bounds");
+            return Err(Error::EventIndexOutOfBounds);
         }
 
         let rejected_event = pending.get(event_index as usize).unwrap().clone();
 
-        // Remove from pending
         pending.remove(event_index as usize);
         if pending.len() > 0 {
             env.storage()
@@ -905,13 +921,12 @@ impl SupplyLinkContract {
                 .remove(&DataKey::PendingEvents(product_id.clone()));
         }
 
-        // Emit rejection event
         env.events().publish(
             (Symbol::new(&env, "event_rejected"), product_id),
             rejected_event.event,
         );
 
-        true
+        Ok(true)
     }
 
     /// Get pending events for a product.
@@ -932,5 +947,252 @@ impl SupplyLinkContract {
             .persistent()
             .get(&DataKey::PendingEvents(product_id))
             .unwrap_or_else(|| Vec::new(&env))
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use soroban_sdk::testutils::{Address as _, Ledger};
+    use soroban_sdk::{Env, String};
+
+    fn setup() -> (Env, soroban_sdk::Address, soroban_sdk::contracttype::ContractClient<'static>) {
+        // This helper is intentionally not used in the inline tests below;
+        // each test constructs its own env for isolation.
+        unreachable!()
+    }
+
+    // ── Error::ProductNotFound ────────────────────────────────────────────────
+
+    #[test]
+    fn get_product_returns_product_not_found() {
+        let env = Env::default();
+        let contract_id = env.register_contract(None, SupplyLinkContract);
+        let client = SupplyLinkContractClient::new(&env, &contract_id);
+
+        let result = client.try_get_product(&String::from_str(&env, "nonexistent"));
+        assert_eq!(result, Err(Ok(Error::ProductNotFound)));
+    }
+
+    #[test]
+    fn add_tracking_event_returns_product_not_found() {
+        let env = Env::default();
+        let contract_id = env.register_contract(None, SupplyLinkContract);
+        let client = SupplyLinkContractClient::new(&env, &contract_id);
+        let caller = soroban_sdk::Address::generate(&env);
+
+        let result = client.try_add_tracking_event(
+            &String::from_str(&env, "ghost"),
+            &caller,
+            &String::from_str(&env, "loc"),
+            &String::from_str(&env, "SHIPPING"),
+            &String::from_str(&env, "{}"),
+        );
+        assert_eq!(result, Err(Ok(Error::ProductNotFound)));
+    }
+
+    #[test]
+    fn transfer_ownership_returns_product_not_found() {
+        let env = Env::default();
+        let contract_id = env.register_contract(None, SupplyLinkContract);
+        let client = SupplyLinkContractClient::new(&env, &contract_id);
+        let new_owner = soroban_sdk::Address::generate(&env);
+
+        let result = client.try_transfer_ownership(
+            &String::from_str(&env, "ghost"),
+            &new_owner,
+        );
+        assert_eq!(result, Err(Ok(Error::ProductNotFound)));
+    }
+
+    // ── Error::NotAuthorized ──────────────────────────────────────────────────
+
+    #[test]
+    fn add_tracking_event_returns_not_authorized_for_stranger() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register_contract(None, SupplyLinkContract);
+        let client = SupplyLinkContractClient::new(&env, &contract_id);
+
+        let owner = soroban_sdk::Address::generate(&env);
+        let stranger = soroban_sdk::Address::generate(&env);
+
+        client.register_product(
+            &String::from_str(&env, "p1"),
+            &String::from_str(&env, "Widget"),
+            &String::from_str(&env, "Factory A"),
+            &owner,
+            &1u32,
+        );
+
+        let result = client.try_add_tracking_event(
+            &String::from_str(&env, "p1"),
+            &stranger,
+            &String::from_str(&env, "Warehouse"),
+            &String::from_str(&env, "SHIPPING"),
+            &String::from_str(&env, "{}"),
+        );
+        assert_eq!(result, Err(Ok(Error::NotAuthorized)));
+    }
+
+    // ── Error::ApproverNotAuthorized ──────────────────────────────────────────
+
+    #[test]
+    fn approve_event_returns_approver_not_authorized() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register_contract(None, SupplyLinkContract);
+        let client = SupplyLinkContractClient::new(&env, &contract_id);
+
+        let owner = soroban_sdk::Address::generate(&env);
+        let actor = soroban_sdk::Address::generate(&env);
+        let stranger = soroban_sdk::Address::generate(&env);
+
+        // Register with multi-sig requirement
+        client.register_product(
+            &String::from_str(&env, "p2"),
+            &String::from_str(&env, "Widget"),
+            &String::from_str(&env, "Factory B"),
+            &owner,
+            &2u32,
+        );
+        client.add_authorized_actor(&String::from_str(&env, "p2"), &actor);
+        client.add_tracking_event(
+            &String::from_str(&env, "p2"),
+            &actor,
+            &String::from_str(&env, "Port"),
+            &String::from_str(&env, "SHIPPING"),
+            &String::from_str(&env, "{}"),
+        );
+
+        let result = client.try_approve_event(
+            &String::from_str(&env, "p2"),
+            &0u32,
+            &stranger,
+        );
+        assert_eq!(result, Err(Ok(Error::ApproverNotAuthorized)));
+    }
+
+    // ── Error::OwnerOnly ──────────────────────────────────────────────────────
+
+    #[test]
+    fn reject_event_returns_owner_only_for_non_owner() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register_contract(None, SupplyLinkContract);
+        let client = SupplyLinkContractClient::new(&env, &contract_id);
+
+        let owner = soroban_sdk::Address::generate(&env);
+        let actor = soroban_sdk::Address::generate(&env);
+
+        client.register_product(
+            &String::from_str(&env, "p3"),
+            &String::from_str(&env, "Widget"),
+            &String::from_str(&env, "Factory C"),
+            &owner,
+            &2u32,
+        );
+        client.add_authorized_actor(&String::from_str(&env, "p3"), &actor);
+        client.add_tracking_event(
+            &String::from_str(&env, "p3"),
+            &actor,
+            &String::from_str(&env, "Port"),
+            &String::from_str(&env, "SHIPPING"),
+            &String::from_str(&env, "{}"),
+        );
+
+        let result = client.try_reject_event(
+            &String::from_str(&env, "p3"),
+            &0u32,
+            &actor, // actor, not owner
+        );
+        assert_eq!(result, Err(Ok(Error::OwnerOnly)));
+    }
+
+    // ── Error::NoPendingEvents ────────────────────────────────────────────────
+
+    #[test]
+    fn approve_event_returns_no_pending_events() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register_contract(None, SupplyLinkContract);
+        let client = SupplyLinkContractClient::new(&env, &contract_id);
+
+        let owner = soroban_sdk::Address::generate(&env);
+        client.register_product(
+            &String::from_str(&env, "p4"),
+            &String::from_str(&env, "Widget"),
+            &String::from_str(&env, "Factory D"),
+            &owner,
+            &1u32,
+        );
+
+        let result = client.try_approve_event(
+            &String::from_str(&env, "p4"),
+            &0u32,
+            &owner,
+        );
+        assert_eq!(result, Err(Ok(Error::NoPendingEvents)));
+    }
+
+    // ── Error::EventIndexOutOfBounds ──────────────────────────────────────────
+
+    #[test]
+    fn approve_event_returns_event_index_out_of_bounds() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register_contract(None, SupplyLinkContract);
+        let client = SupplyLinkContractClient::new(&env, &contract_id);
+
+        let owner = soroban_sdk::Address::generate(&env);
+        let actor = soroban_sdk::Address::generate(&env);
+
+        client.register_product(
+            &String::from_str(&env, "p5"),
+            &String::from_str(&env, "Widget"),
+            &String::from_str(&env, "Factory E"),
+            &owner,
+            &2u32,
+        );
+        client.add_authorized_actor(&String::from_str(&env, "p5"), &actor);
+        client.add_tracking_event(
+            &String::from_str(&env, "p5"),
+            &actor,
+            &String::from_str(&env, "Port"),
+            &String::from_str(&env, "SHIPPING"),
+            &String::from_str(&env, "{}"),
+        );
+
+        // Index 99 is out of bounds (only index 0 exists)
+        let result = client.try_approve_event(
+            &String::from_str(&env, "p5"),
+            &99u32,
+            &owner,
+        );
+        assert_eq!(result, Err(Ok(Error::EventIndexOutOfBounds)));
+    }
+
+    // ── Happy path smoke test ─────────────────────────────────────────────────
+
+    #[test]
+    fn register_and_get_product_succeeds() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register_contract(None, SupplyLinkContract);
+        let client = SupplyLinkContractClient::new(&env, &contract_id);
+
+        let owner = soroban_sdk::Address::generate(&env);
+        client.register_product(
+            &String::from_str(&env, "p6"),
+            &String::from_str(&env, "Coffee"),
+            &String::from_str(&env, "Ethiopia"),
+            &owner,
+            &1u32,
+        );
+
+        let product = client.get_product(&String::from_str(&env, "p6"));
+        assert_eq!(product.name, String::from_str(&env, "Coffee"));
     }
 }


### PR DESCRIPTION
## Summary

Closes #321
Closes #322
Closes #323
Closes #324
Closes #335
Closes #336
Closes #337

Four backend hardening tasks delivered in a single PR.

---

### #321 — Health endpoint expansion with dependency diagnostics

- Split `GET /api/health` into **liveness** (always ok) and **readiness** semantics
- Added `probeRpc`, `probeBlob`, `probeKv`, `probeEnvConfig`, `probeNetworkConfig` — each with bounded timeouts and per-dependency `{status, latencyMs}` in the response
- Returns `503` when readiness is `down` (RPC unreachable)
- Added `docs/HEALTH_ENDPOINT.md` with Vercel and Kubernetes deployment guidance
- 14 tests covering all probe failure modes, 503, latency fields, and rate limiting

### #322 — Secure secret handling and key rotation playbook

- Added `lib/secrets.ts`: `SECRET_REGISTRY` inventory, `validateSecrets()`, `areCriticalSecretsValid()`, `requireSecret()` (throws typed errors, never leaks values), `redactSecrets()`
- Updated fee-bump route to use `requireSecret` and `redactSecrets`; returns `503` on missing/invalid critical secret
- Added `docs/SECRET_ROTATION_RUNBOOK.md`: 90-day scheduled rotation, emergency rotation, rollback, and quarterly drill checklist
- 14 tests covering missing, invalid format, value-not-in-error-message, and redaction

### #323 — Contract network configuration safety and environment parity checks

- Added `lib/network-config.ts`: `NETWORK_MATRIX` per environment, `checkNetworkConfig()` (5 checks: network value, contract ID format, RPC hostname, passphrase match, cross-env contamination), `assertNetworkConfig()` for startup fast-fail
- `effectiveConfig` exposes only `contractIdPrefix` (8 chars) and `passphraseMatch` bool — no full values in health responses
- Wired `probeNetworkConfig()` into health route `dependencies.config`
- Added `docs/NETWORK_CONFIG_PARITY.md`: environment matrix, per-drift remediation, and guide for adding new environments
- 17 tests covering all drift scenarios

### #324 — Smart contract error code standardization

- Added `#[contracterror] enum Error` with 6 stable `u32` codes (1–6)
- Replaced all `panic!()` and `.expect()` in 8 contract functions with `Result<T, Error>` — zero panics remain in critical paths
- Added 8 Rust tests asserting exact `Error` variants via `try_*` client methods
- Added `lib/stellar/contract-errors.ts`: `ContractErrorCode`, `mapContractError()`, `extractContractErrorCode()` with HTTP status per code
- Added `docs/CONTRACT_ERRORS.md`: full catalog, per-function error matrix, client behaviour guide, i18n pattern, extension instructions
- 12 TypeScript tests

## Files Changed

```
frontend/app/api/health/route.ts              (expanded)
frontend/app/api/health/__tests__/route.test.ts (rewritten)
frontend/app/api/v1/fee-bump/route.ts         (updated)
frontend/lib/secrets.ts                       (new)
frontend/lib/network-config.ts                (new)
frontend/lib/stellar/contract-errors.ts       (new)
frontend/lib/__tests__/secrets.test.ts        (new)
frontend/lib/__tests__/network-config.test.ts (new)
frontend/lib/__tests__/contract-errors.test.ts (new)
smart-contract/contracts/src/lib.rs           (updated)
docs/HEALTH_ENDPOINT.md                       (new)
docs/SECRET_ROTATION_RUNBOOK.md               (new)
docs/NETWORK_CONFIG_PARITY.md                 (new)
docs/CONTRACT_ERRORS.md                       (new)
```