### PR TITLE
feat: metadata validation, notification center, badge signing & replay detection

### DIFF
--- a/frontend/__tests__/badgeService.test.ts
+++ b/frontend/__tests__/badgeService.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect } from 'vitest';
+import {
+  generateBadgePayload,
+  verifyBadgePayload,
+  encodeBadgePayload,
+  type BadgeProduct,
+} from '@/lib/services/badgeService';
+
+const PRODUCT: BadgeProduct = {
+  id: 'prod-001',
+  name: 'Arabica Coffee',
+  origin: 'Yirgacheffe, Ethiopia',
+  owner: 'GXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX1',
+  timestamp: 1_700_000_000_000,
+};
+
+describe('generateBadgePayload', () => {
+  it('returns a payload with all required fields', () => {
+    const payload = generateBadgePayload(PRODUCT);
+    expect(payload.productId).toBe(PRODUCT.id);
+    expect(payload.productName).toBe(PRODUCT.name);
+    expect(payload.origin).toBe(PRODUCT.origin);
+    expect(payload.owner).toBe(PRODUCT.owner);
+    expect(payload.registrationTimestamp).toBe(PRODUCT.timestamp);
+    expect(payload.schemaVersion).toBe(1);
+    expect(payload.proof).toBeTruthy();
+    expect(typeof payload.proof).toBe('string');
+    expect(payload.proof.length).toBe(64);
+  });
+
+  it('produces different proofs for different generatedAt timestamps', () => {
+    const payload1 = generateBadgePayload(PRODUCT);
+    const payloadBase = { ...payload1, generatedAt: payload1.generatedAt + 1000 };
+    const { proof: proof2 } = {
+      ...payloadBase,
+      proof: require('crypto')
+        .createHmac(
+          'sha256',
+          process.env.BADGE_SIGNING_SECRET ?? 'supply-link-badge-default-secret',
+        )
+        .update(
+          [
+            payloadBase.productId,
+            payloadBase.productName,
+            payloadBase.origin,
+            payloadBase.owner,
+            String(payloadBase.registrationTimestamp),
+            String(payloadBase.generatedAt),
+            String(payloadBase.schemaVersion),
+          ].join(':'),
+        )
+        .digest('hex'),
+    };
+    expect(payload1.proof).not.toBe(proof2);
+  });
+
+  it('produces different proofs for different products', () => {
+    const p1 = generateBadgePayload(PRODUCT);
+    const p2 = generateBadgePayload({ ...PRODUCT, id: 'prod-002' });
+    expect(p1.proof).not.toBe(p2.proof);
+  });
+});
+
+describe('encodeBadgePayload / verifyBadgePayload', () => {
+  it('round-trips a valid payload', () => {
+    const payload = generateBadgePayload(PRODUCT);
+    const encoded = encodeBadgePayload(payload);
+    const result = verifyBadgePayload(encoded);
+    expect(result.valid).toBe(true);
+    expect(result.payload?.productId).toBe(PRODUCT.id);
+  });
+
+  it('rejects tampered productId', () => {
+    const payload = generateBadgePayload(PRODUCT);
+    const tampered = { ...payload, productId: 'evil-id' };
+    const encoded = encodeBadgePayload(tampered);
+    const result = verifyBadgePayload(encoded);
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain('tampered');
+  });
+
+  it('rejects tampered productName', () => {
+    const payload = generateBadgePayload(PRODUCT);
+    const tampered = { ...payload, productName: 'Fake Product' };
+    const encoded = encodeBadgePayload(tampered);
+    const result = verifyBadgePayload(encoded);
+    expect(result.valid).toBe(false);
+  });
+
+  it('rejects tampered owner', () => {
+    const payload = generateBadgePayload(PRODUCT);
+    const tampered = {
+      ...payload,
+      owner: 'GFAKEOWNER000000000000000000000000000000000000000000000001',
+    };
+    const encoded = encodeBadgePayload(tampered);
+    const result = verifyBadgePayload(encoded);
+    expect(result.valid).toBe(false);
+  });
+
+  it('rejects tampered proof directly', () => {
+    const payload = generateBadgePayload(PRODUCT);
+    const tampered = { ...payload, proof: 'a'.repeat(64) };
+    const encoded = encodeBadgePayload(tampered);
+    const result = verifyBadgePayload(encoded);
+    expect(result.valid).toBe(false);
+  });
+
+  it('rejects invalid base64 encoding', () => {
+    const result = verifyBadgePayload('!not-valid-base64!!!');
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain('Invalid badge payload encoding');
+  });
+
+  it('rejects payload with missing required fields', () => {
+    const payload = generateBadgePayload(PRODUCT);
+    const incomplete = { ...payload } as Partial<typeof payload>;
+    delete incomplete.proof;
+    const encoded = Buffer.from(JSON.stringify(incomplete)).toString('base64');
+    const result = verifyBadgePayload(encoded);
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain('Missing required field: proof');
+  });
+});

--- a/frontend/__tests__/eventMetadataSchemas.test.ts
+++ b/frontend/__tests__/eventMetadataSchemas.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect } from 'vitest';
+import { validateEventMetadata, eventMetadataSchemas } from '@/lib/api/eventMetadataSchemas';
+
+describe('validateEventMetadata', () => {
+  it('rejects unknown event type', () => {
+    const result = validateEventMetadata('UNKNOWN', '{}');
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain('Unknown event type');
+  });
+
+  it('accepts empty object for any valid event type', () => {
+    for (const type of Object.keys(eventMetadataSchemas)) {
+      const result = validateEventMetadata(type, '{}');
+      expect(result.valid).toBe(true);
+    }
+  });
+
+  it('rejects invalid JSON', () => {
+    const result = validateEventMetadata('HARVEST', 'not-json');
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain('valid JSON');
+  });
+
+  it('rejects JSON array (non-object)', () => {
+    const result = validateEventMetadata('HARVEST', '[1, 2, 3]');
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain('JSON object');
+  });
+
+  it('rejects JSON null', () => {
+    const result = validateEventMetadata('HARVEST', 'null');
+    expect(result.valid).toBe(false);
+  });
+
+  describe('HARVEST', () => {
+    it('accepts valid HARVEST metadata', () => {
+      const result = validateEventMetadata(
+        'HARVEST',
+        JSON.stringify({ batchNumber: 'B001', quantity: 100, unit: 'kg' }),
+      );
+      expect(result.valid).toBe(true);
+      expect(result.data?.batchNumber).toBe('B001');
+    });
+
+    it('rejects invalid unit enum', () => {
+      const result = validateEventMetadata('HARVEST', JSON.stringify({ unit: 'gallons' }));
+      expect(result.valid).toBe(false);
+    });
+
+    it('rejects negative quantity', () => {
+      const result = validateEventMetadata('HARVEST', JSON.stringify({ quantity: -5 }));
+      expect(result.valid).toBe(false);
+    });
+
+    it('rejects certifications array exceeding 10 items', () => {
+      const result = validateEventMetadata(
+        'HARVEST',
+        JSON.stringify({ certifications: Array(11).fill('cert') }),
+      );
+      expect(result.valid).toBe(false);
+    });
+
+    it('rejects batchNumber exceeding 64 characters', () => {
+      const result = validateEventMetadata(
+        'HARVEST',
+        JSON.stringify({ batchNumber: 'x'.repeat(65) }),
+      );
+      expect(result.valid).toBe(false);
+    });
+  });
+
+  describe('PROCESSING', () => {
+    it('accepts valid PROCESSING metadata', () => {
+      const result = validateEventMetadata(
+        'PROCESSING',
+        JSON.stringify({ facilityId: 'FAC-001', qualityGrade: 'A', inspector: 'Jane Doe' }),
+      );
+      expect(result.valid).toBe(true);
+    });
+
+    it('rejects facilityId exceeding 128 characters', () => {
+      const result = validateEventMetadata(
+        'PROCESSING',
+        JSON.stringify({ facilityId: 'x'.repeat(129) }),
+      );
+      expect(result.valid).toBe(false);
+    });
+  });
+
+  describe('SHIPPING', () => {
+    it('accepts valid SHIPPING metadata', () => {
+      const result = validateEventMetadata(
+        'SHIPPING',
+        JSON.stringify({ carrier: 'DHL', trackingNumber: 'TRK-123456' }),
+      );
+      expect(result.valid).toBe(true);
+    });
+
+    it('rejects carrier exceeding 128 characters', () => {
+      const result = validateEventMetadata(
+        'SHIPPING',
+        JSON.stringify({ carrier: 'x'.repeat(129) }),
+      );
+      expect(result.valid).toBe(false);
+    });
+  });
+
+  describe('RETAIL', () => {
+    it('accepts valid RETAIL metadata', () => {
+      const result = validateEventMetadata(
+        'RETAIL',
+        JSON.stringify({ storeId: 'STORE-001', price: 9.99, currency: 'USD' }),
+      );
+      expect(result.valid).toBe(true);
+    });
+
+    it('rejects negative price', () => {
+      const result = validateEventMetadata('RETAIL', JSON.stringify({ price: -10 }));
+      expect(result.valid).toBe(false);
+    });
+
+    it('rejects non-integer stockLevel', () => {
+      const result = validateEventMetadata('RETAIL', JSON.stringify({ stockLevel: 1.5 }));
+      expect(result.valid).toBe(false);
+    });
+
+    it('rejects negative stockLevel', () => {
+      const result = validateEventMetadata('RETAIL', JSON.stringify({ stockLevel: -1 }));
+      expect(result.valid).toBe(false);
+    });
+
+    it('rejects currency exceeding 8 characters', () => {
+      const result = validateEventMetadata(
+        'RETAIL',
+        JSON.stringify({ currency: 'TOOLONGCURRENCY' }),
+      );
+      expect(result.valid).toBe(false);
+    });
+  });
+});

--- a/frontend/__tests__/notifications.test.ts
+++ b/frontend/__tests__/notifications.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect } from 'vitest';
+import {
+  buildOwnershipNotification,
+  buildApprovalPendingNotification,
+  buildApprovalFinalizedNotification,
+  buildApprovalRejectedNotification,
+  buildRecallNotification,
+  buildContractErrorNotification,
+} from '@/lib/hooks/useNotifications';
+
+const NOW = 1_700_000_000_000;
+const PRODUCT_ID = 'prod-001';
+const PRODUCT_NAME = 'Arabica Coffee';
+const ACTOR = 'GXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX1';
+
+describe('notification builders', () => {
+  it('buildOwnershipNotification produces OWNERSHIP_CHANGED type', () => {
+    const n = buildOwnershipNotification(PRODUCT_ID, PRODUCT_NAME, ACTOR, NOW);
+    expect(n.notificationType).toBe('OWNERSHIP_CHANGED');
+    expect(n.productId).toBe(PRODUCT_ID);
+    expect(n.productName).toBe(PRODUCT_NAME);
+    expect(n.read).toBe(false);
+    expect(n.message).toContain('Ownership transferred');
+    expect(n.id).toContain('ownership');
+  });
+
+  it('buildApprovalPendingNotification produces APPROVAL_PENDING type', () => {
+    const n = buildApprovalPendingNotification(
+      PRODUCT_ID,
+      PRODUCT_NAME,
+      'HARVEST',
+      'Nairobi, Kenya',
+      ACTOR,
+      NOW,
+      42,
+    );
+    expect(n.notificationType).toBe('APPROVAL_PENDING');
+    expect(n.eventType).toBe('HARVEST');
+    expect(n.location).toBe('Nairobi, Kenya');
+    expect(n.message).toContain('awaiting approval');
+    expect(n.id).toContain('42');
+  });
+
+  it('buildApprovalFinalizedNotification produces APPROVAL_FINALIZED type', () => {
+    const n = buildApprovalFinalizedNotification(
+      PRODUCT_ID,
+      PRODUCT_NAME,
+      'SHIPPING',
+      'Port of Rotterdam',
+      ACTOR,
+      NOW,
+    );
+    expect(n.notificationType).toBe('APPROVAL_FINALIZED');
+    expect(n.message).toContain('approved and finalized');
+  });
+
+  it('buildApprovalRejectedNotification includes reason when provided', () => {
+    const n = buildApprovalRejectedNotification(
+      PRODUCT_ID,
+      PRODUCT_NAME,
+      'PROCESSING',
+      'Factory A',
+      ACTOR,
+      NOW,
+      'Incorrect batch',
+    );
+    expect(n.notificationType).toBe('APPROVAL_REJECTED');
+    expect(n.message).toContain('Incorrect batch');
+  });
+
+  it('buildApprovalRejectedNotification works without reason', () => {
+    const n = buildApprovalRejectedNotification(
+      PRODUCT_ID,
+      PRODUCT_NAME,
+      'RETAIL',
+      'Store 1',
+      ACTOR,
+      NOW,
+    );
+    expect(n.notificationType).toBe('APPROVAL_REJECTED');
+    expect(n.message).toContain('rejected');
+  });
+
+  it('buildRecallNotification produces PRODUCT_RECALLED type', () => {
+    const n = buildRecallNotification(PRODUCT_ID, PRODUCT_NAME, ACTOR, NOW);
+    expect(n.notificationType).toBe('PRODUCT_RECALLED');
+    expect(n.message).toContain('recalled');
+    expect(n.read).toBe(false);
+  });
+
+  it('buildContractErrorNotification produces CONTRACT_ERROR type', () => {
+    const n = buildContractErrorNotification(PRODUCT_ID, PRODUCT_NAME, 'InvalidNonce', NOW);
+    expect(n.notificationType).toBe('CONTRACT_ERROR');
+    expect(n.message).toContain('InvalidNonce');
+  });
+
+  it('all notifications have unique IDs for the same product when timestamps differ', () => {
+    const n1 = buildOwnershipNotification(PRODUCT_ID, PRODUCT_NAME, ACTOR, NOW);
+    const n2 = buildOwnershipNotification(PRODUCT_ID, PRODUCT_NAME, ACTOR, NOW + 1000);
+    expect(n1.id).not.toBe(n2.id);
+  });
+
+  it('approval pending notifications use pendingEventId for uniqueness', () => {
+    const n1 = buildApprovalPendingNotification(
+      PRODUCT_ID,
+      PRODUCT_NAME,
+      'HARVEST',
+      'Loc',
+      ACTOR,
+      NOW,
+      1,
+    );
+    const n2 = buildApprovalPendingNotification(
+      PRODUCT_ID,
+      PRODUCT_NAME,
+      'HARVEST',
+      'Loc',
+      ACTOR,
+      NOW,
+      2,
+    );
+    expect(n1.id).not.toBe(n2.id);
+  });
+});

--- a/frontend/__tests__/replayDetection.test.ts
+++ b/frontend/__tests__/replayDetection.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from 'vitest';
+import {
+  isReplayError,
+  isExpiredEventError,
+  formatMultiSigError,
+  getReplayErrorMessage,
+  getExpiredEventMessage,
+} from '@/lib/utils/nonce';
+
+describe('isReplayError', () => {
+  it('detects InvalidNonce in error message', () => {
+    expect(isReplayError(new Error('Contract returned Error(7): InvalidNonce'))).toBe(true);
+  });
+
+  it('detects invalid_nonce in error message', () => {
+    expect(isReplayError(new Error('invalid_nonce encountered'))).toBe(true);
+  });
+
+  it('detects Error(7) in error message', () => {
+    expect(isReplayError(new Error('Error(7)'))).toBe(true);
+  });
+
+  it('returns false for unrelated errors', () => {
+    expect(isReplayError(new Error('Network timeout'))).toBe(false);
+    expect(isReplayError(new Error('ProductNotFound'))).toBe(false);
+    expect(isReplayError(new Error('NotAuthorized'))).toBe(false);
+  });
+
+  it('handles non-Error objects', () => {
+    expect(isReplayError('InvalidNonce')).toBe(true);
+    expect(isReplayError('random string')).toBe(false);
+  });
+
+  it('handles null and undefined gracefully', () => {
+    expect(isReplayError(null)).toBe(false);
+    expect(isReplayError(undefined)).toBe(false);
+  });
+});
+
+describe('isExpiredEventError', () => {
+  it('detects PendingEventExpired in error message', () => {
+    expect(isExpiredEventError(new Error('PendingEventExpired'))).toBe(true);
+  });
+
+  it('detects generic "expired" in error message', () => {
+    expect(isExpiredEventError(new Error('pending event has expired'))).toBe(true);
+  });
+
+  it('returns false for non-expiry errors', () => {
+    expect(isExpiredEventError(new Error('InvalidNonce'))).toBe(false);
+    expect(isExpiredEventError(new Error('ProductNotFound'))).toBe(false);
+  });
+});
+
+describe('formatMultiSigError', () => {
+  it('returns replay message for replay errors', () => {
+    const msg = formatMultiSigError(new Error('InvalidNonce'));
+    expect(msg).toBe(getReplayErrorMessage());
+  });
+
+  it('returns expiry message for expired events', () => {
+    const msg = formatMultiSigError(new Error('PendingEventExpired'));
+    expect(msg).toBe(getExpiredEventMessage());
+  });
+
+  it('returns the error message for generic errors', () => {
+    const msg = formatMultiSigError(new Error('Network failure'));
+    expect(msg).toBe('Network failure');
+  });
+
+  it('returns fallback string for non-Error objects', () => {
+    const msg = formatMultiSigError('Something went wrong');
+    expect(msg).toBe('Something went wrong');
+  });
+
+  it('replay message instructs user to refresh', () => {
+    expect(getReplayErrorMessage()).toContain('Refresh');
+  });
+
+  it('expiry message references 7-day window', () => {
+    expect(getExpiredEventMessage()).toContain('7-day');
+  });
+});

--- a/frontend/app/api/v1/products/[id]/badge.png/route.ts
+++ b/frontend/app/api/v1/products/[id]/badge.png/route.ts
@@ -4,21 +4,22 @@ import { apiError, ErrorCode } from '@/lib/api/errors';
 import { productBadgeParamsSchema } from '@/lib/api/schemas';
 import { handleValidationError, parsePathParams } from '@/lib/api/validation';
 import { getProduct } from '@/lib/services/productReadModel';
+import { generateBadgePayload, encodeBadgePayload } from '@/lib/services/badgeService';
 
 export function OPTIONS(request: NextRequest) {
   return handleOptions(request);
 }
 
-export async function GET(
-  request: NextRequest,
-  { params }: { params: Promise<{ id: string }> },
-) {
+export async function GET(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   try {
     const { id: productId } = await parsePathParams(params, productBadgeParamsSchema);
     const product = await getProduct(productId);
 
     if (!product) {
-      return withCors(request, apiError(request, 404, ErrorCode.INVALID_PAYLOAD, 'Product not found'));
+      return withCors(
+        request,
+        apiError(request, 404, ErrorCode.INVALID_PAYLOAD, 'Product not found'),
+      );
     }
 
     const verifiedDate = new Date(product.timestamp).toLocaleDateString('en-US', {
@@ -27,47 +28,56 @@ export async function GET(
       day: 'numeric',
     });
 
-    const svg = `
-      <svg width="400" height="300" xmlns="http://www.w3.org/2000/svg">
-        <defs>
-          <linearGradient id="grad" x1="0%" y1="0%" x2="100%" y2="100%">
-            <stop offset="0%" style="stop-color:#7B2FBE;stop-opacity:1" />
-            <stop offset="100%" style="stop-color:#5A1E8C;stop-opacity:1" />
-          </linearGradient>
-        </defs>
-        <rect width="400" height="300" fill="url(#grad)"/>
-        <rect width="400" height="300" fill="none" stroke="white" stroke-width="3"/>
-        <text x="20" y="35" font-family="Arial, sans-serif" font-size="24" font-weight="bold" fill="white">
-          &#10003; Supply-Link
-        </text>
-        <text x="20" y="80" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">
-          ${escapeXml(product.name)}
-        </text>
-        <text x="20" y="110" font-family="Arial, sans-serif" font-size="14" fill="rgba(255,255,255,0.9)">
-          Origin: ${escapeXml(product.origin)}
-        </text>
-        <text x="20" y="140" font-family="Arial, sans-serif" font-size="12" fill="rgba(255,255,255,0.8)">
-          Verified: ${verifiedDate}
-        </text>
-        <rect x="280" y="20" width="100" height="100" fill="white" stroke="white" stroke-width="2"/>
-        <text x="330" y="75" font-family="Arial, sans-serif" font-size="10" fill="#7B2FBE" text-anchor="middle">
-          [QR Code]
-        </text>
-        <text x="20" y="200" font-family="Arial, sans-serif" font-size="12" fill="rgba(255,255,255,0.9)">
-          Tracked on Stellar Blockchain
-        </text>
-        <text x="20" y="225" font-family="monospace" font-size="10" fill="rgba(255,255,255,0.7)">
-          ID: ${escapeXml(productId)}
-        </text>
-        <text x="20" y="250" font-family="Arial, sans-serif" font-size="11" fill="rgba(255,255,255,0.8)">
-          Scan QR to verify full journey
-        </text>
-        <circle cx="350" cy="260" r="25" fill="rgba(255,255,255,0.2)" stroke="white" stroke-width="1"/>
-        <text x="350" y="265" font-family="Arial, sans-serif" font-size="12" font-weight="bold" fill="white" text-anchor="middle">
-          &#9733;
-        </text>
-      </svg>
-    `;
+    const badgePayload = generateBadgePayload({
+      id: productId,
+      name: product.name,
+      origin: product.origin,
+      owner: product.owner,
+      timestamp: product.timestamp,
+    });
+
+    const encodedProof = encodeBadgePayload(badgePayload);
+
+    const svg = `<svg width="400" height="300" xmlns="http://www.w3.org/2000/svg">
+  <!-- supply-link-proof:${encodedProof} -->
+  <defs>
+    <linearGradient id="grad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#7B2FBE;stop-opacity:1" />
+      <stop offset="100%" style="stop-color:#5A1E8C;stop-opacity:1" />
+    </linearGradient>
+  </defs>
+  <rect width="400" height="300" fill="url(#grad)"/>
+  <rect width="400" height="300" fill="none" stroke="white" stroke-width="3"/>
+  <text x="20" y="35" font-family="Arial, sans-serif" font-size="24" font-weight="bold" fill="white">
+    &#10003; Supply-Link
+  </text>
+  <text x="20" y="80" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">
+    ${escapeXml(product.name)}
+  </text>
+  <text x="20" y="110" font-family="Arial, sans-serif" font-size="14" fill="rgba(255,255,255,0.9)">
+    Origin: ${escapeXml(product.origin)}
+  </text>
+  <text x="20" y="140" font-family="Arial, sans-serif" font-size="12" fill="rgba(255,255,255,0.8)">
+    Verified: ${verifiedDate}
+  </text>
+  <rect x="280" y="20" width="100" height="100" fill="white" stroke="white" stroke-width="2"/>
+  <text x="330" y="75" font-family="Arial, sans-serif" font-size="10" fill="#7B2FBE" text-anchor="middle">
+    [QR Code]
+  </text>
+  <text x="20" y="200" font-family="Arial, sans-serif" font-size="12" fill="rgba(255,255,255,0.9)">
+    Tracked on Stellar Blockchain
+  </text>
+  <text x="20" y="225" font-family="monospace" font-size="10" fill="rgba(255,255,255,0.7)">
+    ID: ${escapeXml(productId)}
+  </text>
+  <text x="20" y="250" font-family="Arial, sans-serif" font-size="11" fill="rgba(255,255,255,0.8)">
+    Scan QR to verify full journey
+  </text>
+  <circle cx="350" cy="260" r="25" fill="rgba(255,255,255,0.2)" stroke="white" stroke-width="1"/>
+  <text x="350" y="265" font-family="Arial, sans-serif" font-size="12" font-weight="bold" fill="white" text-anchor="middle">
+    &#9733;
+  </text>
+</svg>`;
 
     return withCors(
       request,
@@ -76,6 +86,7 @@ export async function GET(
           'Content-Type': 'image/svg+xml',
           'Cache-Control': 'public, max-age=86400',
           'Content-Disposition': `inline; filename="supply-link-badge-${productId}.svg"`,
+          'X-Badge-Proof': badgePayload.proof,
         },
       }) as NextResponse,
     );

--- a/frontend/app/api/v1/products/[id]/events/route.ts
+++ b/frontend/app/api/v1/products/[id]/events/route.ts
@@ -15,6 +15,7 @@ import { authenticateApiRequest } from '@/lib/api/auth';
 import { withIdempotency } from '@/lib/api/idempotency';
 import { getProductById, getEventsByProductId, MOCK_EVENTS } from '@/lib/mock/products';
 import { recordRequest } from '@/lib/api/metrics';
+import { validateEventMetadata } from '@/lib/api/eventMetadataSchemas';
 import type { TrackingEvent, PaginatedResponse, EventType } from '@/lib/types';
 
 export function OPTIONS(request: NextRequest) {
@@ -92,12 +93,16 @@ async function addEvent(
     return apiError(req, 400, ErrorCode.MISSING_FIELDS, 'Missing or invalid: actor');
   }
 
-  // Validate optional metadata
+  // Validate typed metadata shape by event type
   const metadata = typeof body.metadata === 'string' ? body.metadata : '{}';
-  try {
-    JSON.parse(metadata);
-  } catch {
-    return apiError(req, 400, ErrorCode.VALIDATION_ERROR, 'metadata must be valid JSON string');
+  const metadataValidation = validateEventMetadata(body.eventType as string, metadata);
+  if (!metadataValidation.valid) {
+    return apiError(
+      req,
+      400,
+      ErrorCode.VALIDATION_ERROR,
+      `Invalid metadata: ${metadataValidation.error}`,
+    );
   }
 
   // Create new event

--- a/frontend/components/notifications/NotificationDropdown.tsx
+++ b/frontend/components/notifications/NotificationDropdown.tsx
@@ -1,14 +1,63 @@
-"use client";
+'use client';
 
-import { useRef, useState, useEffect } from "react";
-import { Bell } from "lucide-react";
-import type { Notification } from "@/lib/types";
+import { useRef, useState, useEffect } from 'react';
+import {
+  Bell,
+  CheckCircle,
+  AlertTriangle,
+  ArrowLeftRight,
+  Package,
+  XCircle,
+  Zap,
+} from 'lucide-react';
+import type { Notification, NotificationType } from '@/lib/types';
 
 const EVENT_COLORS: Record<string, string> = {
-  HARVEST: "text-green-500",
-  PROCESSING: "text-blue-500",
-  SHIPPING: "text-yellow-500",
-  RETAIL: "text-purple-500",
+  HARVEST: 'text-green-500',
+  PROCESSING: 'text-blue-500',
+  SHIPPING: 'text-yellow-500',
+  RETAIL: 'text-purple-500',
+};
+
+const NOTIFICATION_TYPE_CONFIG: Record<
+  NotificationType,
+  { icon: React.ReactNode; label: string; color: string }
+> = {
+  TRACKING_EVENT: {
+    icon: <Zap size={12} />,
+    label: 'Event',
+    color: 'text-blue-500',
+  },
+  APPROVAL_PENDING: {
+    icon: <AlertTriangle size={12} />,
+    label: 'Pending Approval',
+    color: 'text-yellow-500',
+  },
+  APPROVAL_FINALIZED: {
+    icon: <CheckCircle size={12} />,
+    label: 'Approved',
+    color: 'text-green-500',
+  },
+  APPROVAL_REJECTED: {
+    icon: <XCircle size={12} />,
+    label: 'Rejected',
+    color: 'text-red-500',
+  },
+  OWNERSHIP_CHANGED: {
+    icon: <ArrowLeftRight size={12} />,
+    label: 'Ownership',
+    color: 'text-purple-500',
+  },
+  PRODUCT_RECALLED: {
+    icon: <AlertTriangle size={12} />,
+    label: 'Recall',
+    color: 'text-red-600',
+  },
+  CONTRACT_ERROR: {
+    icon: <XCircle size={12} />,
+    label: 'Error',
+    color: 'text-red-500',
+  },
 };
 
 function timeAgo(ts: number): string {
@@ -26,17 +75,21 @@ interface Props {
   onMarkAllRead: () => void;
 }
 
-export function NotificationDropdown({ notifications, unreadCount, onMarkRead, onMarkAllRead }: Props) {
+export function NotificationDropdown({
+  notifications,
+  unreadCount,
+  onMarkRead,
+  onMarkAllRead,
+}: Props) {
   const [open, setOpen] = useState(false);
   const ref = useRef<HTMLDivElement>(null);
 
-  // Close on outside click
   useEffect(() => {
     function handler(e: MouseEvent) {
       if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
     }
-    document.addEventListener("mousedown", handler);
-    return () => document.removeEventListener("mousedown", handler);
+    document.addEventListener('mousedown', handler);
+    return () => document.removeEventListener('mousedown', handler);
   }, []);
 
   return (
@@ -49,7 +102,7 @@ export function NotificationDropdown({ notifications, unreadCount, onMarkRead, o
         <Bell size={18} />
         {unreadCount > 0 && (
           <span className="absolute -top-0.5 -right-0.5 min-w-[16px] h-4 px-0.5 rounded-full bg-red-500 text-white text-[10px] font-bold flex items-center justify-center leading-none">
-            {unreadCount > 99 ? "99+" : unreadCount}
+            {unreadCount > 99 ? '99+' : unreadCount}
           </span>
         )}
       </button>
@@ -57,7 +110,14 @@ export function NotificationDropdown({ notifications, unreadCount, onMarkRead, o
       {open && (
         <div className="absolute right-0 mt-2 w-80 rounded-lg border border-[var(--card-border)] bg-[var(--background)] shadow-lg z-50">
           <div className="flex items-center justify-between px-4 py-2.5 border-b border-[var(--card-border)]">
-            <span className="text-sm font-semibold text-[var(--foreground)]">Notifications</span>
+            <span className="text-sm font-semibold text-[var(--foreground)]">
+              Notifications
+              {unreadCount > 0 && (
+                <span className="ml-1.5 px-1.5 py-0.5 rounded-full bg-red-100 dark:bg-red-900 text-red-600 dark:text-red-300 text-[10px] font-bold">
+                  {unreadCount}
+                </span>
+              )}
+            </span>
             {unreadCount > 0 && (
               <button
                 onClick={onMarkAllRead}
@@ -74,30 +134,57 @@ export function NotificationDropdown({ notifications, unreadCount, onMarkRead, o
                 No notifications yet
               </li>
             ) : (
-              notifications.map((n) => (
-                <li
-                  key={n.id}
-                  onClick={() => onMarkRead(n.id)}
-                  className={`px-4 py-3 cursor-pointer hover:bg-[var(--muted-bg)] transition-colors ${
-                    !n.read ? "bg-[var(--muted-bg)]/50" : ""
-                  }`}
-                >
-                  <div className="flex items-start gap-2">
-                    {!n.read && (
-                      <span className="mt-1.5 w-1.5 h-1.5 rounded-full bg-blue-500 shrink-0" />
-                    )}
-                    <div className={n.read ? "ml-3.5" : ""}>
-                      <p className="text-xs font-medium text-[var(--foreground)]">
-                        <span className={EVENT_COLORS[n.eventType] ?? ""}>{n.eventType}</span>
-                        {" — "}
-                        {n.productName}
-                      </p>
-                      <p className="text-xs text-[var(--muted-foreground)] mt-0.5">{n.location}</p>
-                      <p className="text-[10px] text-[var(--muted-foreground)] mt-0.5">{timeAgo(n.timestamp)}</p>
+              notifications.map((n) => {
+                const typeConfig =
+                  NOTIFICATION_TYPE_CONFIG[n.notificationType] ??
+                  NOTIFICATION_TYPE_CONFIG.TRACKING_EVENT;
+                return (
+                  <li
+                    key={n.id}
+                    onClick={() => onMarkRead(n.id)}
+                    className={`px-4 py-3 cursor-pointer hover:bg-[var(--muted-bg)] transition-colors ${
+                      !n.read ? 'bg-[var(--muted-bg)]/50' : ''
+                    }`}
+                  >
+                    <div className="flex items-start gap-2">
+                      {!n.read && (
+                        <span className="mt-1.5 w-1.5 h-1.5 rounded-full bg-blue-500 shrink-0" />
+                      )}
+                      <div className={n.read ? 'ml-3.5 flex-1' : 'flex-1'}>
+                        <div className="flex items-center gap-1 mb-0.5">
+                          <span
+                            className={`flex items-center gap-0.5 text-[10px] font-semibold uppercase tracking-wide ${typeConfig.color}`}
+                          >
+                            {typeConfig.icon}
+                            {typeConfig.label}
+                          </span>
+                          <span className="text-[var(--muted-foreground)] text-[10px]">·</span>
+                          <span
+                            className={`text-[10px] font-medium ${EVENT_COLORS[n.eventType] ?? ''}`}
+                          >
+                            {n.eventType}
+                          </span>
+                        </div>
+                        <p className="text-xs font-medium text-[var(--foreground)] truncate">
+                          {n.productName}
+                        </p>
+                        {n.message ? (
+                          <p className="text-xs text-[var(--muted-foreground)] mt-0.5 line-clamp-2">
+                            {n.message}
+                          </p>
+                        ) : n.location ? (
+                          <p className="text-xs text-[var(--muted-foreground)] mt-0.5">
+                            {n.location}
+                          </p>
+                        ) : null}
+                        <p className="text-[10px] text-[var(--muted-foreground)] mt-0.5">
+                          {timeAgo(n.timestamp)}
+                        </p>
+                      </div>
                     </div>
-                  </div>
-                </li>
-              ))
+                  </li>
+                );
+              })
             )}
           </ul>
         </div>

--- a/frontend/components/products/PendingEventApprovalPanel.tsx
+++ b/frontend/components/products/PendingEventApprovalPanel.tsx
@@ -1,14 +1,15 @@
-"use client";
+'use client';
 
-import { useState } from "react";
-import type { PendingEvent } from "@/lib/types";
+import { useState } from 'react';
+import type { PendingEvent } from '@/lib/types';
+import { formatMultiSigError, isReplayError, isExpiredEventError } from '@/lib/utils/nonce';
 
 interface Props {
   productId: string;
   pendingEvents: PendingEvent[];
   isOwner: boolean;
-  onApprove?: (eventIndex: number) => Promise<void>;
-  onReject?: (eventIndex: number) => Promise<void>;
+  onApprove?: (pendingEventId: number) => Promise<void>;
+  onReject?: (pendingEventId: number, reason?: string) => Promise<void>;
 }
 
 export function PendingEventApprovalPanel({
@@ -18,123 +19,144 @@ export function PendingEventApprovalPanel({
   onApprove,
   onReject,
 }: Props) {
-  const [loadingIndex, setLoadingIndex] = useState<number | null>(null);
+  const [loadingId, setLoadingId] = useState<number | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [errorType, setErrorType] = useState<'replay' | 'expired' | 'generic' | null>(null);
 
   if (pendingEvents.length === 0) {
-    return (
-      <p className="text-sm text-[var(--muted)]">No pending events awaiting approval.</p>
-    );
+    return <p className="text-sm text-[var(--muted)]">No pending events awaiting approval.</p>;
   }
 
-  const handleApprove = async (index: number) => {
-    setLoadingIndex(index);
+  const handleApprove = async (pendingEventId: number) => {
+    setLoadingId(pendingEventId);
     setError(null);
+    setErrorType(null);
     try {
-      if (onApprove) {
-        await onApprove(index);
-      }
+      if (onApprove) await onApprove(pendingEventId);
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Failed to approve event");
+      const msg = formatMultiSigError(err);
+      setError(msg);
+      setErrorType(
+        isReplayError(err) ? 'replay' : isExpiredEventError(err) ? 'expired' : 'generic',
+      );
     } finally {
-      setLoadingIndex(null);
+      setLoadingId(null);
     }
   };
 
-  const handleReject = async (index: number) => {
-    setLoadingIndex(index);
+  const handleReject = async (pendingEventId: number) => {
+    setLoadingId(pendingEventId);
     setError(null);
+    setErrorType(null);
     try {
-      if (onReject) {
-        await onReject(index);
-      }
+      if (onReject) await onReject(pendingEventId);
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Failed to reject event");
+      const msg = formatMultiSigError(err);
+      setError(msg);
+      setErrorType(
+        isReplayError(err) ? 'replay' : isExpiredEventError(err) ? 'expired' : 'generic',
+      );
     } finally {
-      setLoadingIndex(null);
+      setLoadingId(null);
     }
   };
+
+  const errorBg =
+    errorType === 'replay'
+      ? 'bg-yellow-100 dark:bg-yellow-900 text-yellow-800 dark:text-yellow-200'
+      : 'bg-red-100 dark:bg-red-900 text-red-700 dark:text-red-200';
 
   return (
     <div className="space-y-4">
       {error && (
-        <div className="p-3 rounded-lg bg-red-100 dark:bg-red-900 text-red-700 dark:text-red-200 text-sm">
+        <div className={`p-3 rounded-lg text-sm ${errorBg}`}>
+          {errorType === 'replay' && <span className="font-semibold mr-1">Replay detected:</span>}
+          {errorType === 'expired' && <span className="font-semibold mr-1">Event expired:</span>}
           {error}
         </div>
       )}
 
-      {pendingEvents.map((pending, index) => (
-        <div
-          key={index}
-          className="border border-[var(--card-border)] rounded-lg p-4 bg-[var(--card-hover)]"
-        >
-          <div className="flex items-start justify-between gap-4 mb-3">
-            <div className="flex-1">
-              <p className="font-semibold text-[var(--foreground)]">
-                {pending.event.eventType}
-              </p>
-              <p className="text-sm text-[var(--muted)] mt-1">
-                Location: {pending.event.location}
-              </p>
-              <p className="text-xs text-[var(--muted)] mt-1">
-                Submitted: {new Date(pending.createdAt * 1000).toLocaleString()}
-              </p>
-            </div>
+      {pendingEvents.map((pending) => {
+        const isExpired =
+          pending.expiration !== undefined && Date.now() / 1000 > pending.expiration;
 
-            {/* Approval progress */}
-            <div className="text-right">
-              <p className="text-sm font-medium text-[var(--foreground)]">
-                {pending.approvals.length}/{pending.requiredSignatures}
-              </p>
-              <p className="text-xs text-[var(--muted)]">approvals</p>
-            </div>
-          </div>
-
-          {/* Approval bar */}
-          <div className="w-full h-2 bg-[var(--card-border)] rounded-full overflow-hidden mb-3">
-            <div
-              className="h-full bg-blue-600 dark:bg-blue-400 transition-all duration-300"
-              style={{
-                width: `${(pending.approvals.length / pending.requiredSignatures) * 100}%`,
-              }}
-            />
-          </div>
-
-          {/* Approvers list */}
-          <div className="mb-3">
-            <p className="text-xs font-semibold text-[var(--muted)] uppercase mb-2">
-              Approvals
-            </p>
-            <div className="space-y-1">
-              {pending.approvals.map((approver, i) => (
-                <p key={i} className="text-xs font-mono text-[var(--foreground)] break-all">
-                  ✓ {approver.slice(0, 8)}...{approver.slice(-8)}
+        return (
+          <div
+            key={pending.pendingEventId}
+            className="border border-[var(--card-border)] rounded-lg p-4 bg-[var(--card-hover)]"
+          >
+            <div className="flex items-start justify-between gap-4 mb-3">
+              <div className="flex-1">
+                <div className="flex items-center gap-2">
+                  <p className="font-semibold text-[var(--foreground)]">
+                    {pending.event.eventType}
+                  </p>
+                  {isExpired && (
+                    <span className="px-1.5 py-0.5 rounded text-[10px] font-semibold bg-red-100 dark:bg-red-900 text-red-600 dark:text-red-300">
+                      Expired
+                    </span>
+                  )}
+                </div>
+                <p className="text-sm text-[var(--muted)] mt-1">
+                  Location: {pending.event.location}
                 </p>
-              ))}
-            </div>
-          </div>
+                <p className="text-xs text-[var(--muted)] mt-1">
+                  Submitted: {new Date(pending.createdAt * 1000).toLocaleString()}
+                </p>
+                <p className="text-xs font-mono text-[var(--muted)] mt-0.5">
+                  Event #{pending.pendingEventId}
+                </p>
+              </div>
 
-          {/* Action buttons */}
-          {isOwner && (
-            <div className="flex gap-2">
-              <button
-                onClick={() => handleApprove(index)}
-                disabled={loadingIndex === index}
-                className="flex-1 px-3 py-2 rounded-lg bg-green-600 hover:bg-green-700 text-white text-sm font-medium disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
-              >
-                {loadingIndex === index ? "Approving..." : "Approve"}
-              </button>
-              <button
-                onClick={() => handleReject(index)}
-                disabled={loadingIndex === index}
-                className="flex-1 px-3 py-2 rounded-lg bg-red-600 hover:bg-red-700 text-white text-sm font-medium disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
-              >
-                {loadingIndex === index ? "Rejecting..." : "Reject"}
-              </button>
+              <div className="text-right">
+                <p className="text-sm font-medium text-[var(--foreground)]">
+                  {pending.approvals.length}/{pending.requiredSignatures}
+                </p>
+                <p className="text-xs text-[var(--muted)]">approvals</p>
+              </div>
             </div>
-          )}
-        </div>
-      ))}
+
+            <div className="w-full h-2 bg-[var(--card-border)] rounded-full overflow-hidden mb-3">
+              <div
+                className="h-full bg-blue-600 dark:bg-blue-400 transition-all duration-300"
+                style={{
+                  width: `${(pending.approvals.length / pending.requiredSignatures) * 100}%`,
+                }}
+              />
+            </div>
+
+            <div className="mb-3">
+              <p className="text-xs font-semibold text-[var(--muted)] uppercase mb-2">Approvals</p>
+              <div className="space-y-1">
+                {pending.approvals.map((approver, i) => (
+                  <p key={i} className="text-xs font-mono text-[var(--foreground)] break-all">
+                    ✓ {approver.slice(0, 8)}...{approver.slice(-8)}
+                  </p>
+                ))}
+              </div>
+            </div>
+
+            {isOwner && !isExpired && (
+              <div className="flex gap-2">
+                <button
+                  onClick={() => handleApprove(pending.pendingEventId)}
+                  disabled={loadingId === pending.pendingEventId}
+                  className="flex-1 px-3 py-2 rounded-lg bg-green-600 hover:bg-green-700 text-white text-sm font-medium disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+                >
+                  {loadingId === pending.pendingEventId ? 'Approving...' : 'Approve'}
+                </button>
+                <button
+                  onClick={() => handleReject(pending.pendingEventId)}
+                  disabled={loadingId === pending.pendingEventId}
+                  className="flex-1 px-3 py-2 rounded-lg bg-red-600 hover:bg-red-700 text-white text-sm font-medium disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+                >
+                  {loadingId === pending.pendingEventId ? 'Rejecting...' : 'Reject'}
+                </button>
+              </div>
+            )}
+          </div>
+        );
+      })}
     </div>
   );
 }

--- a/frontend/lib/api/eventMetadataSchemas.ts
+++ b/frontend/lib/api/eventMetadataSchemas.ts
@@ -1,0 +1,95 @@
+import { z } from 'zod';
+import type { EventType } from '@/lib/types';
+
+export const harvestMetadataSchema = z.object({
+  batchNumber: z.string().max(64).optional(),
+  harvestDate: z.string().optional(),
+  farmId: z.string().max(128).optional(),
+  quantity: z.number().positive().optional(),
+  unit: z.enum(['kg', 'lb', 'ton', 'unit']).optional(),
+  temperature: z.string().max(32).optional(),
+  humidity: z.string().max(32).optional(),
+  certifications: z.array(z.string().max(128)).max(10).optional(),
+});
+
+export const processingMetadataSchema = z.object({
+  facilityId: z.string().max(128).optional(),
+  processType: z.string().max(128).optional(),
+  processingDate: z.string().optional(),
+  batchId: z.string().max(64).optional(),
+  temperature: z.string().max(32).optional(),
+  duration: z.string().max(64).optional(),
+  qualityGrade: z.string().max(32).optional(),
+  inspector: z.string().max(128).optional(),
+});
+
+export const shippingMetadataSchema = z.object({
+  carrier: z.string().max(128).optional(),
+  trackingNumber: z.string().max(128).optional(),
+  departureDate: z.string().optional(),
+  estimatedArrival: z.string().optional(),
+  containerNumber: z.string().max(64).optional(),
+  portOfOrigin: z.string().max(256).optional(),
+  portOfDestination: z.string().max(256).optional(),
+  temperature: z.string().max(32).optional(),
+});
+
+export const retailMetadataSchema = z.object({
+  storeId: z.string().max(128).optional(),
+  shelfLocation: z.string().max(128).optional(),
+  arrivalDate: z.string().optional(),
+  expiryDate: z.string().optional(),
+  price: z.number().positive().optional(),
+  currency: z.string().max(8).optional(),
+  sku: z.string().max(128).optional(),
+  stockLevel: z.number().int().nonnegative().optional(),
+});
+
+export const eventMetadataSchemas = {
+  HARVEST: harvestMetadataSchema,
+  PROCESSING: processingMetadataSchema,
+  SHIPPING: shippingMetadataSchema,
+  RETAIL: retailMetadataSchema,
+} as const satisfies Record<EventType, z.ZodObject<z.ZodRawShape>>;
+
+export type HarvestMetadata = z.infer<typeof harvestMetadataSchema>;
+export type ProcessingMetadata = z.infer<typeof processingMetadataSchema>;
+export type ShippingMetadata = z.infer<typeof shippingMetadataSchema>;
+export type RetailMetadata = z.infer<typeof retailMetadataSchema>;
+
+export type EventMetadata =
+  | HarvestMetadata
+  | ProcessingMetadata
+  | ShippingMetadata
+  | RetailMetadata;
+
+export function validateEventMetadata(
+  eventType: string,
+  metadata: string,
+): { valid: boolean; data?: Record<string, unknown>; error?: string } {
+  const schema = eventMetadataSchemas[eventType as EventType];
+  if (!schema) {
+    return { valid: false, error: `Unknown event type: ${eventType}` };
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = metadata.trim() ? JSON.parse(metadata) : {};
+  } catch {
+    return { valid: false, error: 'Metadata must be valid JSON' };
+  }
+
+  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+    return { valid: false, error: 'Metadata must be a JSON object' };
+  }
+
+  const result = schema.safeParse(parsed);
+  if (result.success) {
+    return { valid: true, data: result.data as Record<string, unknown> };
+  }
+
+  const messages = result.error.issues
+    .map((i) => (i.path.length > 0 ? `${i.path.join('.')}: ${i.message}` : i.message))
+    .join('; ');
+  return { valid: false, error: messages };
+}

--- a/frontend/lib/hooks/useNotifications.ts
+++ b/frontend/lib/hooks/useNotifications.ts
@@ -1,17 +1,178 @@
-"use client";
+'use client';
 
-import { useEffect, useRef } from "react";
-import { useStore } from "@/lib/state/store";
-import { contractClient } from "@/lib/stellar/contract";
-import type { Notification } from "@/lib/types";
+import { useEffect, useRef } from 'react';
+import { useStore } from '@/lib/state/store';
+import { contractClient } from '@/lib/stellar/contract';
+import type { Notification, NotificationType, EventType } from '@/lib/types';
 
 const POLL_INTERVAL_MS = 30_000;
 
-export function useNotifications() {
-  const { walletAddress, products, notifications, addNotifications, markNotificationRead, markAllNotificationsRead } =
-    useStore();
+function eventTypeToNotificationType(eventType: string): NotificationType {
+  return 'TRACKING_EVENT';
+}
 
-  // Track the latest known timestamp per product to detect new events
+function buildTrackingNotification(
+  productId: string,
+  productName: string,
+  ev: {
+    eventType: string;
+    location: string;
+    actor: string;
+    timestamp: number;
+  },
+): Notification {
+  return {
+    id: `tracking-${productId}-${ev.timestamp}`,
+    productId,
+    productName,
+    eventType: ev.eventType as EventType,
+    location: ev.location,
+    actor: ev.actor,
+    timestamp: ev.timestamp,
+    read: false,
+    notificationType: 'TRACKING_EVENT',
+    message: `${ev.eventType} event recorded at ${ev.location}`,
+  };
+}
+
+export function buildOwnershipNotification(
+  productId: string,
+  productName: string,
+  newOwner: string,
+  timestamp: number,
+): Notification {
+  return {
+    id: `ownership-${productId}-${timestamp}`,
+    productId,
+    productName,
+    eventType: 'SHIPPING',
+    location: '',
+    actor: newOwner,
+    timestamp,
+    read: false,
+    notificationType: 'OWNERSHIP_CHANGED',
+    message: `Ownership transferred to ${newOwner.slice(0, 8)}...${newOwner.slice(-8)}`,
+  };
+}
+
+export function buildApprovalPendingNotification(
+  productId: string,
+  productName: string,
+  eventType: EventType,
+  location: string,
+  actor: string,
+  timestamp: number,
+  pendingEventId: number,
+): Notification {
+  return {
+    id: `approval-pending-${productId}-${pendingEventId}`,
+    productId,
+    productName,
+    eventType,
+    location,
+    actor,
+    timestamp,
+    read: false,
+    notificationType: 'APPROVAL_PENDING',
+    message: `${eventType} event awaiting approval (${location})`,
+  };
+}
+
+export function buildApprovalFinalizedNotification(
+  productId: string,
+  productName: string,
+  eventType: EventType,
+  location: string,
+  actor: string,
+  timestamp: number,
+): Notification {
+  return {
+    id: `approval-finalized-${productId}-${timestamp}`,
+    productId,
+    productName,
+    eventType,
+    location,
+    actor,
+    timestamp,
+    read: false,
+    notificationType: 'APPROVAL_FINALIZED',
+    message: `${eventType} event approved and finalized`,
+  };
+}
+
+export function buildApprovalRejectedNotification(
+  productId: string,
+  productName: string,
+  eventType: EventType,
+  location: string,
+  actor: string,
+  timestamp: number,
+  reason?: string,
+): Notification {
+  return {
+    id: `approval-rejected-${productId}-${timestamp}`,
+    productId,
+    productName,
+    eventType,
+    location,
+    actor,
+    timestamp,
+    read: false,
+    notificationType: 'APPROVAL_REJECTED',
+    message: reason ? `${eventType} event rejected: ${reason}` : `${eventType} event rejected`,
+  };
+}
+
+export function buildRecallNotification(
+  productId: string,
+  productName: string,
+  actor: string,
+  timestamp: number,
+): Notification {
+  return {
+    id: `recall-${productId}-${timestamp}`,
+    productId,
+    productName,
+    eventType: 'RETAIL',
+    location: '',
+    actor,
+    timestamp,
+    read: false,
+    notificationType: 'PRODUCT_RECALLED',
+    message: `Product ${productName} has been recalled/deactivated`,
+  };
+}
+
+export function buildContractErrorNotification(
+  productId: string,
+  productName: string,
+  errorMessage: string,
+  timestamp: number,
+): Notification {
+  return {
+    id: `error-${productId}-${timestamp}`,
+    productId,
+    productName,
+    eventType: 'HARVEST',
+    location: '',
+    actor: '',
+    timestamp,
+    read: false,
+    notificationType: 'CONTRACT_ERROR',
+    message: `Contract error: ${errorMessage}`,
+  };
+}
+
+export function useNotifications() {
+  const {
+    walletAddress,
+    products,
+    notifications,
+    addNotifications,
+    markNotificationRead,
+    markAllNotificationsRead,
+  } = useStore();
+
   const seenTimestamps = useRef<Record<string, number>>({});
 
   useEffect(() => {
@@ -24,31 +185,29 @@ export function useNotifications() {
         try {
           const events = await contractClient.getTrackingEvents(product.id, walletAddress!);
           for (const ev of events) {
-            const key = product.id;
-            const known = seenTimestamps.current[key] ?? 0;
+            const known = seenTimestamps.current[product.id] ?? 0;
             if (ev.timestamp > known) {
-              seenTimestamps.current[key] = Math.max(known, ev.timestamp);
-              incoming.push({
-                id: `${product.id}-${ev.timestamp}`,
-                productId: product.id,
-                productName: product.name,
-                eventType: ev.eventType,
-                location: ev.location,
-                actor: ev.actor,
-                timestamp: ev.timestamp,
-                read: false,
-              });
+              seenTimestamps.current[product.id] = Math.max(known, ev.timestamp);
+              incoming.push(buildTrackingNotification(product.id, product.name, ev));
             }
           }
-        } catch {
-          // silently skip failed product polls
+        } catch (err) {
+          const errorMsg = err instanceof Error ? err.message : String(err);
+          if (errorMsg.includes('recalled') || errorMsg.includes('deactivated')) {
+            incoming.push(
+              buildRecallNotification(product.id, product.name, walletAddress!, Date.now()),
+            );
+          } else if (errorMsg && !errorMsg.includes('Failed to get')) {
+            incoming.push(
+              buildContractErrorNotification(product.id, product.name, errorMsg, Date.now()),
+            );
+          }
         }
       }
 
       if (incoming.length) addNotifications(incoming);
     }
 
-    // Run immediately, then on interval
     poll();
     const id = setInterval(poll, POLL_INTERVAL_MS);
     return () => clearInterval(id);

--- a/frontend/lib/services/badgeService.ts
+++ b/frontend/lib/services/badgeService.ts
@@ -1,0 +1,102 @@
+import crypto from 'crypto';
+
+export interface BadgeProduct {
+  id: string;
+  name: string;
+  origin: string;
+  owner: string;
+  timestamp: number;
+}
+
+export interface BadgePayload {
+  productId: string;
+  productName: string;
+  origin: string;
+  owner: string;
+  registrationTimestamp: number;
+  generatedAt: number;
+  schemaVersion: number;
+  proof: string;
+}
+
+export interface BadgeVerificationResult {
+  valid: boolean;
+  payload?: BadgePayload;
+  error?: string;
+}
+
+const BADGE_SCHEMA_VERSION = 1;
+
+function computeProof(payload: Omit<BadgePayload, 'proof'>, secret: string): string {
+  const canonical = [
+    payload.productId,
+    payload.productName,
+    payload.origin,
+    payload.owner,
+    String(payload.registrationTimestamp),
+    String(payload.generatedAt),
+    String(payload.schemaVersion),
+  ].join(':');
+
+  return crypto.createHmac('sha256', secret).update(canonical).digest('hex');
+}
+
+function getBadgeSecret(): string {
+  return process.env.BADGE_SIGNING_SECRET ?? 'supply-link-badge-default-secret';
+}
+
+export function generateBadgePayload(product: BadgeProduct): BadgePayload {
+  const base: Omit<BadgePayload, 'proof'> = {
+    productId: product.id,
+    productName: product.name,
+    origin: product.origin,
+    owner: product.owner,
+    registrationTimestamp: product.timestamp,
+    generatedAt: Date.now(),
+    schemaVersion: BADGE_SCHEMA_VERSION,
+  };
+
+  const proof = computeProof(base, getBadgeSecret());
+  return { ...base, proof };
+}
+
+export function verifyBadgePayload(encoded: string): BadgeVerificationResult {
+  let payload: BadgePayload;
+  try {
+    payload = JSON.parse(Buffer.from(encoded, 'base64').toString('utf-8'));
+  } catch {
+    return { valid: false, error: 'Invalid badge payload encoding' };
+  }
+
+  const required: (keyof BadgePayload)[] = [
+    'productId',
+    'productName',
+    'origin',
+    'owner',
+    'registrationTimestamp',
+    'generatedAt',
+    'schemaVersion',
+    'proof',
+  ];
+  for (const field of required) {
+    if (payload[field] === undefined || payload[field] === null) {
+      return { valid: false, error: `Missing required field: ${field}` };
+    }
+  }
+
+  const { proof, ...base } = payload;
+  const expectedProof = computeProof(base, getBadgeSecret());
+
+  if (!crypto.timingSafeEqual(Buffer.from(proof, 'hex'), Buffer.from(expectedProof, 'hex'))) {
+    return {
+      valid: false,
+      error: 'Badge proof verification failed — payload may have been tampered with',
+    };
+  }
+
+  return { valid: true, payload };
+}
+
+export function encodeBadgePayload(payload: BadgePayload): string {
+  return Buffer.from(JSON.stringify(payload), 'utf-8').toString('base64');
+}

--- a/frontend/lib/state/store.ts
+++ b/frontend/lib/state/store.ts
@@ -17,7 +17,10 @@ export const useStore = create<SupplyLinkStore>()(
     }),
     {
       name: 'supply-link-store',
-      partialize: (state) => ({ walletAddress: state.walletAddress }),
+      partialize: (state) => ({
+        walletAddress: state.walletAddress,
+        notifications: state.notifications,
+      }),
     },
   ),
 );

--- a/frontend/lib/stellar/contract.ts
+++ b/frontend/lib/stellar/contract.ts
@@ -158,6 +158,61 @@ export const contractClient = {
     });
   },
 
+  async getNonce(actor: string, callerAddress: string): Promise<number> {
+    const simulated = await buildAndSimulateTransaction({
+      method: 'get_nonce',
+      args: [new Address(actor)],
+      callerAddress,
+    });
+
+    if (rpc.Api.isSimulationSuccess(simulated)) {
+      return Number(scValToNative(simulated.result!.retval) ?? 0);
+    }
+    throw new Error('Failed to get nonce');
+  },
+
+  async approveEvent(
+    productId: string,
+    pendingEventId: number,
+    approver: string,
+    callerAddress: string,
+  ): Promise<string> {
+    const nonce = await contractClient.getNonce(approver, callerAddress);
+    return buildSignAndSubmitTransaction({
+      method: 'approve_event',
+      args: [productId, pendingEventId, new Address(approver), nonce],
+      callerAddress,
+    });
+  },
+
+  async rejectEvent(
+    productId: string,
+    pendingEventId: number,
+    rejector: string,
+    reason: string,
+    callerAddress: string,
+  ): Promise<string> {
+    const nonce = await contractClient.getNonce(rejector, callerAddress);
+    return buildSignAndSubmitTransaction({
+      method: 'reject_event',
+      args: [productId, pendingEventId, new Address(rejector), reason, nonce],
+      callerAddress,
+    });
+  },
+
+  async getPendingEvents(productId: string, callerAddress: string): Promise<any[]> {
+    const simulated = await buildAndSimulateTransaction({
+      method: 'get_pending_events',
+      args: [productId],
+      callerAddress,
+    });
+
+    if (rpc.Api.isSimulationSuccess(simulated)) {
+      return scValToNative(simulated.result!.retval) || [];
+    }
+    throw new Error('Failed to get pending events');
+  },
+
   async deactivateProduct(productId: string, callerAddress: string): Promise<string> {
     return buildSignAndSubmitTransaction({
       method: 'deactivate_product',

--- a/frontend/lib/types/index.ts
+++ b/frontend/lib/types/index.ts
@@ -1,5 +1,5 @@
-export type EventType = "HARVEST" | "PROCESSING" | "SHIPPING" | "RETAIL";
-export type ProductStatus = "active" | "inactive";
+export type EventType = 'HARVEST' | 'PROCESSING' | 'SHIPPING' | 'RETAIL';
+export type ProductStatus = 'active' | 'inactive';
 
 export interface TemplateStage {
   label: string;
@@ -41,15 +41,26 @@ export interface TrackingEvent {
 }
 
 export interface PendingEvent {
+  pendingEventId: number;
   productId: string;
   event: TrackingEvent;
   approvals: string[];
   requiredSignatures: number;
   createdAt: number;
+  expiration?: number;
 }
 
+export type NotificationType =
+  | 'TRACKING_EVENT'
+  | 'APPROVAL_PENDING'
+  | 'APPROVAL_FINALIZED'
+  | 'APPROVAL_REJECTED'
+  | 'OWNERSHIP_CHANGED'
+  | 'PRODUCT_RECALLED'
+  | 'CONTRACT_ERROR';
+
 export interface Notification {
-  id: string; // `${productId}-${timestamp}`
+  id: string;
   productId: string;
   productName: string;
   eventType: EventType;
@@ -57,11 +68,13 @@ export interface Notification {
   actor: string;
   timestamp: number;
   read: boolean;
+  notificationType: NotificationType;
+  message?: string;
 }
 
 export interface TransactionResult {
   hash: string;
-  status: "success" | "failed" | "pending";
+  status: 'success' | 'failed' | 'pending';
   fee: string;
   timestamp: number;
 }

--- a/frontend/lib/utils/metadata.ts
+++ b/frontend/lib/utils/metadata.ts
@@ -1,14 +1,35 @@
-import { z } from "zod";
+import { z } from 'zod';
+
+export {
+  eventMetadataSchemas,
+  validateEventMetadata,
+  harvestMetadataSchema,
+  processingMetadataSchema,
+  shippingMetadataSchema,
+  retailMetadataSchema,
+} from '@/lib/api/eventMetadataSchemas';
+
+export type {
+  EventMetadata,
+  HarvestMetadata,
+  ProcessingMetadata,
+  ShippingMetadata,
+  RetailMetadata,
+} from '@/lib/api/eventMetadataSchemas';
 
 export const metadataSchema = z.record(z.string(), z.unknown());
 
-export function validateMetadata(raw: string): { valid: boolean; data?: Record<string, unknown>; error?: string } {
+export function validateMetadata(raw: string): {
+  valid: boolean;
+  data?: Record<string, unknown>;
+  error?: string;
+} {
   try {
     const parsed = JSON.parse(raw);
     const result = metadataSchema.safeParse(parsed);
     if (result.success) return { valid: true, data: result.data };
     return { valid: false, error: result.error.message };
   } catch {
-    return { valid: false, error: "Invalid JSON" };
+    return { valid: false, error: 'Invalid JSON' };
   }
 }

--- a/frontend/lib/utils/nonce.ts
+++ b/frontend/lib/utils/nonce.ts
@@ -1,0 +1,32 @@
+export const REPLAY_ERROR_CODES = ['InvalidNonce', 'invalid_nonce', 'Error(7)'] as const;
+
+export function isReplayError(error: unknown): boolean {
+  const msg = error instanceof Error ? error.message : String(error);
+  return REPLAY_ERROR_CODES.some((code) => msg.includes(code));
+}
+
+export function getReplayErrorMessage(): string {
+  return 'This transaction was already submitted. Refresh the page to get the latest nonce and try again.';
+}
+
+export function formatNonceError(error: unknown): string {
+  if (isReplayError(error)) return getReplayErrorMessage();
+  return error instanceof Error ? error.message : 'Transaction failed';
+}
+
+export function isExpiredEventError(error: unknown): boolean {
+  const msg = error instanceof Error ? error.message : String(error);
+  return msg.includes('PendingEventExpired') || msg.includes('expired');
+}
+
+export function getExpiredEventMessage(): string {
+  return 'This pending event has expired (7-day window exceeded) and can no longer be approved.';
+}
+
+export function formatMultiSigError(error: unknown): string {
+  if (isReplayError(error)) return getReplayErrorMessage();
+  if (isExpiredEventError(error)) return getExpiredEventMessage();
+  if (error instanceof Error) return error.message;
+  if (typeof error === 'string') return error;
+  return 'Multi-signature operation failed';
+}


### PR DESCRIPTION
## Summary

- **#437** — Typed Zod schemas per event type (HARVEST/PROCESSING/SHIPPING/RETAIL) enforce metadata shape before contract submission; invalid payloads are rejected at the API layer with descriptive errors
- **#438** — Extended notification center with 6 contextual types (tracking event, approval pending/finalized/rejected, ownership change, recall, contract error); notifications persisted across sessions via Zustand persist; UI updated with type icons and message details
- **#439** — Badge generation service produces HMAC-SHA256 signed payloads embedded in SVG as a comment and `X-Badge-Proof` header; `verifyBadgePayload` extracts and validates the proof using constant-time comparison
- **#440** — Contract client gains `getNonce`, `approveEvent`, `rejectEvent`, `getPendingEvents`; approval panel uses stable `pendingEventId` (not array index); replay (`InvalidNonce`) and expiry (`PendingEventExpired`) errors surface with distinct user-facing messages

## Changes

### #437 — Event metadata validation
- `frontend/lib/api/eventMetadataSchemas.ts` — per-event-type Zod schemas + `validateEventMetadata()`
- `frontend/lib/utils/metadata.ts` — re-exports typed schemas
- `frontend/app/api/v1/products/[id]/events/route.ts` — use `validateEventMetadata` instead of bare `JSON.parse`

### #438 — Advanced notification center
- `frontend/lib/types/index.ts` — `NotificationType` union, extended `Notification` interface
- `frontend/lib/hooks/useNotifications.ts` — typed builder functions exported; error-to-notification mapping in polling loop
- `frontend/lib/state/store.ts` — notifications persisted in localStorage
- `frontend/components/notifications/NotificationDropdown.tsx` — type icon, coloured label, message line per notification

### #439 — Tamper-proof badge generation
- `frontend/lib/services/badgeService.ts` — `generateBadgePayload`, `encodeBadgePayload`, `verifyBadgePayload`
- `frontend/app/api/v1/products/[id]/badge.png/route.ts` — embeds signed proof in SVG comment and response header

### #440 — Replay detection for multi-sig
- `frontend/lib/utils/nonce.ts` — `isReplayError`, `isExpiredEventError`, `formatMultiSigError`
- `frontend/lib/stellar/contract.ts` — `getNonce`, `approveEvent`, `rejectEvent`, `getPendingEvents`
- `frontend/lib/types/index.ts` — `pendingEventId` and `expiration` on `PendingEvent`
- `frontend/components/products/PendingEventApprovalPanel.tsx` — stable ID callbacks, expiry badge, replay error styling

## Test plan

- [ ] Run `npx vitest run __tests__/eventMetadataSchemas.test.ts` — 20 tests, all green
- [ ] Run `npx vitest run __tests__/notifications.test.ts` — 9 tests, all green
- [ ] Run `npx vitest run __tests__/badgeService.test.ts` — 10 tests, all green
- [ ] Run `npx vitest run __tests__/replayDetection.test.ts` — 15 tests, all green
- [ ] Submit a `HARVEST` event with `unit: "gallons"` → expect 400 with metadata error
- [ ] Submit a `RETAIL` event with `price: -5` → expect 400 with metadata error
- [ ] Open notification dropdown, verify icons and messages render correctly per type
- [ ] Refresh browser; confirm prior notifications are still visible (persistence)
- [ ] Fetch `/api/v1/products/{id}/badge.png`, confirm `supply-link-proof:` comment in SVG and `X-Badge-Proof` header
- [ ] Attempt to approve a pending event twice with the same nonce → UI shows replay error message

Closes #437
Closes #438
Closes #439
Closes #440