### PR TITLE
feat: Add hazard metadata and UI warnings. Closes #454

### DIFF
--- a/frontend/app/[locale]/(app)/products/[id]/page.tsx
+++ b/frontend/app/[locale]/(app)/products/[id]/page.tsx
@@ -46,6 +46,16 @@ export default function ProductDetailPage({ params }: Props) {
         <ProductQRCode productId={p.id} size={160} />
       </div>
 
+      {p.hazardous && (
+        <section className="border border-red-200 bg-red-50 rounded-xl p-4 mb-6">
+          <div className="flex items-center gap-2 text-red-800">
+            <span className="text-xl">⚠️</span>
+            <h2 className="text-base font-bold">Hazardous Material</h2>
+          </div>
+          <p className="text-sm text-red-700 mt-1">Classification: {p.hazardClassification}</p>
+        </section>
+      )}
+
       {/* Product Fields */}
       <section className="border border-[var(--card-border)] bg-[var(--card)] rounded-xl p-6 mb-6">
         <h2 className="text-base font-semibold mb-4 text-[var(--foreground)]">Details</h2>

--- a/frontend/app/[locale]/verify/[id]/page.tsx
+++ b/frontend/app/[locale]/verify/[id]/page.tsx
@@ -119,6 +119,12 @@ export default async function VerifyPage({ params }: Props) {
         <ProductQRCode productId={product.id} size={140} />
       </div>
 
+      {product.hazardous && (
+        <div className="inline-flex items-center gap-2 px-4 py-2 mb-6 mr-3 rounded-full border border-red-200 bg-red-100 text-sm text-red-800 font-semibold">
+          ⚠️ Hazard Warning: {product.hazardClassification}
+        </div>
+      )}
+
       {/* Verified on Stellar badge */}
       <a
         href={stellarExpertUrl}

--- a/frontend/lib/types/index.ts
+++ b/frontend/lib/types/index.ts
@@ -38,6 +38,8 @@ export interface Product {
   spoiled?: boolean;
   /** true while an on-chain transaction is in-flight */
   pending?: boolean;
+  hazardous?: boolean;
+  hazardClassification?: string;
 }
 
 export interface Batch {

--- a/smart-contract/contracts/src/lib.rs
+++ b/smart-contract/contracts/src/lib.rs
@@ -128,6 +128,9 @@ pub struct Product {
     pub recall_timestamp: u64,
     /// Schema version of this record (#392).
     pub schema_version: u32,
+    /// Hazard status (#454)
+    pub hazardous: bool,
+    pub hazard_classification: String,
 }
 
 #[contracttype]
@@ -444,6 +447,8 @@ impl SupplyLinkContract {
             active: true,
             category,
             subcategory,
+            hazardous: false,
+            hazard_classification: String::from_str(&env, ""),
         };
         env.storage()
             .persistent()
@@ -505,6 +510,8 @@ impl SupplyLinkContract {
                 recall_reason: String::from_str(&env, ""),
                 recall_timestamp: 0,
                 schema_version: SCHEMA_VERSION,
+                hazardous: false,
+                hazard_classification: String::from_str(&env, ""),
             };
             env.storage()
                 .persistent()
@@ -814,6 +821,26 @@ o            actor: caller,
             (Symbol::new(&env, "product_recalled"), product_id),
             product.recalled,
         );
+
+        true
+    }
+
+    /// Set hazard classification for a product (#454)
+    pub fn set_hazard_status(env: Env, product_id: String, hazardous: bool, classification: String) -> bool {
+        let mut product: Product = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Product(product_id.clone()))
+            .expect("product not found");
+
+        product.owner.require_auth();
+
+        product.hazardous = hazardous;
+        product.hazard_classification = classification;
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::Product(product_id), &product);
 
         true
     }

--- a/smart-contract/contracts/src/tests.rs
+++ b/smart-contract/contracts/src/tests.rs
@@ -627,3 +627,34 @@ fn test_nonce_isolated_per_actor() {
     assert_eq!(client.get_nonce(&owner1), 1);
     assert_eq!(client.get_nonce(&owner2), 1);
 }
+
+#[test]
+fn test_set_hazard_status() {
+    let env = Env::default();
+    env.mock_all_auths();
+    
+    let contract_id = env.register_contract(None, SupplyLinkContract);
+    let client = SupplyLinkContractClient::new(&env, &contract_id);
+    
+    let owner = Address::generate(&env);
+    
+    client.register_product(
+        &String::from_str(&env, "haz1"),
+        &String::from_str(&env, "Chemical"),
+        &String::from_str(&env, "Factory"),
+        &owner,
+        &1,
+        &String::from_str(&env, "cat"),
+        &String::from_str(&env, "sub"),
+    );
+    
+    client.set_hazard_status(
+        &String::from_str(&env, "haz1"),
+        &true,
+        &String::from_str(&env, "Flammable"),
+    );
+    
+    let product = client.get_product(&String::from_str(&env, "haz1"));
+    assert_eq!(product.hazardous, true);
+    assert_eq!(product.hazard_classification, String::from_str(&env, "Flammable"));
+}


### PR DESCRIPTION
## Summary

<!-- One paragraph describing what this PR does and why. -->

## Changes

<!-- Bullet list of the key changes. -->

Closes #456
Closes #454
Closes #455
Closes #453   
 

## Testing

<!-- How was this tested? Check all that apply. -->

- [ ] `cargo test` passes locally
- [ ] New tests added for new behavior
- [ ] Existing tests updated to reflect changed behavior

## Smart contract doc-behavior checklist

<!-- Required for any PR that touches smart-contract/contracts/src/. -->
<!-- Skip with justification if the PR does not touch contract source. -->

- [ ] Every changed public function's `# Panics` section lists all current panic messages exactly as they appear in code
- [ ] Every changed public function's `# Emitted Events` section lists all emitted topics with correct slot count and types
- [ ] `# Parameters` docs match the current function signature (no removed/added params left undocumented)
- [ ] Immutable-field lists in `update_*` functions include all fields not modified by that function
- [ ] `# Warning` added if the function can silently overwrite existing state
- [ ] `EVENT_SCHEMA_VERSION` version table updated if `TrackingEvent` layout changed
- [ ] `docs/event-schema-versioning.md` version history updated if schema version was bumped

## General review checklist

- [ ] No secrets or credentials committed
- [ ] Breaking changes are documented
- [ ] `RUSTDOCFLAGS="-D warnings" cargo doc` passes (enforced by CI `doc` job)
