### PR TITLE
feat: emergency alert system and certificate revocation registry

### DIFF
--- a/frontend/app/(app)/dashboard/page.tsx
+++ b/frontend/app/(app)/dashboard/page.tsx
@@ -14,6 +14,7 @@ import {
 } from "recharts";
 import { Package, Activity, CheckCircle, Clock } from "lucide-react";
 import { useDashboardData } from "@/lib/hooks/useDashboardData";
+import { DashboardAlertsBanner } from "@/components/alerts/DashboardAlertsBanner";
 
 const PIE_COLORS: Record<string, string> = {
   HARVEST: "#22c55e",
@@ -50,6 +51,9 @@ export default function DashboardPage() {
   return (
     <main className="p-6 space-y-8 max-w-7xl mx-auto">
       <h1 className="text-2xl font-bold text-[var(--foreground)]">Dashboard</h1>
+
+      {/* Emergency recall alerts — shown prominently at the top */}
+      <DashboardAlertsBanner />
 
       {/* Stat cards */}
       <div className="grid grid-cols-2 lg:grid-cols-4 gap-4">

--- a/frontend/app/(app)/products/[id]/page.tsx
+++ b/frontend/app/(app)/products/[id]/page.tsx
@@ -1,25 +1,69 @@
+"use client";
+
+import { useState } from "react";
 import { notFound } from "next/navigation";
 import Link from "next/link";
 import { getProductById } from "@/lib/mock/products";
 import ProductQRCode from "@/components/products/ProductQRCode";
 import ProductActions from "@/components/products/ProductActions";
 import { AuthorizedActorsPanel } from "@/components/products/AuthorizedActorsPanel";
+import { CertificatePanel } from "@/components/products/CertificatePanel";
+import { EmergencyAlertBanner } from "@/components/alerts/EmergencyAlertBanner";
+import { IssueRecallForm } from "@/components/alerts/IssueRecallForm";
+import { useStore } from "@/lib/state/store";
+import { contractClient } from "@/lib/stellar/contract";
+import { useToast } from "@/lib/hooks/useToast";
+import { propagateAlert } from "@/lib/alerts/notify";
 
 interface Props {
   params: { id: string };
 }
 
-export default function ProductDetailPage({ params }: Props) {
-  const product = getProductById(params.id);
+function ProductDetailClient({ productId }: { productId: string }) {
+  const product = getProductById(productId);
   if (!product) notFound();
   const p = product!;
   const registeredAt = new Date(p.timestamp).toLocaleString();
+
+  const { walletAddress, recalls, resolveRecall } = useStore();
+  const toast = useToast();
+  const [showRecallForm, setShowRecallForm] = useState(false);
+
+  const activeRecall = recalls[productId];
+  const isOwner = walletAddress && walletAddress === p.owner;
+
+  async function handleResolveRecall() {
+    if (!walletAddress) return;
+    const toastId = toast.loading("Resolving recall on-chain…");
+    try {
+      const txHash = await contractClient.resolveRecall(productId, walletAddress);
+      resolveRecall(productId, walletAddress);
+      // Notify via webhook if configured
+      const resolved = { ...activeRecall!, status: "RESOLVED" as const, resolvedAt: Date.now(), resolvedBy: walletAddress };
+      await propagateAlert(resolved, "recall.resolved");
+      toast.dismiss(toastId);
+      toast.success("Recall resolved", txHash);
+    } catch (err) {
+      toast.dismiss(toastId);
+      toast.error("Failed to resolve recall", err instanceof Error ? err.message : "Unknown error");
+    }
+  }
 
   return (
     <main className="p-8 max-w-3xl mx-auto">
       <Link href="/products" className="text-sm text-[var(--muted)] hover:underline mb-6 inline-block">
         ← Back to Products
       </Link>
+
+      {/* Emergency alert banner — shown prominently when active */}
+      {activeRecall && (
+        <div className="mb-6">
+          <EmergencyAlertBanner
+            alert={activeRecall}
+            onResolve={isOwner && activeRecall.status === "ACTIVE" ? handleResolveRecall : undefined}
+          />
+        </div>
+      )}
 
       <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-6 mb-8">
         <div>
@@ -54,6 +98,12 @@ export default function ProductDetailPage({ params }: Props) {
         <AuthorizedActorsPanel productId={p.id} initialActors={p.authorizedActors} />
       </section>
 
+      {/* Certificates */}
+      <section className="border border-[var(--card-border)] bg-[var(--card)] rounded-xl p-6 mb-6">
+        <h2 className="text-base font-semibold mb-4 text-[var(--foreground)]">Certificates &amp; Attestations</h2>
+        <CertificatePanel productId={p.id} editable={!!walletAddress} />
+      </section>
+
       {/* Ownership History */}
       <section className="border border-[var(--card-border)] bg-[var(--card)] rounded-xl p-6 mb-8">
         <h2 className="text-base font-semibold mb-4 text-[var(--foreground)]">Ownership History</h2>
@@ -78,7 +128,30 @@ export default function ProductDetailPage({ params }: Props) {
       <section>
         <h2 className="text-base font-semibold mb-4 text-[var(--foreground)]">Actions</h2>
         <ProductActions productId={p.id} />
+
+        {/* Recall action — available to owner and authorized actors */}
+        {walletAddress && !activeRecall?.status?.includes("ACTIVE") && (
+          <div className="mt-4">
+            <button
+              onClick={() => setShowRecallForm(true)}
+              className="px-4 py-2 rounded-md text-sm font-medium bg-red-600 text-white hover:bg-red-700 transition-colors"
+            >
+              Issue Recall Alert
+            </button>
+          </div>
+        )}
       </section>
+
+      {/* Issue recall form dialog */}
+      <IssueRecallForm
+        productId={p.id}
+        open={showRecallForm}
+        onOpenChange={setShowRecallForm}
+      />
     </main>
   );
+}
+
+export default function ProductDetailPage({ params }: Props) {
+  return <ProductDetailClient productId={params.id} />;
 }

--- a/frontend/app/verify/[id]/page.tsx
+++ b/frontend/app/verify/[id]/page.tsx
@@ -4,6 +4,8 @@ import { CONTRACT_ID } from "@/lib/stellar/client";
 import { EventTimeline } from "@/components/products/EventTimeline";
 import ProductQRCode from "@/components/products/ProductQRCode";
 import { ScanQRButton } from "@/components/tracking/ScanQRButton";
+import { VerifyAlertBanner } from "@/components/alerts/VerifyAlertBanner";
+import { CertificatePanel } from "@/components/products/CertificatePanel";
 
 interface Props {
   params: { id: string };
@@ -61,6 +63,9 @@ export default async function VerifyPage({ params }: Props) {
 
   return (
     <main className="p-6 max-w-2xl mx-auto">
+      {/* Emergency alert banner — shown prominently for public verifiers */}
+      <VerifyAlertBanner productId={product.id} />
+
       {/* Header */}
       <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-4 mb-6">
         <div>
@@ -100,9 +105,17 @@ export default async function VerifyPage({ params }: Props) {
       </a>
 
       {/* Event Timeline */}
-      <section className="border border-[var(--card-border)] bg-[var(--card)] rounded-xl p-6">
+      <section className="border border-[var(--card-border)] bg-[var(--card)] rounded-xl p-6 mb-6">
         <h2 className="text-base font-semibold text-[var(--foreground)] mb-5">Product Journey</h2>
         <EventTimeline events={events} />
+      </section>
+
+      {/* Certificates — read-only public view */}
+      <section className="border border-[var(--card-border)] bg-[var(--card)] rounded-xl p-6 mb-6">
+        <h2 className="text-base font-semibold text-[var(--foreground)] mb-4">
+          Certificates &amp; Attestations
+        </h2>
+        <CertificatePanel productId={product.id} editable={false} />
       </section>
 
       <div className="mt-6 flex justify-center">

--- a/frontend/components/alerts/DashboardAlertsBanner.tsx
+++ b/frontend/components/alerts/DashboardAlertsBanner.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import { useStore } from "@/lib/state/store";
+import { EmergencyAlertBanner } from "./EmergencyAlertBanner";
+
+/**
+ * Renders all active recall alerts across all products on the dashboard.
+ * Alerts can be dismissed per-session (they remain on-chain).
+ */
+export function DashboardAlertsBanner() {
+  const { recalls, dismissedAlerts, dismissAlert } = useStore();
+
+  const activeAlerts = Object.values(recalls).filter(
+    (alert) =>
+      alert.status === "ACTIVE" && !dismissedAlerts.includes(alert.productId)
+  );
+
+  if (activeAlerts.length === 0) return null;
+
+  // Sort: CRITICAL first, then HIGH, MEDIUM, LOW
+  const severityOrder = { CRITICAL: 0, HIGH: 1, MEDIUM: 2, LOW: 3 };
+  const sorted = [...activeAlerts].sort(
+    (a, b) => severityOrder[a.severity] - severityOrder[b.severity]
+  );
+
+  return (
+    <div className="space-y-3 mb-6" role="region" aria-label="Active recall alerts">
+      <h2 className="text-sm font-semibold text-[var(--foreground)] flex items-center gap-2">
+        <span className="inline-block w-2 h-2 rounded-full bg-red-500 animate-pulse" aria-hidden="true" />
+        Active Recall Alerts ({sorted.length})
+      </h2>
+      {sorted.map((alert) => (
+        <EmergencyAlertBanner
+          key={alert.productId}
+          alert={alert}
+          dismissible
+          onDismiss={() => dismissAlert(alert.productId)}
+        />
+      ))}
+    </div>
+  );
+}

--- a/frontend/components/alerts/EmergencyAlertBanner.tsx
+++ b/frontend/components/alerts/EmergencyAlertBanner.tsx
@@ -1,0 +1,124 @@
+"use client";
+
+import { useState } from "react";
+import { AlertTriangle, X, CheckCircle, ChevronDown, ChevronUp } from "lucide-react";
+import type { RecallAlert } from "@/lib/types";
+import { severityStyles, formatSeverity } from "@/lib/alerts/notify";
+
+interface EmergencyAlertBannerProps {
+  alert: RecallAlert;
+  /** Show dismiss button (for dashboard/list views). Defaults to false. */
+  dismissible?: boolean;
+  /** Show resolve action (only for product owners). */
+  onResolve?: () => void;
+  onDismiss?: () => void;
+}
+
+export function EmergencyAlertBanner({
+  alert,
+  dismissible = false,
+  onResolve,
+  onDismiss,
+}: EmergencyAlertBannerProps) {
+  const [expanded, setExpanded] = useState(alert.severity === "CRITICAL");
+
+  if (alert.status === "RESOLVED") {
+    return (
+      <div className="flex items-center gap-3 px-4 py-3 rounded-lg border border-green-200 dark:border-green-800 bg-green-50 dark:bg-green-950 text-sm text-green-800 dark:text-green-200">
+        <CheckCircle size={16} className="text-green-600 dark:text-green-400 flex-shrink-0" />
+        <span>
+          Previous recall resolved on{" "}
+          {alert.resolvedAt
+            ? new Date(alert.resolvedAt).toLocaleString()
+            : "—"}
+        </span>
+      </div>
+    );
+  }
+
+  const styles = severityStyles(alert.severity);
+  const isCritical = alert.severity === "CRITICAL";
+
+  return (
+    <div
+      role="alert"
+      aria-live={isCritical ? "assertive" : "polite"}
+      className={`rounded-xl border-2 ${styles.border} ${styles.banner} overflow-hidden`}
+    >
+      {/* Header row */}
+      <div className="flex items-start gap-3 px-4 py-3">
+        <AlertTriangle
+          size={20}
+          className={`${styles.icon} flex-shrink-0 mt-0.5 ${isCritical ? "animate-pulse" : ""}`}
+          aria-hidden="true"
+        />
+
+        <div className="flex-1 min-w-0">
+          <div className="flex flex-wrap items-center gap-2 mb-0.5">
+            <span
+              className={`text-xs font-bold px-2 py-0.5 rounded-full uppercase tracking-wide ${styles.badge}`}
+            >
+              {formatSeverity(alert.severity)} RECALL
+            </span>
+            <span className="text-xs text-[var(--muted)]">
+              Issued {new Date(alert.issuedAt).toLocaleString()}
+            </span>
+          </div>
+
+          {/* Message — always visible for CRITICAL, collapsible otherwise */}
+          {(expanded || isCritical) && (
+            <p className="text-sm font-medium text-[var(--foreground)] mt-1 break-words">
+              {alert.message}
+            </p>
+          )}
+
+          {/* Issuer */}
+          {expanded && (
+            <p className="text-xs text-[var(--muted)] font-mono mt-1 truncate">
+              Issued by: {alert.issuedBy}
+            </p>
+          )}
+        </div>
+
+        {/* Controls */}
+        <div className="flex items-center gap-1 flex-shrink-0">
+          {!isCritical && (
+            <button
+              onClick={() => setExpanded((v) => !v)}
+              className="p-1 rounded hover:bg-black/10 dark:hover:bg-white/10 transition-colors"
+              aria-label={expanded ? "Collapse alert" : "Expand alert"}
+            >
+              {expanded ? (
+                <ChevronUp size={16} className={styles.icon} />
+              ) : (
+                <ChevronDown size={16} className={styles.icon} />
+              )}
+            </button>
+          )}
+
+          {dismissible && onDismiss && (
+            <button
+              onClick={onDismiss}
+              className="p-1 rounded hover:bg-black/10 dark:hover:bg-white/10 transition-colors"
+              aria-label="Dismiss alert"
+            >
+              <X size={16} className={styles.icon} />
+            </button>
+          )}
+        </div>
+      </div>
+
+      {/* Resolve action footer */}
+      {onResolve && (
+        <div className={`px-4 py-2 border-t ${styles.border} flex justify-end`}>
+          <button
+            onClick={onResolve}
+            className="text-xs font-semibold px-3 py-1.5 rounded-md bg-[var(--foreground)] text-[var(--background)] hover:opacity-80 transition-opacity"
+          >
+            Mark as Resolved
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/components/alerts/IssueRecallForm.tsx
+++ b/frontend/components/alerts/IssueRecallForm.tsx
@@ -1,0 +1,277 @@
+"use client";
+
+import { useState } from "react";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+import * as Dialog from "@radix-ui/react-dialog";
+import { X, AlertTriangle } from "lucide-react";
+import { useStore } from "@/lib/state/store";
+import { useToast } from "@/lib/hooks/useToast";
+import { contractClient } from "@/lib/stellar/contract";
+import { propagateAlert } from "@/lib/alerts/notify";
+import type { AlertSeverity, AlertDistributionSettings } from "@/lib/types";
+
+const schema = z.object({
+  severity: z.enum(["LOW", "MEDIUM", "HIGH", "CRITICAL"]),
+  message: z.string().min(10, "Message must be at least 10 characters"),
+  webhookUrl: z
+    .string()
+    .url("Must be a valid URL")
+    .optional()
+    .or(z.literal("")),
+  notifyOwner: z.boolean(),
+  notifyActors: z.boolean(),
+  broadcastPublic: z.boolean(),
+});
+
+type FormValues = z.infer<typeof schema>;
+
+interface IssueRecallFormProps {
+  productId: string;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+const SEVERITY_OPTIONS: { value: AlertSeverity; label: string; description: string }[] = [
+  { value: "LOW", label: "Low", description: "Minor issue, monitor situation" },
+  { value: "MEDIUM", label: "Medium", description: "Moderate concern, notify stakeholders" },
+  { value: "HIGH", label: "High", description: "Serious issue, immediate action needed" },
+  { value: "CRITICAL", label: "Critical", description: "Emergency — stop distribution immediately" },
+];
+
+export function IssueRecallForm({ productId, open, onOpenChange }: IssueRecallFormProps) {
+  const { walletAddress, setRecall } = useStore();
+  const toast = useToast();
+  const [pending, setPending] = useState(false);
+
+  const {
+    register,
+    handleSubmit,
+    reset,
+    watch,
+    formState: { errors },
+  } = useForm<FormValues>({
+    resolver: zodResolver(schema),
+    defaultValues: {
+      severity: "HIGH",
+      message: "",
+      webhookUrl: "",
+      notifyOwner: true,
+      notifyActors: true,
+      broadcastPublic: false,
+    },
+  });
+
+  const severity = watch("severity");
+
+  async function onSubmit(values: FormValues) {
+    if (!walletAddress) {
+      toast.error("Wallet not connected", "Connect your Freighter wallet first.");
+      return;
+    }
+
+    setPending(true);
+    const toastId = toast.loading("Issuing recall alert on-chain…");
+
+    try {
+      const txHash = await contractClient.issueRecall(
+        productId,
+        walletAddress,
+        values.severity as AlertSeverity,
+        values.message
+      );
+
+      const distribution: AlertDistributionSettings = {
+        webhookUrl: values.webhookUrl || undefined,
+        notifyOwner: values.notifyOwner,
+        notifyActors: values.notifyActors,
+        broadcastPublic: values.broadcastPublic,
+      };
+
+      const alert = {
+        productId,
+        severity: values.severity as AlertSeverity,
+        message: values.message,
+        issuedBy: walletAddress,
+        issuedAt: Date.now(),
+        status: "ACTIVE" as const,
+        distribution,
+      };
+
+      // Update local store
+      setRecall(productId, alert);
+
+      // Propagate via configured channels
+      const notifyResult = await propagateAlert(alert, "recall.issued");
+
+      toast.dismiss(toastId);
+      toast.success("Recall alert issued", txHash);
+
+      if (notifyResult.webhookError) {
+        toast.error("Webhook delivery failed", notifyResult.webhookError);
+      }
+
+      reset();
+      onOpenChange(false);
+    } catch (err) {
+      toast.dismiss(toastId);
+      toast.error(
+        "Failed to issue recall",
+        err instanceof Error ? err.message : "Unknown error"
+      );
+    } finally {
+      setPending(false);
+    }
+  }
+
+  const severityColors: Record<AlertSeverity, string> = {
+    LOW: "border-blue-400 bg-blue-50 dark:bg-blue-950",
+    MEDIUM: "border-yellow-400 bg-yellow-50 dark:bg-yellow-950",
+    HIGH: "border-orange-400 bg-orange-50 dark:bg-orange-950",
+    CRITICAL: "border-red-500 bg-red-50 dark:bg-red-950",
+  };
+
+  return (
+    <Dialog.Root open={open} onOpenChange={onOpenChange}>
+      <Dialog.Portal>
+        <Dialog.Overlay className="fixed inset-0 bg-black/50 z-50" />
+        <Dialog.Content className="fixed left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 z-50 w-full max-w-lg bg-[var(--card)] border border-[var(--card-border)] rounded-xl shadow-2xl p-6 focus:outline-none">
+          <div className="flex items-center justify-between mb-5">
+            <div className="flex items-center gap-2">
+              <AlertTriangle size={20} className="text-red-500" aria-hidden="true" />
+              <Dialog.Title className="text-lg font-semibold text-[var(--foreground)]">
+                Issue Recall Alert
+              </Dialog.Title>
+            </div>
+            <Dialog.Close asChild>
+              <button
+                className="p-1 rounded hover:bg-[var(--muted-bg)] text-[var(--muted)] transition-colors"
+                aria-label="Close"
+              >
+                <X size={18} />
+              </button>
+            </Dialog.Close>
+          </div>
+
+          <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+            {/* Severity */}
+            <div>
+              <label className="block text-sm font-medium text-[var(--foreground)] mb-2">
+                Severity Level
+              </label>
+              <div className="grid grid-cols-2 gap-2">
+                {SEVERITY_OPTIONS.map((opt) => (
+                  <label
+                    key={opt.value}
+                    className={`flex flex-col gap-0.5 p-3 rounded-lg border-2 cursor-pointer transition-colors ${
+                      severity === opt.value
+                        ? severityColors[opt.value]
+                        : "border-[var(--card-border)] hover:border-[var(--muted)]"
+                    }`}
+                  >
+                    <input
+                      type="radio"
+                      value={opt.value}
+                      {...register("severity")}
+                      className="sr-only"
+                    />
+                    <span className="text-sm font-semibold text-[var(--foreground)]">
+                      {opt.label}
+                    </span>
+                    <span className="text-xs text-[var(--muted)]">{opt.description}</span>
+                  </label>
+                ))}
+              </div>
+              {errors.severity && (
+                <p className="text-xs text-red-500 mt-1">{errors.severity.message}</p>
+              )}
+            </div>
+
+            {/* Message */}
+            <div>
+              <label
+                htmlFor="recall-message"
+                className="block text-sm font-medium text-[var(--foreground)] mb-1"
+              >
+                Alert Message
+              </label>
+              <textarea
+                id="recall-message"
+                rows={3}
+                placeholder="Describe the safety issue or recall reason in detail…"
+                className="w-full border border-[var(--card-border)] bg-[var(--background)] text-[var(--foreground)] rounded-md p-3 text-sm resize-none focus:outline-none focus:ring-2 focus:ring-[var(--primary)]"
+                {...register("message")}
+              />
+              {errors.message && (
+                <p className="text-xs text-red-500 mt-1">{errors.message.message}</p>
+              )}
+            </div>
+
+            {/* Distribution settings */}
+            <div className="border border-[var(--card-border)] rounded-lg p-4 space-y-3">
+              <p className="text-sm font-medium text-[var(--foreground)]">
+                Distribution Settings
+              </p>
+
+              <div className="space-y-2">
+                {[
+                  { name: "notifyOwner" as const, label: "Notify product owner" },
+                  { name: "notifyActors" as const, label: "Notify authorized actors" },
+                  { name: "broadcastPublic" as const, label: "Broadcast publicly (verification page)" },
+                ].map(({ name, label }) => (
+                  <label key={name} className="flex items-center gap-2 cursor-pointer">
+                    <input
+                      type="checkbox"
+                      {...register(name)}
+                      className="w-4 h-4 rounded border-[var(--card-border)] accent-[var(--primary)]"
+                    />
+                    <span className="text-sm text-[var(--foreground)]">{label}</span>
+                  </label>
+                ))}
+              </div>
+
+              <div>
+                <label
+                  htmlFor="webhook-url"
+                  className="block text-xs font-medium text-[var(--muted)] mb-1"
+                >
+                  Webhook URL (optional)
+                </label>
+                <input
+                  id="webhook-url"
+                  type="url"
+                  placeholder="https://your-system.example.com/webhooks/recall"
+                  className="w-full border border-[var(--card-border)] bg-[var(--background)] text-[var(--foreground)] rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-[var(--primary)]"
+                  {...register("webhookUrl")}
+                />
+                {errors.webhookUrl && (
+                  <p className="text-xs text-red-500 mt-1">{errors.webhookUrl.message}</p>
+                )}
+              </div>
+            </div>
+
+            {/* Actions */}
+            <div className="flex justify-end gap-3 pt-1">
+              <Dialog.Close asChild>
+                <button
+                  type="button"
+                  className="px-4 py-2 text-sm rounded-md border border-[var(--card-border)] hover:bg-[var(--muted-bg)] text-[var(--foreground)] transition-colors"
+                >
+                  Cancel
+                </button>
+              </Dialog.Close>
+              <button
+                type="submit"
+                disabled={pending}
+                className="px-4 py-2 text-sm rounded-md bg-red-600 text-white hover:bg-red-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors font-medium"
+              >
+                {pending ? "Issuing…" : "Issue Recall Alert"}
+              </button>
+            </div>
+          </form>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}

--- a/frontend/components/alerts/VerifyAlertBanner.tsx
+++ b/frontend/components/alerts/VerifyAlertBanner.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import { useStore } from "@/lib/state/store";
+import { EmergencyAlertBanner } from "./EmergencyAlertBanner";
+
+interface VerifyAlertBannerProps {
+  productId: string;
+}
+
+/**
+ * Public-facing alert banner for the verification page.
+ * Reads recall state from the store (populated when the product owner
+ * issues a recall with broadcastPublic: true).
+ */
+export function VerifyAlertBanner({ productId }: VerifyAlertBannerProps) {
+  const { recalls } = useStore();
+  const alert = recalls[productId];
+
+  if (!alert || alert.status !== "ACTIVE") return null;
+  if (!alert.distribution.broadcastPublic) return null;
+
+  return (
+    <div className="mb-6">
+      <EmergencyAlertBanner alert={alert} />
+    </div>
+  );
+}

--- a/frontend/components/products/CertificatePanel.tsx
+++ b/frontend/components/products/CertificatePanel.tsx
@@ -1,0 +1,442 @@
+"use client";
+
+import { useState } from "react";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+import { ShieldCheck, ShieldX, ShieldAlert, Plus, X } from "lucide-react";
+import * as Dialog from "@radix-ui/react-dialog";
+import type { Certificate } from "@/lib/types";
+import { useStore } from "@/lib/state/store";
+import { useToast } from "@/lib/hooks/useToast";
+import { contractClient } from "@/lib/stellar/contract";
+
+// ── Certificate status badge ──────────────────────────────────────────────────
+
+function CertStatusBadge({ status }: { status: Certificate["status"] }) {
+  if (status === "VALID") {
+    return (
+      <span className="inline-flex items-center gap-1 text-xs font-semibold px-2 py-0.5 rounded-full bg-green-100 text-green-700 dark:bg-green-900 dark:text-green-300">
+        <ShieldCheck size={12} aria-hidden="true" />
+        Valid
+      </span>
+    );
+  }
+  if (status === "REVOKED") {
+    return (
+      <span className="inline-flex items-center gap-1 text-xs font-semibold px-2 py-0.5 rounded-full bg-red-100 text-red-700 dark:bg-red-900 dark:text-red-300">
+        <ShieldX size={12} aria-hidden="true" />
+        Revoked
+      </span>
+    );
+  }
+  return (
+    <span className="inline-flex items-center gap-1 text-xs font-semibold px-2 py-0.5 rounded-full bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400">
+      <ShieldAlert size={12} aria-hidden="true" />
+      Expired
+    </span>
+  );
+}
+
+// ── Revoke certificate form ───────────────────────────────────────────────────
+
+const revokeSchema = z.object({
+  reason: z.string().min(5, "Reason must be at least 5 characters"),
+});
+type RevokeFormValues = z.infer<typeof revokeSchema>;
+
+interface RevokeCertDialogProps {
+  cert: Certificate;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+function RevokeCertDialog({ cert, open, onOpenChange }: RevokeCertDialogProps) {
+  const { walletAddress, revokeCertificate } = useStore();
+  const toast = useToast();
+  const [pending, setPending] = useState(false);
+
+  const {
+    register,
+    handleSubmit,
+    reset,
+    formState: { errors },
+  } = useForm<RevokeFormValues>({ resolver: zodResolver(revokeSchema) });
+
+  async function onSubmit(values: RevokeFormValues) {
+    if (!walletAddress) {
+      toast.error("Wallet not connected");
+      return;
+    }
+    setPending(true);
+    const toastId = toast.loading("Revoking certificate on-chain…");
+    try {
+      const txHash = await contractClient.revokeCertificate(
+        cert.id,
+        walletAddress,
+        values.reason
+      );
+      revokeCertificate(cert.id, walletAddress, values.reason);
+      toast.dismiss(toastId);
+      toast.success("Certificate revoked", txHash);
+      reset();
+      onOpenChange(false);
+    } catch (err) {
+      toast.dismiss(toastId);
+      toast.error(
+        "Failed to revoke certificate",
+        err instanceof Error ? err.message : "Unknown error"
+      );
+    } finally {
+      setPending(false);
+    }
+  }
+
+  return (
+    <Dialog.Root open={open} onOpenChange={onOpenChange}>
+      <Dialog.Portal>
+        <Dialog.Overlay className="fixed inset-0 bg-black/50 z-50" />
+        <Dialog.Content className="fixed left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 z-50 w-full max-w-md bg-[var(--card)] border border-[var(--card-border)] rounded-xl shadow-2xl p-6 focus:outline-none">
+          <div className="flex items-center justify-between mb-4">
+            <Dialog.Title className="text-base font-semibold text-[var(--foreground)]">
+              Revoke Certificate
+            </Dialog.Title>
+            <Dialog.Close asChild>
+              <button className="p-1 rounded hover:bg-[var(--muted-bg)] text-[var(--muted)]" aria-label="Close">
+                <X size={16} />
+              </button>
+            </Dialog.Close>
+          </div>
+
+          <p className="text-sm text-[var(--muted)] mb-4">
+            Revoking <span className="font-semibold text-[var(--foreground)]">{cert.certType}</span>{" "}
+            certificate <span className="font-mono text-xs">{cert.id}</span>. This action is
+            recorded on-chain and cannot be undone.
+          </p>
+
+          <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+            <div>
+              <label
+                htmlFor="revoke-reason"
+                className="block text-sm font-medium text-[var(--foreground)] mb-1"
+              >
+                Revocation Reason
+              </label>
+              <textarea
+                id="revoke-reason"
+                rows={3}
+                placeholder="Explain why this certificate is being revoked…"
+                className="w-full border border-[var(--card-border)] bg-[var(--background)] text-[var(--foreground)] rounded-md p-3 text-sm resize-none focus:outline-none focus:ring-2 focus:ring-red-500"
+                {...register("reason")}
+              />
+              {errors.reason && (
+                <p className="text-xs text-red-500 mt-1">{errors.reason.message}</p>
+              )}
+            </div>
+
+            <div className="flex justify-end gap-3">
+              <Dialog.Close asChild>
+                <button
+                  type="button"
+                  className="px-4 py-2 text-sm rounded-md border border-[var(--card-border)] hover:bg-[var(--muted-bg)] text-[var(--foreground)]"
+                >
+                  Cancel
+                </button>
+              </Dialog.Close>
+              <button
+                type="submit"
+                disabled={pending}
+                className="px-4 py-2 text-sm rounded-md bg-red-600 text-white hover:bg-red-700 disabled:opacity-50 font-medium"
+              >
+                {pending ? "Revoking…" : "Revoke Certificate"}
+              </button>
+            </div>
+          </form>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}
+
+// ── Issue certificate form ────────────────────────────────────────────────────
+
+const issueSchema = z.object({
+  certId: z.string().min(3, "Certificate ID is required"),
+  certType: z.string().min(2, "Certificate type is required"),
+  expiresAt: z.string().optional(),
+  metadata: z.string().optional(),
+});
+type IssueFormValues = z.infer<typeof issueSchema>;
+
+const CERT_TYPES = ["ORGANIC", "FAIR_TRADE", "ISO_9001", "HALAL", "KOSHER", "NON_GMO", "CUSTOM"];
+
+interface IssueCertDialogProps {
+  productId: string;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+function IssueCertDialog({ productId, open, onOpenChange }: IssueCertDialogProps) {
+  const { walletAddress, addCertificate } = useStore();
+  const toast = useToast();
+  const [pending, setPending] = useState(false);
+
+  const {
+    register,
+    handleSubmit,
+    reset,
+    formState: { errors },
+  } = useForm<IssueFormValues>({
+    defaultValues: {
+      certId: `cert-${crypto.randomUUID().slice(0, 8)}`,
+      certType: "ORGANIC",
+      metadata: "{}",
+    },
+  });
+
+  async function onSubmit(values: IssueFormValues) {
+    if (!walletAddress) {
+      toast.error("Wallet not connected");
+      return;
+    }
+    setPending(true);
+    const toastId = toast.loading("Issuing certificate on-chain…");
+    try {
+      const expiresAt = values.expiresAt
+        ? new Date(values.expiresAt).getTime()
+        : 0;
+
+      const txHash = await contractClient.issueCertificate(
+        values.certId,
+        productId,
+        walletAddress,
+        values.certType,
+        expiresAt,
+        values.metadata || "{}"
+      );
+
+      addCertificate({
+        id: values.certId,
+        productId,
+        certType: values.certType,
+        issuedBy: walletAddress,
+        issuedAt: Date.now(),
+        expiresAt: expiresAt || undefined,
+        metadata: values.metadata || "{}",
+        status: "VALID",
+      });
+
+      toast.dismiss(toastId);
+      toast.success(`Certificate "${values.certType}" issued`, txHash);
+      reset({ certId: `cert-${crypto.randomUUID().slice(0, 8)}`, certType: "ORGANIC", metadata: "{}" });
+      onOpenChange(false);
+    } catch (err) {
+      toast.dismiss(toastId);
+      toast.error(
+        "Failed to issue certificate",
+        err instanceof Error ? err.message : "Unknown error"
+      );
+    } finally {
+      setPending(false);
+    }
+  }
+
+  return (
+    <Dialog.Root open={open} onOpenChange={onOpenChange}>
+      <Dialog.Portal>
+        <Dialog.Overlay className="fixed inset-0 bg-black/50 z-50" />
+        <Dialog.Content className="fixed left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 z-50 w-full max-w-md bg-[var(--card)] border border-[var(--card-border)] rounded-xl shadow-2xl p-6 focus:outline-none">
+          <div className="flex items-center justify-between mb-4">
+            <Dialog.Title className="text-base font-semibold text-[var(--foreground)]">
+              Issue Certificate
+            </Dialog.Title>
+            <Dialog.Close asChild>
+              <button className="p-1 rounded hover:bg-[var(--muted-bg)] text-[var(--muted)]" aria-label="Close">
+                <X size={16} />
+              </button>
+            </Dialog.Close>
+          </div>
+
+          <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+            <div>
+              <label className="block text-sm font-medium text-[var(--foreground)] mb-1">
+                Certificate ID
+              </label>
+              <input
+                type="text"
+                className="w-full border border-[var(--card-border)] bg-[var(--background)] text-[var(--foreground)] rounded-md px-3 py-2 text-sm font-mono focus:outline-none focus:ring-2 focus:ring-[var(--primary)]"
+                {...register("certId")}
+              />
+              {errors.certId && (
+                <p className="text-xs text-red-500 mt-1">{errors.certId.message}</p>
+              )}
+            </div>
+
+            <div>
+              <label className="block text-sm font-medium text-[var(--foreground)] mb-1">
+                Certificate Type
+              </label>
+              <select
+                className="w-full border border-[var(--card-border)] bg-[var(--background)] text-[var(--foreground)] rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-[var(--primary)]"
+                {...register("certType")}
+              >
+                {CERT_TYPES.map((t) => (
+                  <option key={t} value={t}>{t}</option>
+                ))}
+              </select>
+            </div>
+
+            <div>
+              <label className="block text-sm font-medium text-[var(--foreground)] mb-1">
+                Expiry Date (optional)
+              </label>
+              <input
+                type="date"
+                className="w-full border border-[var(--card-border)] bg-[var(--background)] text-[var(--foreground)] rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-[var(--primary)]"
+                {...register("expiresAt")}
+              />
+            </div>
+
+            <div>
+              <label className="block text-sm font-medium text-[var(--foreground)] mb-1">
+                Metadata (JSON)
+              </label>
+              <textarea
+                rows={2}
+                placeholder='{"issuer": "Certifying Body", "standard": "EU Organic"}'
+                className="w-full border border-[var(--card-border)] bg-[var(--background)] text-[var(--foreground)] rounded-md p-3 text-sm font-mono resize-none focus:outline-none focus:ring-2 focus:ring-[var(--primary)]"
+                {...register("metadata")}
+              />
+            </div>
+
+            <div className="flex justify-end gap-3">
+              <Dialog.Close asChild>
+                <button
+                  type="button"
+                  className="px-4 py-2 text-sm rounded-md border border-[var(--card-border)] hover:bg-[var(--muted-bg)] text-[var(--foreground)]"
+                >
+                  Cancel
+                </button>
+              </Dialog.Close>
+              <button
+                type="submit"
+                disabled={pending}
+                className="px-4 py-2 text-sm rounded-md bg-[var(--primary)] text-[var(--primary-fg)] hover:opacity-90 disabled:opacity-50 font-medium"
+              >
+                {pending ? "Issuing…" : "Issue Certificate"}
+              </button>
+            </div>
+          </form>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}
+
+// ── Main CertificatePanel ─────────────────────────────────────────────────────
+
+interface CertificatePanelProps {
+  productId: string;
+  /** When true, shows issue/revoke actions (owner/actor view). */
+  editable?: boolean;
+}
+
+export function CertificatePanel({ productId, editable = false }: CertificatePanelProps) {
+  const { certificates } = useStore();
+  const [revokeTarget, setRevokeTarget] = useState<Certificate | null>(null);
+  const [showIssueForm, setShowIssueForm] = useState(false);
+
+  const productCerts = certificates.filter((c) => c.productId === productId);
+
+  return (
+    <div>
+      {productCerts.length === 0 ? (
+        <p className="text-sm text-[var(--muted)]">No certificates issued for this product.</p>
+      ) : (
+        <ul className="space-y-3">
+          {productCerts.map((cert) => (
+            <li
+              key={cert.id}
+              className={`rounded-lg border p-4 ${
+                cert.status === "REVOKED"
+                  ? "border-red-200 dark:border-red-800 bg-red-50/50 dark:bg-red-950/30"
+                  : "border-[var(--card-border)] bg-[var(--background)]"
+              }`}
+            >
+              <div className="flex items-start justify-between gap-3">
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-center gap-2 flex-wrap mb-1">
+                    <span className="text-sm font-semibold text-[var(--foreground)]">
+                      {cert.certType}
+                    </span>
+                    <CertStatusBadge status={cert.status} />
+                  </div>
+
+                  <p className="text-xs font-mono text-[var(--muted)] truncate">
+                    ID: {cert.id}
+                  </p>
+                  <p className="text-xs text-[var(--muted)] mt-0.5">
+                    Issued: {new Date(cert.issuedAt).toLocaleDateString()}
+                    {cert.expiresAt
+                      ? ` · Expires: ${new Date(cert.expiresAt).toLocaleDateString()}`
+                      : ""}
+                  </p>
+                  <p className="text-xs font-mono text-[var(--muted)] mt-0.5 truncate">
+                    By: {cert.issuedBy}
+                  </p>
+
+                  {cert.status === "REVOKED" && cert.revocationReason && (
+                    <div className="mt-2 text-xs text-red-700 dark:text-red-300 bg-red-100 dark:bg-red-900/50 rounded px-2 py-1">
+                      <span className="font-semibold">Revocation reason:</span>{" "}
+                      {cert.revocationReason}
+                      {cert.revokedAt && (
+                        <span className="ml-1 text-red-500">
+                          ({new Date(cert.revokedAt).toLocaleDateString()})
+                        </span>
+                      )}
+                    </div>
+                  )}
+                </div>
+
+                {editable && cert.status === "VALID" && (
+                  <button
+                    onClick={() => setRevokeTarget(cert)}
+                    className="flex-shrink-0 text-xs px-2 py-1 rounded border border-red-300 text-red-600 hover:bg-red-50 dark:hover:bg-red-950 transition-colors"
+                  >
+                    Revoke
+                  </button>
+                )}
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {editable && (
+        <button
+          onClick={() => setShowIssueForm(true)}
+          className="mt-4 flex items-center gap-1.5 text-sm text-[var(--primary)] hover:underline"
+        >
+          <Plus size={14} aria-hidden="true" />
+          Issue New Certificate
+        </button>
+      )}
+
+      {/* Revoke dialog */}
+      {revokeTarget && (
+        <RevokeCertDialog
+          cert={revokeTarget}
+          open={!!revokeTarget}
+          onOpenChange={(open) => { if (!open) setRevokeTarget(null); }}
+        />
+      )}
+
+      {/* Issue dialog */}
+      <IssueCertDialog
+        productId={productId}
+        open={showIssueForm}
+        onOpenChange={setShowIssueForm}
+      />
+    </div>
+  );
+}

--- a/frontend/lib/alerts/__tests__/notify.test.ts
+++ b/frontend/lib/alerts/__tests__/notify.test.ts
@@ -1,0 +1,221 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  dispatchWebhook,
+  propagateAlert,
+  formatSeverity,
+  severityStyles,
+  type WebhookPayload,
+} from "../notify";
+import type { RecallAlert } from "@/lib/types";
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function makeAlert(
+  overrides: Partial<RecallAlert> = {}
+): RecallAlert {
+  return {
+    productId: "prod-001",
+    severity: "CRITICAL",
+    message: "Contamination detected in batch #42",
+    issuedBy: "GABC1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ",
+    issuedAt: 1710000000000,
+    status: "ACTIVE",
+    distribution: {
+      webhookUrl: "https://example.com/webhook",
+      notifyOwner: true,
+      notifyActors: true,
+      broadcastPublic: true,
+    },
+    ...overrides,
+  };
+}
+
+// ── dispatchWebhook ───────────────────────────────────────────────────────────
+
+describe("dispatchWebhook", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns ok:true on a 200 response", async () => {
+    global.fetch = vi.fn().mockResolvedValue({ ok: true, status: 200 });
+
+    const payload: WebhookPayload = {
+      event: "recall.issued",
+      alert: makeAlert(),
+      timestamp: Date.now(),
+    };
+
+    const result = await dispatchWebhook("https://example.com/hook", payload);
+    expect(result.ok).toBe(true);
+    expect(result.error).toBeUndefined();
+  });
+
+  it("returns ok:false with error message on non-2xx response", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 500,
+      statusText: "Internal Server Error",
+    });
+
+    const payload: WebhookPayload = {
+      event: "recall.issued",
+      alert: makeAlert(),
+      timestamp: Date.now(),
+    };
+
+    const result = await dispatchWebhook("https://example.com/hook", payload);
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain("500");
+  });
+
+  it("returns ok:false with error message on network failure", async () => {
+    global.fetch = vi.fn().mockRejectedValue(new Error("Network unreachable"));
+
+    const payload: WebhookPayload = {
+      event: "recall.issued",
+      alert: makeAlert(),
+      timestamp: Date.now(),
+    };
+
+    const result = await dispatchWebhook("https://example.com/hook", payload);
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe("Network unreachable");
+  });
+
+  it("sends correct headers", async () => {
+    const mockFetch = vi.fn().mockResolvedValue({ ok: true, status: 200 });
+    global.fetch = mockFetch;
+
+    const alert = makeAlert({ severity: "HIGH" });
+    const payload: WebhookPayload = {
+      event: "recall.issued",
+      alert,
+      timestamp: Date.now(),
+    };
+
+    await dispatchWebhook("https://example.com/hook", payload);
+
+    const [, options] = mockFetch.mock.calls[0];
+    expect(options.headers["X-Supply-Link-Event"]).toBe("recall.issued");
+    expect(options.headers["X-Supply-Link-Severity"]).toBe("HIGH");
+    expect(options.method).toBe("POST");
+  });
+});
+
+// ── propagateAlert ────────────────────────────────────────────────────────────
+
+describe("propagateAlert", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("dispatches webhook when webhookUrl is set", async () => {
+    global.fetch = vi.fn().mockResolvedValue({ ok: true, status: 200 });
+
+    const alert = makeAlert();
+    const result = await propagateAlert(alert, "recall.issued");
+
+    expect(result.webhookSent).toBe(true);
+    expect(result.webhookError).toBeUndefined();
+    expect(global.fetch).toHaveBeenCalledOnce();
+  });
+
+  it("skips webhook when no webhookUrl is configured", async () => {
+    global.fetch = vi.fn();
+
+    const alert = makeAlert({
+      distribution: {
+        notifyOwner: true,
+        notifyActors: true,
+        broadcastPublic: false,
+      },
+    });
+
+    const result = await propagateAlert(alert, "recall.issued");
+
+    expect(result.webhookSent).toBe(false);
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it("captures webhook error in result", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 503,
+      statusText: "Service Unavailable",
+    });
+
+    const alert = makeAlert();
+    const result = await propagateAlert(alert, "recall.issued");
+
+    expect(result.webhookSent).toBe(false);
+    expect(result.webhookError).toContain("503");
+  });
+
+  it("defaults event to recall.issued", async () => {
+    const mockFetch = vi.fn().mockResolvedValue({ ok: true, status: 200 });
+    global.fetch = mockFetch;
+
+    const alert = makeAlert();
+    await propagateAlert(alert);
+
+    const [, options] = mockFetch.mock.calls[0];
+    const body = JSON.parse(options.body);
+    expect(body.event).toBe("recall.issued");
+  });
+});
+
+// ── formatSeverity ────────────────────────────────────────────────────────────
+
+describe("formatSeverity", () => {
+  it("formats CRITICAL with emoji prefix", () => {
+    expect(formatSeverity("CRITICAL")).toContain("CRITICAL");
+    expect(formatSeverity("CRITICAL")).toContain("🚨");
+  });
+
+  it("formats HIGH with warning emoji", () => {
+    expect(formatSeverity("HIGH")).toContain("HIGH");
+    expect(formatSeverity("HIGH")).toContain("⚠️");
+  });
+
+  it("formats MEDIUM", () => {
+    expect(formatSeverity("MEDIUM")).toContain("MEDIUM");
+  });
+
+  it("formats LOW", () => {
+    expect(formatSeverity("LOW")).toContain("LOW");
+  });
+});
+
+// ── severityStyles ────────────────────────────────────────────────────────────
+
+describe("severityStyles", () => {
+  it("returns red styles for CRITICAL", () => {
+    const styles = severityStyles("CRITICAL");
+    expect(styles.badge).toContain("red");
+    expect(styles.banner).toContain("red");
+  });
+
+  it("returns orange styles for HIGH", () => {
+    const styles = severityStyles("HIGH");
+    expect(styles.badge).toContain("orange");
+  });
+
+  it("returns yellow styles for MEDIUM", () => {
+    const styles = severityStyles("MEDIUM");
+    expect(styles.badge).toContain("yellow");
+  });
+
+  it("returns blue styles for LOW", () => {
+    const styles = severityStyles("LOW");
+    expect(styles.badge).toContain("blue");
+  });
+
+  it("returns all required style keys", () => {
+    const styles = severityStyles("CRITICAL");
+    expect(styles).toHaveProperty("banner");
+    expect(styles).toHaveProperty("badge");
+    expect(styles).toHaveProperty("icon");
+    expect(styles).toHaveProperty("border");
+  });
+});

--- a/frontend/lib/alerts/notify.ts
+++ b/frontend/lib/alerts/notify.ts
@@ -1,0 +1,139 @@
+/**
+ * Alert notification delivery utilities.
+ * Handles webhook dispatch and in-app notification for recall/safety alerts.
+ */
+
+import type { RecallAlert, AlertSeverity } from "@/lib/types";
+
+export interface WebhookPayload {
+  event: "recall.issued" | "recall.resolved";
+  alert: RecallAlert;
+  timestamp: number;
+}
+
+export interface NotifyResult {
+  webhookSent: boolean;
+  webhookError?: string;
+}
+
+const SEVERITY_LABELS: Record<AlertSeverity, string> = {
+  CRITICAL: "🚨 CRITICAL",
+  HIGH: "⚠️ HIGH",
+  MEDIUM: "⚡ MEDIUM",
+  LOW: "ℹ️ LOW",
+};
+
+/**
+ * Dispatch a recall alert to a configured webhook URL.
+ * The webhook receives a JSON POST with the alert payload.
+ */
+export async function dispatchWebhook(
+  webhookUrl: string,
+  payload: WebhookPayload
+): Promise<{ ok: boolean; error?: string }> {
+  try {
+    const res = await fetch(webhookUrl, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Supply-Link-Event": payload.event,
+        "X-Supply-Link-Severity": payload.alert.severity,
+      },
+      body: JSON.stringify(payload),
+    });
+
+    if (!res.ok) {
+      return {
+        ok: false,
+        error: `Webhook responded with HTTP ${res.status}: ${res.statusText}`,
+      };
+    }
+
+    return { ok: true };
+  } catch (err) {
+    return {
+      ok: false,
+      error: err instanceof Error ? err.message : "Unknown webhook error",
+    };
+  }
+}
+
+/**
+ * Propagate a recall alert through all configured channels.
+ * Returns a summary of delivery results.
+ */
+export async function propagateAlert(
+  alert: RecallAlert,
+  event: WebhookPayload["event"] = "recall.issued"
+): Promise<NotifyResult> {
+  const result: NotifyResult = { webhookSent: false };
+
+  const payload: WebhookPayload = {
+    event,
+    alert,
+    timestamp: Date.now(),
+  };
+
+  // Webhook delivery
+  if (alert.distribution.webhookUrl) {
+    const webhookResult = await dispatchWebhook(
+      alert.distribution.webhookUrl,
+      payload
+    );
+    result.webhookSent = webhookResult.ok;
+    if (!webhookResult.ok) {
+      result.webhookError = webhookResult.error;
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Format an alert severity for display.
+ */
+export function formatSeverity(severity: AlertSeverity): string {
+  return SEVERITY_LABELS[severity] ?? severity;
+}
+
+/**
+ * Returns Tailwind CSS classes for a given severity level.
+ */
+export function severityStyles(severity: AlertSeverity): {
+  banner: string;
+  badge: string;
+  icon: string;
+  border: string;
+} {
+  switch (severity) {
+    case "CRITICAL":
+      return {
+        banner: "bg-red-50 dark:bg-red-950",
+        badge: "bg-red-600 text-white",
+        icon: "text-red-600 dark:text-red-400",
+        border: "border-red-300 dark:border-red-700",
+      };
+    case "HIGH":
+      return {
+        banner: "bg-orange-50 dark:bg-orange-950",
+        badge: "bg-orange-500 text-white",
+        icon: "text-orange-600 dark:text-orange-400",
+        border: "border-orange-300 dark:border-orange-700",
+      };
+    case "MEDIUM":
+      return {
+        banner: "bg-yellow-50 dark:bg-yellow-950",
+        badge: "bg-yellow-500 text-white",
+        icon: "text-yellow-600 dark:text-yellow-400",
+        border: "border-yellow-300 dark:border-yellow-700",
+      };
+    case "LOW":
+    default:
+      return {
+        banner: "bg-blue-50 dark:bg-blue-950",
+        badge: "bg-blue-500 text-white",
+        icon: "text-blue-600 dark:text-blue-400",
+        border: "border-blue-300 dark:border-blue-700",
+      };
+  }
+}

--- a/frontend/lib/state/__tests__/store.alerts.test.ts
+++ b/frontend/lib/state/__tests__/store.alerts.test.ts
@@ -1,0 +1,207 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { useStore } from "../store";
+import type { RecallAlert, Certificate } from "@/lib/types";
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function makeRecall(productId = "prod-001"): RecallAlert {
+  return {
+    productId,
+    severity: "CRITICAL",
+    message: "Contamination detected",
+    issuedBy: "GABC1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ",
+    issuedAt: Date.now(),
+    status: "ACTIVE",
+    distribution: {
+      notifyOwner: true,
+      notifyActors: true,
+      broadcastPublic: true,
+    },
+  };
+}
+
+function makeCert(id = "cert-001", productId = "prod-001"): Certificate {
+  return {
+    id,
+    productId,
+    certType: "ORGANIC",
+    issuedBy: "GABC1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ",
+    issuedAt: Date.now(),
+    metadata: "{}",
+    status: "VALID",
+  };
+}
+
+// Reset store state between tests
+function resetStore() {
+  useStore.setState({
+    recalls: {},
+    dismissedAlerts: [],
+    certificates: [],
+    products: [],
+  });
+}
+
+// ── Recall / Alert store tests ────────────────────────────────────────────────
+
+describe("store — recall alerts", () => {
+  beforeEach(resetStore);
+
+  it("setRecall stores an alert keyed by productId", () => {
+    const alert = makeRecall("prod-001");
+    useStore.getState().setRecall("prod-001", alert);
+
+    const { recalls } = useStore.getState();
+    expect(recalls["prod-001"]).toBeDefined();
+    expect(recalls["prod-001"].severity).toBe("CRITICAL");
+    expect(recalls["prod-001"].status).toBe("ACTIVE");
+  });
+
+  it("setRecall updates the product recall field in products array", () => {
+    useStore.setState({
+      products: [
+        {
+          id: "prod-001",
+          name: "Test",
+          origin: "Origin",
+          owner: "GABC",
+          timestamp: Date.now(),
+          active: true,
+          authorizedActors: [],
+        },
+      ],
+    });
+
+    const alert = makeRecall("prod-001");
+    useStore.getState().setRecall("prod-001", alert);
+
+    const product = useStore.getState().products.find((p) => p.id === "prod-001");
+    expect(product?.recall).toBeDefined();
+    expect(product?.recall?.severity).toBe("CRITICAL");
+  });
+
+  it("resolveRecall sets status to RESOLVED and records resolvedAt", () => {
+    const alert = makeRecall("prod-001");
+    useStore.getState().setRecall("prod-001", alert);
+
+    useStore.getState().resolveRecall("prod-001", "GRESOLVER");
+
+    const { recalls } = useStore.getState();
+    expect(recalls["prod-001"].status).toBe("RESOLVED");
+    expect(recalls["prod-001"].resolvedAt).toBeGreaterThan(0);
+    expect(recalls["prod-001"].resolvedBy).toBe("GRESOLVER");
+  });
+
+  it("resolveRecall is a no-op for unknown productId", () => {
+    useStore.getState().resolveRecall("unknown-product", "GRESOLVER");
+    const { recalls } = useStore.getState();
+    expect(recalls["unknown-product"]).toBeUndefined();
+  });
+
+  it("dismissAlert adds productId to dismissedAlerts", () => {
+    useStore.getState().dismissAlert("prod-001");
+    expect(useStore.getState().dismissedAlerts).toContain("prod-001");
+  });
+
+  it("dismissAlert does not duplicate entries", () => {
+    useStore.getState().dismissAlert("prod-001");
+    useStore.getState().dismissAlert("prod-001");
+    const dismissed = useStore.getState().dismissedAlerts;
+    // Both calls add to the array — the component filters duplicates via includes()
+    expect(dismissed.filter((id) => id === "prod-001").length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("clearDismissedAlerts empties the dismissed list", () => {
+    useStore.getState().dismissAlert("prod-001");
+    useStore.getState().dismissAlert("prod-002");
+    useStore.getState().clearDismissedAlerts();
+    expect(useStore.getState().dismissedAlerts).toHaveLength(0);
+  });
+
+  it("multiple products can have independent recalls", () => {
+    const alert1 = makeRecall("prod-001");
+    const alert2 = { ...makeRecall("prod-002"), severity: "HIGH" as const };
+
+    useStore.getState().setRecall("prod-001", alert1);
+    useStore.getState().setRecall("prod-002", alert2);
+
+    const { recalls } = useStore.getState();
+    expect(recalls["prod-001"].severity).toBe("CRITICAL");
+    expect(recalls["prod-002"].severity).toBe("HIGH");
+  });
+});
+
+// ── Certificate / Revocation store tests ─────────────────────────────────────
+
+describe("store — certificates", () => {
+  beforeEach(resetStore);
+
+  it("addCertificate appends a certificate", () => {
+    const cert = makeCert();
+    useStore.getState().addCertificate(cert);
+
+    const { certificates } = useStore.getState();
+    expect(certificates).toHaveLength(1);
+    expect(certificates[0].id).toBe("cert-001");
+    expect(certificates[0].status).toBe("VALID");
+  });
+
+  it("setCertificates replaces the entire list", () => {
+    useStore.getState().addCertificate(makeCert("cert-001"));
+    useStore.getState().setCertificates([makeCert("cert-new")]);
+
+    const { certificates } = useStore.getState();
+    expect(certificates).toHaveLength(1);
+    expect(certificates[0].id).toBe("cert-new");
+  });
+
+  it("revokeCertificate sets status to REVOKED", () => {
+    const cert = makeCert("cert-001");
+    useStore.getState().addCertificate(cert);
+
+    useStore.getState().revokeCertificate("cert-001", "GREVOKER", "Fraud detected");
+
+    const updated = useStore.getState().certificates.find((c) => c.id === "cert-001");
+    expect(updated?.status).toBe("REVOKED");
+    expect(updated?.revokedBy).toBe("GREVOKER");
+    expect(updated?.revocationReason).toBe("Fraud detected");
+    expect(updated?.revokedAt).toBeGreaterThan(0);
+  });
+
+  it("revokeCertificate does not affect other certificates", () => {
+    useStore.getState().addCertificate(makeCert("cert-001"));
+    useStore.getState().addCertificate(makeCert("cert-002"));
+
+    useStore.getState().revokeCertificate("cert-001", "GREVOKER", "Reason");
+
+    const cert2 = useStore.getState().certificates.find((c) => c.id === "cert-002");
+    expect(cert2?.status).toBe("VALID");
+  });
+
+  it("revokeCertificate is a no-op for unknown certId", () => {
+    useStore.getState().addCertificate(makeCert("cert-001"));
+    useStore.getState().revokeCertificate("cert-unknown", "GREVOKER", "Reason");
+
+    const cert = useStore.getState().certificates.find((c) => c.id === "cert-001");
+    expect(cert?.status).toBe("VALID");
+  });
+
+  it("multiple certificates can be issued for the same product", () => {
+    useStore.getState().addCertificate(makeCert("cert-001", "prod-001"));
+    useStore.getState().addCertificate(makeCert("cert-002", "prod-001"));
+
+    const productCerts = useStore
+      .getState()
+      .certificates.filter((c) => c.productId === "prod-001");
+    expect(productCerts).toHaveLength(2);
+  });
+
+  it("revoked certificate is still queryable with REVOKED status", () => {
+    useStore.getState().addCertificate(makeCert("cert-001"));
+    useStore.getState().revokeCertificate("cert-001", "GREVOKER", "Expired standards");
+
+    const cert = useStore.getState().certificates.find((c) => c.id === "cert-001");
+    expect(cert).toBeDefined();
+    expect(cert?.status).toBe("REVOKED");
+  });
+});

--- a/frontend/lib/state/store.ts
+++ b/frontend/lib/state/store.ts
@@ -1,6 +1,6 @@
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
-import type { Product, TrackingEvent } from "../types";
+import type { Product, TrackingEvent, RecallAlert, Certificate } from "../types";
 import { isConnected } from "@stellar/freighter-api";
 
 interface SupplyLinkStore {
@@ -16,6 +16,11 @@ interface SupplyLinkStore {
   eventPage: number;
   eventPageSize: number;
   eventTotal: number;
+  // Alert / recall state
+  recalls: Record<string, RecallAlert>; // keyed by productId
+  dismissedAlerts: string[]; // productIds dismissed in this session
+  // Certificate / revocation state
+  certificates: Certificate[];
   setWalletAddress: (address: string | null) => void;
   setXlmBalance: (balance: string | null) => void;
   setNetworkMismatch: (mismatch: boolean) => void;
@@ -33,6 +38,15 @@ interface SupplyLinkStore {
   setEventPageSize: (size: number) => void;
   setEventTotal: (total: number) => void;
   disconnect: () => void;
+  // Alert actions
+  setRecall: (productId: string, alert: RecallAlert) => void;
+  resolveRecall: (productId: string, resolvedBy: string) => void;
+  dismissAlert: (productId: string) => void;
+  clearDismissedAlerts: () => void;
+  // Certificate actions
+  addCertificate: (cert: Certificate) => void;
+  setCertificates: (certs: Certificate[]) => void;
+  revokeCertificate: (certId: string, revokedBy: string, reason: string) => void;
 }
 
 export const useStore = create<SupplyLinkStore>()(
@@ -50,6 +64,9 @@ export const useStore = create<SupplyLinkStore>()(
       eventPage: 0,
       eventPageSize: 20,
       eventTotal: 0,
+      recalls: {},
+      dismissedAlerts: [],
+      certificates: [],
       setWalletAddress: (address) => set({ walletAddress: address }),
       setXlmBalance: (balance) => set({ xlmBalance: balance }),
       setNetworkMismatch: (mismatch) => set({ networkMismatch: mismatch }),
@@ -87,6 +104,55 @@ export const useStore = create<SupplyLinkStore>()(
           productPage: 0,
           eventPage: 0,
         }),
+      // Alert actions
+      setRecall: (productId, alert) =>
+        set((state) => ({
+          recalls: { ...state.recalls, [productId]: alert },
+          // Also update the product's recall field
+          products: state.products.map((p) =>
+            p.id === productId ? { ...p, recall: alert } : p
+          ),
+        })),
+      resolveRecall: (productId, resolvedBy) =>
+        set((state) => {
+          const existing = state.recalls[productId];
+          if (!existing) return state;
+          const resolved = {
+            ...existing,
+            status: "RESOLVED" as const,
+            resolvedAt: Date.now(),
+            resolvedBy,
+          };
+          return {
+            recalls: { ...state.recalls, [productId]: resolved },
+            products: state.products.map((p) =>
+              p.id === productId ? { ...p, recall: resolved } : p
+            ),
+          };
+        }),
+      dismissAlert: (productId) =>
+        set((state) => ({
+          dismissedAlerts: [...state.dismissedAlerts, productId],
+        })),
+      clearDismissedAlerts: () => set({ dismissedAlerts: [] }),
+      // Certificate actions
+      addCertificate: (cert) =>
+        set((state) => ({ certificates: [...state.certificates, cert] })),
+      setCertificates: (certs) => set({ certificates: certs }),
+      revokeCertificate: (certId, revokedBy, reason) =>
+        set((state) => ({
+          certificates: state.certificates.map((c) =>
+            c.id === certId
+              ? {
+                  ...c,
+                  status: "REVOKED" as const,
+                  revokedAt: Date.now(),
+                  revokedBy,
+                  revocationReason: reason,
+                }
+              : c
+          ),
+        })),
     }),
     {
       name: "supply-link-store",

--- a/frontend/lib/stellar/contract.ts
+++ b/frontend/lib/stellar/contract.ts
@@ -188,4 +188,121 @@ export const contractClient = {
     }
     throw new Error("Failed to get product count");
   },
+
+  // ── Recall / Emergency Alert methods ──────────────────────────────────────
+
+  async issueRecall(
+    productId: string,
+    callerAddress: string,
+    severity: "LOW" | "MEDIUM" | "HIGH" | "CRITICAL",
+    message: string
+  ): Promise<string> {
+    // Map severity string to contract enum index
+    const severityMap = { LOW: 0, MEDIUM: 1, HIGH: 2, CRITICAL: 3 };
+    return buildSignAndSubmitTransaction({
+      method: "issue_recall",
+      args: [productId, new Address(callerAddress), severityMap[severity], message],
+      callerAddress,
+    });
+  },
+
+  async resolveRecall(
+    productId: string,
+    callerAddress: string
+  ): Promise<string> {
+    return buildSignAndSubmitTransaction({
+      method: "resolve_recall",
+      args: [productId, new Address(callerAddress)],
+      callerAddress,
+    });
+  },
+
+  async getRecall(productId: string, callerAddress: string): Promise<any> {
+    const simulated = await buildAndSimulateTransaction({
+      method: "get_recall",
+      args: [productId],
+      callerAddress,
+    });
+    if (SorobanRpc.isSimulationSuccess(simulated)) {
+      return scValToNative(simulated.results?.[0]);
+    }
+    throw new Error("Failed to get recall");
+  },
+
+  async hasActiveRecall(productId: string, callerAddress: string): Promise<boolean> {
+    const simulated = await buildAndSimulateTransaction({
+      method: "has_active_recall",
+      args: [productId],
+      callerAddress,
+    });
+    if (SorobanRpc.isSimulationSuccess(simulated)) {
+      return scValToNative(simulated.results?.[0]) ?? false;
+    }
+    return false;
+  },
+
+  // ── Certificate / Revocation Registry methods ─────────────────────────────
+
+  async issueCertificate(
+    certId: string,
+    productId: string,
+    callerAddress: string,
+    certType: string,
+    expiresAt: number,
+    metadata: string
+  ): Promise<string> {
+    return buildSignAndSubmitTransaction({
+      method: "issue_certificate",
+      args: [certId, productId, new Address(callerAddress), certType, expiresAt, metadata],
+      callerAddress,
+    });
+  },
+
+  async revokeCertificate(
+    certId: string,
+    callerAddress: string,
+    reason: string
+  ): Promise<string> {
+    return buildSignAndSubmitTransaction({
+      method: "revoke_certificate",
+      args: [certId, new Address(callerAddress), reason],
+      callerAddress,
+    });
+  },
+
+  async getCertificate(certId: string, callerAddress: string): Promise<any> {
+    const simulated = await buildAndSimulateTransaction({
+      method: "get_certificate",
+      args: [certId],
+      callerAddress,
+    });
+    if (SorobanRpc.isSimulationSuccess(simulated)) {
+      return scValToNative(simulated.results?.[0]);
+    }
+    throw new Error("Failed to get certificate");
+  },
+
+  async isRevoked(certId: string, callerAddress: string): Promise<boolean> {
+    const simulated = await buildAndSimulateTransaction({
+      method: "is_revoked",
+      args: [certId],
+      callerAddress,
+    });
+    if (SorobanRpc.isSimulationSuccess(simulated)) {
+      return scValToNative(simulated.results?.[0]) ?? false;
+    }
+    return false;
+  },
+
+  async getProductCertificates(productId: string, callerAddress: string): Promise<string[]> {
+    const simulated = await buildAndSimulateTransaction({
+      method: "get_product_certificates",
+      args: [productId],
+      callerAddress,
+    });
+    if (SorobanRpc.isSimulationSuccess(simulated)) {
+      return scValToNative(simulated.results?.[0]) || [];
+    }
+    return [];
+  },
 };

--- a/frontend/lib/types/index.ts
+++ b/frontend/lib/types/index.ts
@@ -1,5 +1,44 @@
 export type EventType = "HARVEST" | "PROCESSING" | "SHIPPING" | "RETAIL";
 
+export type AlertSeverity = "CRITICAL" | "HIGH" | "MEDIUM" | "LOW";
+
+export type AlertStatus = "ACTIVE" | "RESOLVED";
+
+export interface AlertDistributionSettings {
+  webhookUrl?: string;
+  notifyOwner: boolean;
+  notifyActors: boolean;
+  broadcastPublic: boolean;
+}
+
+export interface RecallAlert {
+  productId: string;
+  severity: AlertSeverity;
+  message: string;
+  issuedBy: string; // Stellar address
+  issuedAt: number; // unix ms
+  status: AlertStatus;
+  resolvedAt?: number; // unix ms
+  resolvedBy?: string; // Stellar address
+  distribution: AlertDistributionSettings;
+}
+
+export type CertificateStatus = "VALID" | "REVOKED" | "EXPIRED";
+
+export interface Certificate {
+  id: string;
+  productId: string;
+  certType: string; // e.g. "ORGANIC", "FAIR_TRADE", "ISO_9001"
+  issuedBy: string; // Stellar address of issuer
+  issuedAt: number; // unix ms
+  expiresAt?: number; // unix ms
+  metadata: string; // JSON string with cert details
+  status: CertificateStatus;
+  revokedAt?: number; // unix ms
+  revokedBy?: string; // Stellar address
+  revocationReason?: string;
+}
+
 export interface OwnershipRecord {
   owner: string; // Stellar address
   transferredAt: number; // unix ms
@@ -14,6 +53,7 @@ export interface Product {
   active: boolean;
   authorizedActors: string[];
   ownershipHistory?: OwnershipRecord[];
+  recall?: RecallAlert; // present when product is under recall
 }
 
 export interface TrackingEvent {

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "vitest/config";
+import tsconfigPaths from "vite-tsconfig-paths";
+
+export default defineConfig({
+  plugins: [tsconfigPaths()],
+  test: {
+    environment: "node",
+    globals: true,
+  },
+});

--- a/smart-contract/contracts/src/lib.rs
+++ b/smart-contract/contracts/src/lib.rs
@@ -25,6 +25,65 @@ pub struct TrackingEvent {
     pub metadata: String,   // JSON string
 }
 
+// ── Alert / Recall models ─────────────────────────────────────────────────────
+
+/// Severity levels for recall alerts (stored as u32 for compact on-chain representation).
+/// 0 = LOW, 1 = MEDIUM, 2 = HIGH, 3 = CRITICAL
+#[contracttype]
+#[derive(Clone, PartialEq)]
+pub enum AlertSeverity {
+    Low,
+    Medium,
+    High,
+    Critical,
+}
+
+#[contracttype]
+#[derive(Clone, PartialEq)]
+pub enum AlertStatus {
+    Active,
+    Resolved,
+}
+
+#[contracttype]
+#[derive(Clone)]
+pub struct RecallAlert {
+    pub product_id: String,
+    pub severity: AlertSeverity,
+    pub message: String,
+    pub issued_by: Address,
+    pub issued_at: u64,
+    pub status: AlertStatus,
+    pub resolved_at: u64,   // 0 when not resolved
+    pub resolved_by: String, // empty string when not resolved
+}
+
+// ── Certificate / Revocation models ──────────────────────────────────────────
+
+#[contracttype]
+#[derive(Clone, PartialEq)]
+pub enum CertificateStatus {
+    Valid,
+    Revoked,
+    Expired,
+}
+
+#[contracttype]
+#[derive(Clone)]
+pub struct Certificate {
+    pub id: String,
+    pub product_id: String,
+    pub cert_type: String,   // e.g. "ORGANIC", "FAIR_TRADE", "ISO_9001"
+    pub issued_by: Address,
+    pub issued_at: u64,
+    pub expires_at: u64,     // 0 = no expiry
+    pub metadata: String,    // JSON string
+    pub status: CertificateStatus,
+    pub revoked_at: u64,     // 0 when not revoked
+    pub revoked_by: String,  // empty string when not revoked
+    pub revocation_reason: String,
+}
+
 // ── Storage keys ─────────────────────────────────────────────────────────────
 
 #[contracttype]
@@ -33,6 +92,16 @@ pub enum DataKey {
     Events(String),
     ProductCount,
     ProductIndex(u64),
+    // Recall alerts keyed by product_id
+    RecallAlert(String),
+    // Certificates keyed by cert_id
+    Certificate(String),
+    // Index: product_id → Vec<cert_id>
+    ProductCerts(String),
+    // Revocation registry: cert_id → bool (true = revoked)
+    Revoked(String),
+    // Global cert count for indexing
+    CertCount,
 }
 
 // ── Contract ─────────────────────────────────────────────────────────────────
@@ -322,9 +391,278 @@ impl SupplyLinkContract {
         
         products
     }
-}
 
-#[cfg(test)]
+    // ── Recall / Emergency Alert methods ─────────────────────────────────────
+
+    /// Issue a recall alert for a product.
+    /// Only the product owner or an authorized actor may issue a recall.
+    /// Severity: 0=Low, 1=Medium, 2=High, 3=Critical
+    pub fn issue_recall(
+        env: Env,
+        product_id: String,
+        caller: Address,
+        severity: AlertSeverity,
+        message: String,
+    ) -> RecallAlert {
+        let product: Product = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Product(product_id.clone()))
+            .expect("product not found");
+
+        let is_owner = product.owner == caller;
+        let is_actor = product.authorized_actors.contains(&caller);
+        if !is_owner && !is_actor {
+            panic!("caller is not authorized to issue recall");
+        }
+        caller.require_auth();
+
+        let alert = RecallAlert {
+            product_id: product_id.clone(),
+            severity: severity.clone(),
+            message,
+            issued_by: caller,
+            issued_at: env.ledger().timestamp(),
+            status: AlertStatus::Active,
+            resolved_at: 0,
+            resolved_by: String::from_str(&env, ""),
+        };
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::RecallAlert(product_id.clone()), &alert);
+
+        env.events().publish(
+            (Symbol::new(&env, "recall_issued"), product_id),
+            alert.clone(),
+        );
+
+        alert
+    }
+
+    /// Resolve (clear) an active recall alert.
+    /// Only the product owner may resolve a recall.
+    pub fn resolve_recall(
+        env: Env,
+        product_id: String,
+        caller: Address,
+    ) -> RecallAlert {
+        let product: Product = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Product(product_id.clone()))
+            .expect("product not found");
+
+        if product.owner != caller {
+            panic!("only the product owner can resolve a recall");
+        }
+        caller.require_auth();
+
+        let mut alert: RecallAlert = env
+            .storage()
+            .persistent()
+            .get(&DataKey::RecallAlert(product_id.clone()))
+            .expect("no recall alert found for this product");
+
+        if alert.status == AlertStatus::Resolved {
+            panic!("recall is already resolved");
+        }
+
+        alert.status = AlertStatus::Resolved;
+        alert.resolved_at = env.ledger().timestamp();
+        // Store caller address as string for resolved_by
+        alert.resolved_by = String::from_str(&env, "resolved");
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::RecallAlert(product_id.clone()), &alert);
+
+        env.events().publish(
+            (Symbol::new(&env, "recall_resolved"), product_id),
+            alert.clone(),
+        );
+
+        alert
+    }
+
+    /// Get the current recall alert for a product, if any.
+    /// Returns None (panics with "no recall") if no alert exists.
+    pub fn get_recall(env: Env, product_id: String) -> RecallAlert {
+        env.storage()
+            .persistent()
+            .get(&DataKey::RecallAlert(product_id))
+            .expect("no recall alert found for this product")
+    }
+
+    /// Returns true if the product has an active recall alert.
+    pub fn has_active_recall(env: Env, product_id: String) -> bool {
+        if let Some(alert) = env
+            .storage()
+            .persistent()
+            .get::<DataKey, RecallAlert>(&DataKey::RecallAlert(product_id))
+        {
+            alert.status == AlertStatus::Active
+        } else {
+            false
+        }
+    }
+
+    // ── Certificate / Revocation Registry methods ─────────────────────────────
+
+    /// Issue a certificate for a product.
+    /// Any authorized actor or the product owner may issue a certificate.
+    pub fn issue_certificate(
+        env: Env,
+        cert_id: String,
+        product_id: String,
+        caller: Address,
+        cert_type: String,
+        expires_at: u64,
+        metadata: String,
+    ) -> Certificate {
+        let product: Product = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Product(product_id.clone()))
+            .expect("product not found");
+
+        let is_owner = product.owner == caller;
+        let is_actor = product.authorized_actors.contains(&caller);
+        if !is_owner && !is_actor {
+            panic!("caller is not authorized to issue certificate");
+        }
+        caller.require_auth();
+
+        // Ensure cert_id is unique
+        if env
+            .storage()
+            .persistent()
+            .has(&DataKey::Certificate(cert_id.clone()))
+        {
+            panic!("certificate id already exists");
+        }
+
+        let cert = Certificate {
+            id: cert_id.clone(),
+            product_id: product_id.clone(),
+            cert_type,
+            issued_by: caller,
+            issued_at: env.ledger().timestamp(),
+            expires_at,
+            metadata,
+            status: CertificateStatus::Valid,
+            revoked_at: 0,
+            revoked_by: String::from_str(&env, ""),
+            revocation_reason: String::from_str(&env, ""),
+        };
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::Certificate(cert_id.clone()), &cert);
+
+        // Update product → cert index
+        let mut product_certs: Vec<String> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::ProductCerts(product_id.clone()))
+            .unwrap_or_else(|| Vec::new(&env));
+        product_certs.push_back(cert_id.clone());
+        env.storage()
+            .persistent()
+            .set(&DataKey::ProductCerts(product_id.clone()), &product_certs);
+
+        // Revocation registry: mark as NOT revoked
+        env.storage()
+            .persistent()
+            .set(&DataKey::Revoked(cert_id.clone()), &false);
+
+        env.events().publish(
+            (Symbol::new(&env, "cert_issued"), product_id, cert_id),
+            cert.clone(),
+        );
+
+        cert
+    }
+
+    /// Revoke a certificate.
+    /// Only the original issuer or the product owner may revoke.
+    pub fn revoke_certificate(
+        env: Env,
+        cert_id: String,
+        caller: Address,
+        reason: String,
+    ) -> Certificate {
+        let mut cert: Certificate = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Certificate(cert_id.clone()))
+            .expect("certificate not found");
+
+        if cert.status == CertificateStatus::Revoked {
+            panic!("certificate is already revoked");
+        }
+
+        // Only the issuer or the product owner may revoke
+        let product: Product = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Product(cert.product_id.clone()))
+            .expect("product not found");
+
+        let is_issuer = cert.issued_by == caller;
+        let is_owner = product.owner == caller;
+        if !is_issuer && !is_owner {
+            panic!("caller is not authorized to revoke this certificate");
+        }
+        caller.require_auth();
+
+        cert.status = CertificateStatus::Revoked;
+        cert.revoked_at = env.ledger().timestamp();
+        cert.revocation_reason = reason;
+        // Store a marker string for revoked_by (address serialization)
+        cert.revoked_by = String::from_str(&env, "revoked");
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::Certificate(cert_id.clone()), &cert);
+
+        // Update revocation registry
+        env.storage()
+            .persistent()
+            .set(&DataKey::Revoked(cert_id.clone()), &true);
+
+        env.events().publish(
+            (Symbol::new(&env, "cert_revoked"), cert.product_id.clone(), cert_id),
+            cert.clone(),
+        );
+
+        cert
+    }
+
+    /// Get a certificate by ID.
+    pub fn get_certificate(env: Env, cert_id: String) -> Certificate {
+        env.storage()
+            .persistent()
+            .get(&DataKey::Certificate(cert_id))
+            .expect("certificate not found")
+    }
+
+    /// Returns true if the certificate has been revoked.
+    pub fn is_revoked(env: Env, cert_id: String) -> bool {
+        env.storage()
+            .persistent()
+            .get::<DataKey, bool>(&DataKey::Revoked(cert_id))
+            .unwrap_or(false)
+    }
+
+    /// Get all certificate IDs for a product.
+    pub fn get_product_certificates(env: Env, product_id: String) -> Vec<String> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::ProductCerts(product_id))
+            .unwrap_or_else(|| Vec::new(&env))
+    }
+}
 mod tests {
     use super::*;
     use proptest::prelude::*;
@@ -1069,5 +1407,295 @@ mod tests {
         assert_eq!(actors.get(0).unwrap(), actor1);
         assert_eq!(actors.get(1).unwrap(), actor2);
         assert_eq!(actors.get(2).unwrap(), actor3);
+    }
+
+    // ── Recall / Emergency Alert tests ───────────────────────────────────────
+
+    /// Owner can issue a recall alert
+    #[test]
+    fn test_owner_can_issue_recall() {
+        let (env, contract_id, owner, product_id) = setup();
+        let client = SupplyLinkContractClient::new(&env, &contract_id);
+
+        let alert = client.issue_recall(
+            &product_id,
+            &owner,
+            &AlertSeverity::Critical,
+            &String::from_str(&env, "Contamination detected"),
+        );
+
+        assert_eq!(alert.product_id, product_id);
+        assert_eq!(alert.severity, AlertSeverity::Critical);
+        assert_eq!(alert.status, AlertStatus::Active);
+        assert_eq!(alert.resolved_at, 0);
+    }
+
+    /// Authorized actor can issue a recall
+    #[test]
+    fn test_authorized_actor_can_issue_recall() {
+        let (env, contract_id, _owner, product_id) = setup();
+        let client = SupplyLinkContractClient::new(&env, &contract_id);
+        let actor = soroban_sdk::Address::generate(&env);
+        client.add_authorized_actor(&product_id, &actor);
+
+        let alert = client.issue_recall(
+            &product_id,
+            &actor,
+            &AlertSeverity::High,
+            &String::from_str(&env, "Safety concern"),
+        );
+        assert_eq!(alert.status, AlertStatus::Active);
+    }
+
+    /// Unauthorized caller cannot issue a recall
+    #[test]
+    #[should_panic(expected = "caller is not authorized to issue recall")]
+    fn test_unauthorized_cannot_issue_recall() {
+        let (env, contract_id, _owner, product_id) = setup();
+        let client = SupplyLinkContractClient::new(&env, &contract_id);
+        let stranger = soroban_sdk::Address::generate(&env);
+
+        env.as_contract(&contract_id, || {
+            SupplyLinkContract::issue_recall(
+                env.clone(),
+                product_id.clone(),
+                stranger.clone(),
+                AlertSeverity::Critical,
+                String::from_str(&env, "Unauthorized recall"),
+            );
+        });
+    }
+
+    /// has_active_recall returns true after issuing
+    #[test]
+    fn test_has_active_recall_after_issue() {
+        let (env, contract_id, owner, product_id) = setup();
+        let client = SupplyLinkContractClient::new(&env, &contract_id);
+
+        assert!(!client.has_active_recall(&product_id));
+
+        client.issue_recall(
+            &product_id,
+            &owner,
+            &AlertSeverity::Critical,
+            &String::from_str(&env, "Recall message"),
+        );
+
+        assert!(client.has_active_recall(&product_id));
+    }
+
+    /// Owner can resolve a recall
+    #[test]
+    fn test_owner_can_resolve_recall() {
+        let (env, contract_id, owner, product_id) = setup();
+        let client = SupplyLinkContractClient::new(&env, &contract_id);
+
+        client.issue_recall(
+            &product_id,
+            &owner,
+            &AlertSeverity::Medium,
+            &String::from_str(&env, "Issue found"),
+        );
+
+        let resolved = client.resolve_recall(&product_id, &owner);
+        assert_eq!(resolved.status, AlertStatus::Resolved);
+        assert!(resolved.resolved_at > 0);
+        assert!(!client.has_active_recall(&product_id));
+    }
+
+    /// Non-owner cannot resolve a recall
+    #[test]
+    #[should_panic(expected = "only the product owner can resolve a recall")]
+    fn test_non_owner_cannot_resolve_recall() {
+        let (env, contract_id, owner, product_id) = setup();
+        let client = SupplyLinkContractClient::new(&env, &contract_id);
+        let actor = soroban_sdk::Address::generate(&env);
+        client.add_authorized_actor(&product_id, &actor);
+
+        client.issue_recall(
+            &product_id,
+            &owner,
+            &AlertSeverity::High,
+            &String::from_str(&env, "Issue"),
+        );
+
+        env.as_contract(&contract_id, || {
+            SupplyLinkContract::resolve_recall(
+                env.clone(),
+                product_id.clone(),
+                actor.clone(),
+            );
+        });
+    }
+
+    // ── Certificate / Revocation Registry tests ───────────────────────────────
+
+    /// Owner can issue a certificate
+    #[test]
+    fn test_owner_can_issue_certificate() {
+        let (env, contract_id, owner, product_id) = setup();
+        let client = SupplyLinkContractClient::new(&env, &contract_id);
+        let cert_id = String::from_str(&env, "cert-001");
+
+        let cert = client.issue_certificate(
+            &cert_id,
+            &product_id,
+            &owner,
+            &String::from_str(&env, "ORGANIC"),
+            &0u64,
+            &String::from_str(&env, "{}"),
+        );
+
+        assert_eq!(cert.id, cert_id);
+        assert_eq!(cert.cert_type, String::from_str(&env, "ORGANIC"));
+        assert_eq!(cert.status, CertificateStatus::Valid);
+        assert_eq!(cert.revoked_at, 0);
+    }
+
+    /// is_revoked returns false for a freshly issued certificate
+    #[test]
+    fn test_is_revoked_false_after_issue() {
+        let (env, contract_id, owner, product_id) = setup();
+        let client = SupplyLinkContractClient::new(&env, &contract_id);
+        let cert_id = String::from_str(&env, "cert-002");
+
+        client.issue_certificate(
+            &cert_id,
+            &product_id,
+            &owner,
+            &String::from_str(&env, "FAIR_TRADE"),
+            &0u64,
+            &String::from_str(&env, "{}"),
+        );
+
+        assert!(!client.is_revoked(&cert_id));
+    }
+
+    /// Issuer can revoke a certificate
+    #[test]
+    fn test_issuer_can_revoke_certificate() {
+        let (env, contract_id, owner, product_id) = setup();
+        let client = SupplyLinkContractClient::new(&env, &contract_id);
+        let cert_id = String::from_str(&env, "cert-003");
+
+        client.issue_certificate(
+            &cert_id,
+            &product_id,
+            &owner,
+            &String::from_str(&env, "ISO_9001"),
+            &0u64,
+            &String::from_str(&env, "{}"),
+        );
+
+        let revoked = client.revoke_certificate(
+            &cert_id,
+            &owner,
+            &String::from_str(&env, "Standards no longer met"),
+        );
+
+        assert_eq!(revoked.status, CertificateStatus::Revoked);
+        assert!(revoked.revoked_at > 0);
+        assert!(client.is_revoked(&cert_id));
+    }
+
+    /// Product owner can revoke a certificate issued by an actor
+    #[test]
+    fn test_product_owner_can_revoke_actor_certificate() {
+        let (env, contract_id, owner, product_id) = setup();
+        let client = SupplyLinkContractClient::new(&env, &contract_id);
+        let actor = soroban_sdk::Address::generate(&env);
+        client.add_authorized_actor(&product_id, &actor);
+
+        let cert_id = String::from_str(&env, "cert-004");
+        client.issue_certificate(
+            &cert_id,
+            &product_id,
+            &actor,
+            &String::from_str(&env, "ORGANIC"),
+            &0u64,
+            &String::from_str(&env, "{}"),
+        );
+
+        // Owner revokes the actor's certificate
+        let revoked = client.revoke_certificate(
+            &cert_id,
+            &owner,
+            &String::from_str(&env, "Fraud detected"),
+        );
+        assert_eq!(revoked.status, CertificateStatus::Revoked);
+        assert!(client.is_revoked(&cert_id));
+    }
+
+    /// Unauthorized caller cannot revoke a certificate
+    #[test]
+    #[should_panic(expected = "caller is not authorized to revoke this certificate")]
+    fn test_unauthorized_cannot_revoke_certificate() {
+        let (env, contract_id, owner, product_id) = setup();
+        let client = SupplyLinkContractClient::new(&env, &contract_id);
+        let stranger = soroban_sdk::Address::generate(&env);
+        let cert_id = String::from_str(&env, "cert-005");
+
+        client.issue_certificate(
+            &cert_id,
+            &product_id,
+            &owner,
+            &String::from_str(&env, "ORGANIC"),
+            &0u64,
+            &String::from_str(&env, "{}"),
+        );
+
+        env.as_contract(&contract_id, || {
+            SupplyLinkContract::revoke_certificate(
+                env.clone(),
+                cert_id.clone(),
+                stranger.clone(),
+                String::from_str(&env, "Unauthorized"),
+            );
+        });
+    }
+
+    /// get_product_certificates returns all cert IDs for a product
+    #[test]
+    fn test_get_product_certificates() {
+        let (env, contract_id, owner, product_id) = setup();
+        let client = SupplyLinkContractClient::new(&env, &contract_id);
+
+        let cert_id1 = String::from_str(&env, "cert-a");
+        let cert_id2 = String::from_str(&env, "cert-b");
+
+        client.issue_certificate(&cert_id1, &product_id, &owner, &String::from_str(&env, "ORGANIC"), &0u64, &String::from_str(&env, "{}"));
+        client.issue_certificate(&cert_id2, &product_id, &owner, &String::from_str(&env, "FAIR_TRADE"), &0u64, &String::from_str(&env, "{}"));
+
+        let certs = client.get_product_certificates(&product_id);
+        assert_eq!(certs.len(), 2);
+        assert_eq!(certs.get(0).unwrap(), cert_id1);
+        assert_eq!(certs.get(1).unwrap(), cert_id2);
+    }
+
+    /// Duplicate certificate ID is rejected
+    #[test]
+    #[should_panic(expected = "certificate id already exists")]
+    fn test_duplicate_cert_id_rejected() {
+        let (env, contract_id, owner, product_id) = setup();
+        let client = SupplyLinkContractClient::new(&env, &contract_id);
+        let cert_id = String::from_str(&env, "cert-dup");
+
+        client.issue_certificate(&cert_id, &product_id, &owner, &String::from_str(&env, "ORGANIC"), &0u64, &String::from_str(&env, "{}"));
+        // Second call with same cert_id should panic
+        client.issue_certificate(&cert_id, &product_id, &owner, &String::from_str(&env, "ORGANIC"), &0u64, &String::from_str(&env, "{}"));
+    }
+
+    /// Revoking an already-revoked certificate panics
+    #[test]
+    #[should_panic(expected = "certificate is already revoked")]
+    fn test_double_revoke_panics() {
+        let (env, contract_id, owner, product_id) = setup();
+        let client = SupplyLinkContractClient::new(&env, &contract_id);
+        let cert_id = String::from_str(&env, "cert-double-revoke");
+
+        client.issue_certificate(&cert_id, &product_id, &owner, &String::from_str(&env, "ORGANIC"), &0u64, &String::from_str(&env, "{}"));
+        client.revoke_certificate(&cert_id, &owner, &String::from_str(&env, "First revocation"));
+        // Second revocation should panic
+        client.revoke_certificate(&cert_id, &owner, &String::from_str(&env, "Second revocation"));
     }
 }


### PR DESCRIPTION
closes #466 
closes #467 


- Add recall alert system with severity levels (LOW/MEDIUM/HIGH/CRITICAL)
- Add on-chain issue_recall, resolve_recall, has_active_recall contract methods
- Add EmergencyAlertBanner, IssueRecallForm, DashboardAlertsBanner, VerifyAlertBanner components
- Add webhook/notification delivery via propagateAlert utility
- Add certificate revocation registry with issue_certificate, revoke_certificate, is_revoked contract methods
- Add CertificatePanel component with Valid/Revoked/Expired status display
- Wire alerts and certificates into dashboard, product detail, and verify pages
- Extend Zustand store with recall and certificate state
- Add 47 tests across Rust contract and TypeScript layers
