### PR TITLE
feat: add product assembly relationships and warranty tracking

### DIFF
--- a/frontend/__tests__/AssemblyPanel.test.tsx
+++ b/frontend/__tests__/AssemblyPanel.test.tsx
@@ -1,0 +1,317 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+
+// ── Mocks ─────────────────────────────────────────────────────────────────────
+
+const {
+  mockRegisterAssembly,
+  mockWalletAddress,
+  mockToastLoading,
+  mockToastSuccess,
+  mockToastError,
+  mockToastDismiss,
+} = vi.hoisted(() => ({
+  mockRegisterAssembly: vi.fn(),
+  mockWalletAddress: { current: 'GOWNER123' as string | null },
+  mockToastLoading: vi.fn().mockReturnValue('toast-id'),
+  mockToastSuccess: vi.fn(),
+  mockToastError: vi.fn(),
+  mockToastDismiss: vi.fn(),
+}));
+
+vi.mock('@/lib/stellar/client', () => ({
+  registerAssembly: mockRegisterAssembly,
+}));
+
+vi.mock('@/lib/hooks/useToast', () => ({
+  useToast: () => ({
+    loading: mockToastLoading,
+    success: mockToastSuccess,
+    error: mockToastError,
+    dismiss: mockToastDismiss,
+  }),
+}));
+
+vi.mock('@/lib/state/store', () => ({
+  useStore: (selector?: (s: { walletAddress: string | null }) => unknown) => {
+    const state = { walletAddress: mockWalletAddress.current };
+    return selector ? selector(state) : state;
+  },
+}));
+
+// next/link stub
+vi.mock('next/link', () => ({
+  default: ({ href, children, ...rest }: { href: string; children: React.ReactNode }) =>
+    React.createElement('a', { href, ...rest }, children),
+}));
+
+import { AssemblyPanel } from '@/components/products/AssemblyPanel';
+import type { ProductAssembly, Product } from '@/lib/types';
+
+const MOCK_ASSEMBLY: ProductAssembly = {
+  parentId: 'prod-parent',
+  componentIds: ['comp-001', 'comp-002'],
+  registeredBy: 'GOWNER123',
+  registeredAt: 1712000000000,
+  description: 'Assembled from two components',
+};
+
+const MOCK_PRODUCTS: Product[] = [
+  {
+    id: 'comp-001',
+    name: 'Component A',
+    origin: 'Germany',
+    owner: 'GOWNER123',
+    timestamp: 1710000000000,
+    authorizedActors: [],
+  },
+  {
+    id: 'comp-002',
+    name: 'Component B',
+    origin: 'France',
+    owner: 'GOWNER123',
+    timestamp: 1710000000000,
+    authorizedActors: [],
+  },
+];
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockWalletAddress.current = 'GOWNER123';
+});
+
+describe('AssemblyPanel', () => {
+  it('renders "no assembly" message when no assembly provided', () => {
+    render(<AssemblyPanel productId="prod-001" />);
+    expect(screen.getByText(/no assembly relationship registered/i)).toBeInTheDocument();
+  });
+
+  it('renders component IDs when assembly is provided', () => {
+    render(
+      <AssemblyPanel
+        productId="prod-parent"
+        assembly={MOCK_ASSEMBLY}
+        allProducts={MOCK_PRODUCTS}
+      />,
+    );
+    expect(screen.getByText('comp-001')).toBeInTheDocument();
+    expect(screen.getByText('comp-002')).toBeInTheDocument();
+  });
+
+  it('renders assembly description', () => {
+    render(
+      <AssemblyPanel
+        productId="prod-parent"
+        assembly={MOCK_ASSEMBLY}
+        allProducts={MOCK_PRODUCTS}
+      />,
+    );
+    expect(screen.getByText('Assembled from two components')).toBeInTheDocument();
+  });
+
+  it('renders component count badge', () => {
+    render(
+      <AssemblyPanel
+        productId="prod-parent"
+        assembly={MOCK_ASSEMBLY}
+        allProducts={MOCK_PRODUCTS}
+      />,
+    );
+    expect(screen.getByText(/2 components/i)).toBeInTheDocument();
+  });
+
+  it('shows "View provenance" links for each component', () => {
+    render(
+      <AssemblyPanel
+        productId="prod-parent"
+        assembly={MOCK_ASSEMBLY}
+        allProducts={MOCK_PRODUCTS}
+      />,
+    );
+    const links = screen.getAllByText(/view provenance/i);
+    expect(links).toHaveLength(2);
+  });
+
+  it('shows register button for owner when no assembly exists', () => {
+    render(
+      <AssemblyPanel
+        productId="prod-001"
+        allProducts={MOCK_PRODUCTS}
+        isOwner={true}
+      />,
+    );
+    expect(screen.getByText(/register assembly/i)).toBeInTheDocument();
+  });
+
+  it('does not show register button for non-owner', () => {
+    render(
+      <AssemblyPanel
+        productId="prod-001"
+        allProducts={MOCK_PRODUCTS}
+        isOwner={false}
+      />,
+    );
+    expect(screen.queryByText(/register assembly/i)).not.toBeInTheDocument();
+  });
+
+  it('opens register form when register button is clicked', async () => {
+    render(
+      <AssemblyPanel
+        productId="prod-001"
+        allProducts={MOCK_PRODUCTS}
+        isOwner={true}
+      />,
+    );
+    await userEvent.click(screen.getByText(/register assembly/i));
+    expect(screen.getByText(/select component products/i)).toBeInTheDocument();
+  });
+
+  it('shows component checkboxes in register form', async () => {
+    render(
+      <AssemblyPanel
+        productId="prod-001"
+        allProducts={MOCK_PRODUCTS}
+        isOwner={true}
+      />,
+    );
+    await userEvent.click(screen.getByText(/register assembly/i));
+    expect(screen.getByText('Component A')).toBeInTheDocument();
+    expect(screen.getByText('Component B')).toBeInTheDocument();
+  });
+
+  it('calls registerAssembly with selected components on submit', async () => {
+    mockRegisterAssembly.mockResolvedValue('mock_tx_123');
+    render(
+      <AssemblyPanel
+        productId="prod-001"
+        allProducts={MOCK_PRODUCTS}
+        isOwner={true}
+      />,
+    );
+    await userEvent.click(screen.getByText(/register assembly/i));
+
+    // Select first component
+    const checkboxes = screen.getAllByRole('checkbox');
+    await userEvent.click(checkboxes[0]);
+
+    await userEvent.click(screen.getByRole('button', { name: /save assembly/i }));
+
+    await waitFor(() => {
+      expect(mockRegisterAssembly).toHaveBeenCalledWith(
+        'prod-001',
+        ['comp-001'],
+        '',
+        'GOWNER123',
+      );
+    });
+  });
+
+  it('shows success toast after successful registration', async () => {
+    mockRegisterAssembly.mockResolvedValue('mock_tx_123');
+    render(
+      <AssemblyPanel
+        productId="prod-001"
+        allProducts={MOCK_PRODUCTS}
+        isOwner={true}
+      />,
+    );
+    await userEvent.click(screen.getByText(/register assembly/i));
+    const checkboxes = screen.getAllByRole('checkbox');
+    await userEvent.click(checkboxes[0]);
+    await userEvent.click(screen.getByRole('button', { name: /save assembly/i }));
+
+    await waitFor(() => {
+      expect(mockToastSuccess).toHaveBeenCalledWith(
+        'Assembly registered',
+        expect.any(String),
+      );
+    });
+  });
+
+  it('shows error toast when wallet not connected', async () => {
+    mockWalletAddress.current = null;
+    render(
+      <AssemblyPanel
+        productId="prod-001"
+        allProducts={MOCK_PRODUCTS}
+        isOwner={true}
+      />,
+    );
+    await userEvent.click(screen.getByText(/register assembly/i));
+    const checkboxes = screen.getAllByRole('checkbox');
+    await userEvent.click(checkboxes[0]);
+    await userEvent.click(screen.getByRole('button', { name: /save assembly/i }));
+
+    await waitFor(() => {
+      expect(mockToastError).toHaveBeenCalledWith(
+        'Wallet not connected',
+        expect.any(String),
+      );
+    });
+  });
+
+  it('shows error toast when no components selected', async () => {
+    render(
+      <AssemblyPanel
+        productId="prod-001"
+        allProducts={MOCK_PRODUCTS}
+        isOwner={true}
+      />,
+    );
+    await userEvent.click(screen.getByText(/register assembly/i));
+    // Don't select any component
+    await userEvent.click(screen.getByRole('button', { name: /save assembly/i }));
+
+    await waitFor(() => {
+      expect(mockToastError).toHaveBeenCalledWith(
+        'No components selected',
+        expect.any(String),
+      );
+    });
+  });
+
+  it('collapses panel when header is clicked', async () => {
+    render(
+      <AssemblyPanel
+        productId="prod-parent"
+        assembly={MOCK_ASSEMBLY}
+        allProducts={MOCK_PRODUCTS}
+      />,
+    );
+    // Initially expanded — component IDs visible
+    expect(screen.getByText('comp-001')).toBeInTheDocument();
+
+    // Click header to collapse
+    await userEvent.click(screen.getByRole('button', { name: /assembly structure/i }));
+    expect(screen.queryByText('comp-001')).not.toBeInTheDocument();
+  });
+
+  it('shows update assembly button for owner when assembly exists', () => {
+    render(
+      <AssemblyPanel
+        productId="prod-parent"
+        assembly={MOCK_ASSEMBLY}
+        allProducts={MOCK_PRODUCTS}
+        isOwner={true}
+      />,
+    );
+    expect(screen.getByText(/update assembly/i)).toBeInTheDocument();
+  });
+
+  it('cancels form when cancel button is clicked', async () => {
+    render(
+      <AssemblyPanel
+        productId="prod-001"
+        allProducts={MOCK_PRODUCTS}
+        isOwner={true}
+      />,
+    );
+    await userEvent.click(screen.getByText(/register assembly/i));
+    expect(screen.getByText(/select component products/i)).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('button', { name: /cancel/i }));
+    expect(screen.queryByText(/select component products/i)).not.toBeInTheDocument();
+  });
+});

--- a/frontend/__tests__/WarrantyPanel.test.tsx
+++ b/frontend/__tests__/WarrantyPanel.test.tsx
@@ -1,0 +1,484 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+
+// ── Mocks ─────────────────────────────────────────────────────────────────────
+
+const {
+  mockRegisterWarranty,
+  mockFileWarrantyClaim,
+  mockUpdateClaimStatus,
+  mockVoidWarranty,
+  mockWalletAddress,
+  mockToastLoading,
+  mockToastSuccess,
+  mockToastError,
+  mockToastDismiss,
+} = vi.hoisted(() => ({
+  mockRegisterWarranty: vi.fn(),
+  mockFileWarrantyClaim: vi.fn(),
+  mockUpdateClaimStatus: vi.fn(),
+  mockVoidWarranty: vi.fn(),
+  mockWalletAddress: { current: 'GOWNER123' as string | null },
+  mockToastLoading: vi.fn().mockReturnValue('toast-id'),
+  mockToastSuccess: vi.fn(),
+  mockToastError: vi.fn(),
+  mockToastDismiss: vi.fn(),
+}));
+
+vi.mock('@/lib/stellar/client', () => ({
+  registerWarranty: mockRegisterWarranty,
+  fileWarrantyClaim: mockFileWarrantyClaim,
+  updateClaimStatus: mockUpdateClaimStatus,
+  voidWarranty: mockVoidWarranty,
+}));
+
+vi.mock('@/lib/hooks/useToast', () => ({
+  useToast: () => ({
+    loading: mockToastLoading,
+    success: mockToastSuccess,
+    error: mockToastError,
+    dismiss: mockToastDismiss,
+  }),
+}));
+
+vi.mock('@/lib/state/store', () => ({
+  useStore: (selector?: (s: { walletAddress: string | null }) => unknown) => {
+    const state = { walletAddress: mockWalletAddress.current };
+    return selector ? selector(state) : state;
+  },
+}));
+
+import { WarrantyPanel } from '@/components/products/WarrantyPanel';
+import type { WarrantyInfo, WarrantyClaim } from '@/lib/types';
+
+// Product registered 1 year ago
+const ONE_YEAR_AGO = Date.now() - 365 * 24 * 3600 * 1000;
+const PRODUCT_TIMESTAMP = ONE_YEAR_AGO;
+
+const ACTIVE_WARRANTY: WarrantyInfo = {
+  productId: 'prod-001',
+  durationSeconds: 2 * 365 * 24 * 3600, // 2 years
+  issuer: 'GOWNER123',
+  issuedAt: PRODUCT_TIMESTAMP,
+  terms: 'Full replacement within 2 years.',
+  termsRef: 'ipfs://QmWarrantyDoc',
+  voided: false,
+  voidedAt: 0,
+};
+
+const EXPIRED_WARRANTY: WarrantyInfo = {
+  ...ACTIVE_WARRANTY,
+  durationSeconds: 1, // 1 second — already expired
+};
+
+const VOIDED_WARRANTY: WarrantyInfo = {
+  ...ACTIVE_WARRANTY,
+  voided: true,
+  voidedAt: Date.now() - 1000,
+};
+
+const LIFETIME_WARRANTY: WarrantyInfo = {
+  ...ACTIVE_WARRANTY,
+  durationSeconds: 0,
+  terms: 'Lifetime warranty.',
+};
+
+const PENDING_CLAIM: WarrantyClaim = {
+  claimId: 'claim-001',
+  productId: 'prod-001',
+  claimant: 'GCUSTOMER123',
+  filedAt: Date.now() - 86400000,
+  description: 'Product stopped working.',
+  proofRef: 'ipfs://QmProof',
+  status: 'Pending',
+  updatedAt: Date.now() - 86400000,
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockWalletAddress.current = 'GOWNER123';
+});
+
+describe('WarrantyPanel', () => {
+  // ── No warranty ─────────────────────────────────────────────────────────────
+
+  it('renders "no warranty" message when no warranty provided', () => {
+    render(<WarrantyPanel productId="prod-001" productTimestamp={PRODUCT_TIMESTAMP} />);
+    expect(screen.getByText(/no warranty registered/i)).toBeInTheDocument();
+  });
+
+  it('shows register button for owner when no warranty', () => {
+    render(
+      <WarrantyPanel productId="prod-001" productTimestamp={PRODUCT_TIMESTAMP} isOwner={true} />,
+    );
+    expect(screen.getByText(/register warranty/i)).toBeInTheDocument();
+  });
+
+  it('does not show register button for non-owner', () => {
+    render(
+      <WarrantyPanel productId="prod-001" productTimestamp={PRODUCT_TIMESTAMP} isOwner={false} />,
+    );
+    expect(screen.queryByText(/register warranty/i)).not.toBeInTheDocument();
+  });
+
+  // ── Active warranty ──────────────────────────────────────────────────────────
+
+  it('renders Active badge for active warranty', () => {
+    render(
+      <WarrantyPanel
+        productId="prod-001"
+        productTimestamp={PRODUCT_TIMESTAMP}
+        warranty={ACTIVE_WARRANTY}
+      />,
+    );
+    expect(screen.getByText('Active')).toBeInTheDocument();
+  });
+
+  it('renders warranty terms', () => {
+    render(
+      <WarrantyPanel
+        productId="prod-001"
+        productTimestamp={PRODUCT_TIMESTAMP}
+        warranty={ACTIVE_WARRANTY}
+      />,
+    );
+    expect(screen.getByText('Full replacement within 2 years.')).toBeInTheDocument();
+  });
+
+  it('renders warranty duration', () => {
+    render(
+      <WarrantyPanel
+        productId="prod-001"
+        productTimestamp={PRODUCT_TIMESTAMP}
+        warranty={ACTIVE_WARRANTY}
+      />,
+    );
+    expect(screen.getByText(/2 years/i)).toBeInTheDocument();
+  });
+
+  it('renders "Lifetime" for zero-duration warranty', () => {
+    render(
+      <WarrantyPanel
+        productId="prod-001"
+        productTimestamp={PRODUCT_TIMESTAMP}
+        warranty={LIFETIME_WARRANTY}
+      />,
+    );
+    expect(screen.getByText('Lifetime')).toBeInTheDocument();
+  });
+
+  it('renders document reference link', () => {
+    render(
+      <WarrantyPanel
+        productId="prod-001"
+        productTimestamp={PRODUCT_TIMESTAMP}
+        warranty={ACTIVE_WARRANTY}
+      />,
+    );
+    const link = screen.getByText('ipfs://QmWarrantyDoc');
+    expect(link.closest('a')).toHaveAttribute('href', 'ipfs://QmWarrantyDoc');
+  });
+
+  // ── Expired warranty ─────────────────────────────────────────────────────────
+
+  it('renders Expired badge for expired warranty', () => {
+    render(
+      <WarrantyPanel
+        productId="prod-001"
+        productTimestamp={PRODUCT_TIMESTAMP}
+        warranty={EXPIRED_WARRANTY}
+      />,
+    );
+    expect(screen.getByText('Expired')).toBeInTheDocument();
+  });
+
+  // ── Voided warranty ──────────────────────────────────────────────────────────
+
+  it('renders Voided badge for voided warranty', () => {
+    render(
+      <WarrantyPanel
+        productId="prod-001"
+        productTimestamp={PRODUCT_TIMESTAMP}
+        warranty={VOIDED_WARRANTY}
+      />,
+    );
+    expect(screen.getByText('Voided')).toBeInTheDocument();
+  });
+
+  it('does not show void button when warranty is already voided', () => {
+    render(
+      <WarrantyPanel
+        productId="prod-001"
+        productTimestamp={PRODUCT_TIMESTAMP}
+        warranty={VOIDED_WARRANTY}
+        isOwner={true}
+      />,
+    );
+    expect(screen.queryByText(/void warranty/i)).not.toBeInTheDocument();
+  });
+
+  // ── Register warranty form ───────────────────────────────────────────────────
+
+  it('opens register form when register button clicked', async () => {
+    render(
+      <WarrantyPanel productId="prod-001" productTimestamp={PRODUCT_TIMESTAMP} isOwner={true} />,
+    );
+    await userEvent.click(screen.getByText(/register warranty/i));
+    expect(screen.getByLabelText(/duration/i)).toBeInTheDocument();
+  });
+
+  it('calls registerWarranty on form submit', async () => {
+    mockRegisterWarranty.mockResolvedValue('mock_tx_warranty');
+    render(
+      <WarrantyPanel productId="prod-001" productTimestamp={PRODUCT_TIMESTAMP} isOwner={true} />,
+    );
+    await userEvent.click(screen.getByText(/register warranty/i));
+    await userEvent.click(screen.getByRole('button', { name: /register warranty/i }));
+
+    await waitFor(() => {
+      expect(mockRegisterWarranty).toHaveBeenCalledWith(
+        'prod-001',
+        expect.any(Number),
+        expect.any(String),
+        expect.any(String),
+        'GOWNER123',
+      );
+    });
+  });
+
+  it('shows success toast after warranty registration', async () => {
+    mockRegisterWarranty.mockResolvedValue('mock_tx_warranty');
+    render(
+      <WarrantyPanel productId="prod-001" productTimestamp={PRODUCT_TIMESTAMP} isOwner={true} />,
+    );
+    await userEvent.click(screen.getByText(/register warranty/i));
+    await userEvent.click(screen.getByRole('button', { name: /register warranty/i }));
+
+    await waitFor(() => {
+      expect(mockToastSuccess).toHaveBeenCalledWith('Warranty registered', expect.any(String));
+    });
+  });
+
+  it('shows error toast when wallet not connected during registration', async () => {
+    mockWalletAddress.current = null;
+    render(
+      <WarrantyPanel productId="prod-001" productTimestamp={PRODUCT_TIMESTAMP} isOwner={true} />,
+    );
+    await userEvent.click(screen.getByText(/register warranty/i));
+    await userEvent.click(screen.getByRole('button', { name: /register warranty/i }));
+
+    await waitFor(() => {
+      expect(mockToastError).toHaveBeenCalledWith('Wallet not connected', expect.any(String));
+    });
+  });
+
+  // ── Void warranty ────────────────────────────────────────────────────────────
+
+  it('shows void button for owner with active warranty', () => {
+    render(
+      <WarrantyPanel
+        productId="prod-001"
+        productTimestamp={PRODUCT_TIMESTAMP}
+        warranty={ACTIVE_WARRANTY}
+        isOwner={true}
+      />,
+    );
+    expect(screen.getByText(/void warranty/i)).toBeInTheDocument();
+  });
+
+  it('calls voidWarranty when void button clicked', async () => {
+    mockVoidWarranty.mockResolvedValue('mock_tx_void');
+    render(
+      <WarrantyPanel
+        productId="prod-001"
+        productTimestamp={PRODUCT_TIMESTAMP}
+        warranty={ACTIVE_WARRANTY}
+        isOwner={true}
+      />,
+    );
+    await userEvent.click(screen.getByText(/void warranty/i));
+
+    await waitFor(() => {
+      expect(mockVoidWarranty).toHaveBeenCalledWith('prod-001', 'GOWNER123');
+    });
+  });
+
+  // ── Claims ───────────────────────────────────────────────────────────────────
+
+  it('renders "no claims" message when no claims', () => {
+    render(
+      <WarrantyPanel
+        productId="prod-001"
+        productTimestamp={PRODUCT_TIMESTAMP}
+        warranty={ACTIVE_WARRANTY}
+        warrantyClaims={[]}
+      />,
+    );
+    expect(screen.getByText(/no claims filed yet/i)).toBeInTheDocument();
+  });
+
+  it('renders existing claims', () => {
+    render(
+      <WarrantyPanel
+        productId="prod-001"
+        productTimestamp={PRODUCT_TIMESTAMP}
+        warranty={ACTIVE_WARRANTY}
+        warrantyClaims={[PENDING_CLAIM]}
+      />,
+    );
+    expect(screen.getByText('Product stopped working.')).toBeInTheDocument();
+    expect(screen.getByText('Pending')).toBeInTheDocument();
+  });
+
+  it('shows "File claim" button for active warranty', () => {
+    render(
+      <WarrantyPanel
+        productId="prod-001"
+        productTimestamp={PRODUCT_TIMESTAMP}
+        warranty={ACTIVE_WARRANTY}
+        warrantyClaims={[]}
+      />,
+    );
+    expect(screen.getByText(/file claim/i)).toBeInTheDocument();
+  });
+
+  it('does not show "File claim" for voided warranty', () => {
+    render(
+      <WarrantyPanel
+        productId="prod-001"
+        productTimestamp={PRODUCT_TIMESTAMP}
+        warranty={VOIDED_WARRANTY}
+        warrantyClaims={[]}
+      />,
+    );
+    expect(screen.queryByText(/file claim/i)).not.toBeInTheDocument();
+  });
+
+  it('opens claim form when "File claim" clicked', async () => {
+    render(
+      <WarrantyPanel
+        productId="prod-001"
+        productTimestamp={PRODUCT_TIMESTAMP}
+        warranty={ACTIVE_WARRANTY}
+        warrantyClaims={[]}
+      />,
+    );
+    await userEvent.click(screen.getByText(/file claim/i));
+    expect(screen.getByLabelText(/issue description/i)).toBeInTheDocument();
+  });
+
+  it('calls fileWarrantyClaim on claim form submit', async () => {
+    mockFileWarrantyClaim.mockResolvedValue('mock_tx_claim');
+    render(
+      <WarrantyPanel
+        productId="prod-001"
+        productTimestamp={PRODUCT_TIMESTAMP}
+        warranty={ACTIVE_WARRANTY}
+        warrantyClaims={[]}
+      />,
+    );
+    await userEvent.click(screen.getByText(/file claim/i));
+    await userEvent.type(
+      screen.getByLabelText(/issue description/i),
+      'Screen cracked after normal use',
+    );
+    await userEvent.click(screen.getByRole('button', { name: /file claim/i }));
+
+    await waitFor(() => {
+      expect(mockFileWarrantyClaim).toHaveBeenCalledWith(
+        'prod-001',
+        expect.any(String),
+        'Screen cracked after normal use',
+        '',
+        'GOWNER123',
+      );
+    });
+  });
+
+  it('shows error when description is empty on claim submit', async () => {
+    render(
+      <WarrantyPanel
+        productId="prod-001"
+        productTimestamp={PRODUCT_TIMESTAMP}
+        warranty={ACTIVE_WARRANTY}
+        warrantyClaims={[]}
+      />,
+    );
+    await userEvent.click(screen.getByText(/file claim/i));
+    await userEvent.click(screen.getByRole('button', { name: /file claim/i }));
+
+    await waitFor(() => {
+      expect(mockToastError).toHaveBeenCalledWith('Description required', expect.any(String));
+    });
+  });
+
+  it('shows status update buttons for owner on pending claims', () => {
+    render(
+      <WarrantyPanel
+        productId="prod-001"
+        productTimestamp={PRODUCT_TIMESTAMP}
+        warranty={ACTIVE_WARRANTY}
+        warrantyClaims={[PENDING_CLAIM]}
+        isOwner={true}
+      />,
+    );
+    expect(screen.getByRole('button', { name: /approved/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /rejected/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /resolved/i })).toBeInTheDocument();
+  });
+
+  it('calls updateClaimStatus when owner approves a claim', async () => {
+    mockUpdateClaimStatus.mockResolvedValue('mock_tx_status');
+    render(
+      <WarrantyPanel
+        productId="prod-001"
+        productTimestamp={PRODUCT_TIMESTAMP}
+        warranty={ACTIVE_WARRANTY}
+        warrantyClaims={[PENDING_CLAIM]}
+        isOwner={true}
+      />,
+    );
+    await userEvent.click(screen.getByRole('button', { name: /approved/i }));
+
+    await waitFor(() => {
+      expect(mockUpdateClaimStatus).toHaveBeenCalledWith(
+        'prod-001',
+        'claim-001',
+        'Approved',
+        'GOWNER123',
+      );
+    });
+  });
+
+  // ── Collapse ─────────────────────────────────────────────────────────────────
+
+  it('collapses panel when header clicked', async () => {
+    render(
+      <WarrantyPanel
+        productId="prod-001"
+        productTimestamp={PRODUCT_TIMESTAMP}
+        warranty={ACTIVE_WARRANTY}
+      />,
+    );
+    expect(screen.getByText('Full replacement within 2 years.')).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('button', { name: /warranty/i }));
+    expect(screen.queryByText('Full replacement within 2 years.')).not.toBeInTheDocument();
+  });
+
+  // ── Claims count ─────────────────────────────────────────────────────────────
+
+  it('renders claims count in section header', () => {
+    render(
+      <WarrantyPanel
+        productId="prod-001"
+        productTimestamp={PRODUCT_TIMESTAMP}
+        warranty={ACTIVE_WARRANTY}
+        warrantyClaims={[PENDING_CLAIM]}
+      />,
+    );
+    expect(screen.getByText(/claims \(1\)/i)).toBeInTheDocument();
+  });
+});

--- a/frontend/__tests__/assemblyWarrantyApi.test.ts
+++ b/frontend/__tests__/assemblyWarrantyApi.test.ts
@@ -1,0 +1,362 @@
+/**
+ * Tests for assembly and warranty REST API routes.
+ *
+ * Uses the same pattern as existing API tests in this project:
+ * mock auth + rate-limit middleware, then call the route handler directly.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextRequest } from 'next/server';
+
+// ── Shared middleware mocks ───────────────────────────────────────────────────
+
+vi.mock('@/lib/api/cors', () => ({
+  withCors: (_req: unknown, res: unknown) => res,
+  handleOptions: () => new Response(null, { status: 204 }),
+}));
+
+vi.mock('@/lib/api/errors', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/api/errors')>();
+  return {
+    ...actual,
+    withCorrelationId: (_req: unknown, res: unknown) => res,
+  };
+});
+
+vi.mock('@/lib/api/rateLimit', () => ({
+  applyRateLimit: () => null,
+  RATE_LIMIT_PRESETS: { default: {}, publicRead: {}, authenticated: {} },
+}));
+
+vi.mock('@/lib/api/auth', () => ({
+  authenticateApiRequest: () => Promise.resolve({ apiKey: 'test-key', error: null }),
+}));
+
+vi.mock('@/lib/api/idempotency', () => ({
+  withIdempotency: (_req: NextRequest, fn: (req: NextRequest, body: string) => unknown) =>
+    _req.text().then((body) => fn(_req, body)),
+}));
+
+vi.mock('@/lib/api/metrics', () => ({
+  recordRequest: vi.fn(),
+}));
+
+// ── Mock products store ───────────────────────────────────────────────────────
+
+import type { Product } from '@/lib/types';
+
+const mockProducts: Product[] = [
+  {
+    id: 'prod-001',
+    name: 'Coffee Beans',
+    origin: 'Ethiopia',
+    owner: 'GOWNER123',
+    timestamp: 1710000000000,
+    active: true,
+    authorizedActors: [],
+    warranty: {
+      productId: 'prod-001',
+      durationSeconds: 2 * 365 * 24 * 3600,
+      issuer: 'GOWNER123',
+      issuedAt: 1710000000000,
+      terms: 'Quality guarantee',
+      termsRef: 'ipfs://QmDoc',
+      voided: false,
+      voidedAt: 0,
+    },
+    warrantyClaims: [],
+  },
+  {
+    id: 'prod-002',
+    name: 'Cocoa',
+    origin: 'Ghana',
+    owner: 'GOWNER456',
+    timestamp: 1711000000000,
+    active: true,
+    authorizedActors: [],
+  },
+  {
+    id: 'prod-003',
+    name: 'Chocolate Bar',
+    origin: 'Belgium',
+    owner: 'GOWNER123',
+    timestamp: 1712000000000,
+    active: true,
+    authorizedActors: [],
+    assembly: {
+      parentId: 'prod-003',
+      componentIds: ['prod-001', 'prod-002'],
+      registeredBy: 'GOWNER123',
+      registeredAt: 1712100000000,
+      description: 'Assembled product',
+    },
+  },
+];
+
+vi.mock('@/lib/mock/products', () => ({
+  getProductById: (id: string) => mockProducts.find((p) => p.id === id),
+  getAllProducts: () => mockProducts,
+  MOCK_PRODUCTS: mockProducts,
+}));
+
+// ── Import route handlers ─────────────────────────────────────────────────────
+
+import { GET as getAssembly, POST as postAssembly } from '@/app/api/v1/products/[id]/assembly/route';
+import { GET as getWarranty, POST as postWarranty } from '@/app/api/v1/products/[id]/warranty/route';
+import { GET as getClaims, POST as postClaim } from '@/app/api/v1/products/[id]/warranty/claims/route';
+
+function makeRequest(method: string, url: string, body?: object): NextRequest {
+  return new NextRequest(url, {
+    method,
+    headers: { 'content-type': 'application/json', 'x-api-key': 'test-key' },
+    body: body ? JSON.stringify(body) : undefined,
+  });
+}
+
+// ── Assembly GET ──────────────────────────────────────────────────────────────
+
+describe('GET /api/v1/products/[id]/assembly', () => {
+  it('returns assembly for product with assembly', async () => {
+    const req = makeRequest('GET', 'http://localhost/api/v1/products/prod-003/assembly');
+    const res = await getAssembly(req, { params: Promise.resolve({ id: 'prod-003' }) });
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.assembly.parentId).toBe('prod-003');
+    expect(data.assembly.componentIds).toEqual(['prod-001', 'prod-002']);
+  });
+
+  it('returns null assembly for product without assembly', async () => {
+    const req = makeRequest('GET', 'http://localhost/api/v1/products/prod-001/assembly');
+    const res = await getAssembly(req, { params: Promise.resolve({ id: 'prod-001' }) });
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.assembly).toBeNull();
+  });
+
+  it('returns 404 for unknown product', async () => {
+    const req = makeRequest('GET', 'http://localhost/api/v1/products/unknown/assembly');
+    const res = await getAssembly(req, { params: Promise.resolve({ id: 'unknown' }) });
+    expect(res.status).toBe(404);
+  });
+});
+
+// ── Assembly POST ─────────────────────────────────────────────────────────────
+
+describe('POST /api/v1/products/[id]/assembly', () => {
+  it('registers assembly with valid payload', async () => {
+    const req = makeRequest('POST', 'http://localhost/api/v1/products/prod-001/assembly', {
+      componentIds: ['prod-002'],
+      description: 'Test assembly',
+      registeredBy: 'GOWNER123',
+    });
+    const res = await postAssembly(req, { params: Promise.resolve({ id: 'prod-001' }) });
+    expect(res.status).toBe(201);
+    const data = await res.json();
+    expect(data.assembly.parentId).toBe('prod-001');
+    expect(data.assembly.componentIds).toEqual(['prod-002']);
+  });
+
+  it('returns 400 when componentIds is empty', async () => {
+    const req = makeRequest('POST', 'http://localhost/api/v1/products/prod-001/assembly', {
+      componentIds: [],
+    });
+    const res = await postAssembly(req, { params: Promise.resolve({ id: 'prod-001' }) });
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 when componentIds is missing', async () => {
+    const req = makeRequest('POST', 'http://localhost/api/v1/products/prod-001/assembly', {
+      description: 'No components',
+    });
+    const res = await postAssembly(req, { params: Promise.resolve({ id: 'prod-001' }) });
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 when a component product does not exist', async () => {
+    const req = makeRequest('POST', 'http://localhost/api/v1/products/prod-001/assembly', {
+      componentIds: ['nonexistent-product'],
+    });
+    const res = await postAssembly(req, { params: Promise.resolve({ id: 'prod-001' }) });
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 when componentIds exceeds 50', async () => {
+    const req = makeRequest('POST', 'http://localhost/api/v1/products/prod-001/assembly', {
+      componentIds: Array.from({ length: 51 }, (_, i) => `comp-${i}`),
+    });
+    const res = await postAssembly(req, { params: Promise.resolve({ id: 'prod-001' }) });
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 404 for unknown parent product', async () => {
+    const req = makeRequest('POST', 'http://localhost/api/v1/products/unknown/assembly', {
+      componentIds: ['prod-001'],
+    });
+    const res = await postAssembly(req, { params: Promise.resolve({ id: 'unknown' }) });
+    expect(res.status).toBe(404);
+  });
+});
+
+// ── Warranty GET ──────────────────────────────────────────────────────────────
+
+describe('GET /api/v1/products/[id]/warranty', () => {
+  it('returns warranty for product with warranty', async () => {
+    const req = makeRequest('GET', 'http://localhost/api/v1/products/prod-001/warranty');
+    const res = await getWarranty(req, { params: Promise.resolve({ id: 'prod-001' }) });
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.warranty.productId).toBe('prod-001');
+    expect(data.warranty.terms).toBe('Quality guarantee');
+  });
+
+  it('returns null warranty for product without warranty', async () => {
+    const req = makeRequest('GET', 'http://localhost/api/v1/products/prod-002/warranty');
+    const res = await getWarranty(req, { params: Promise.resolve({ id: 'prod-002' }) });
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.warranty).toBeNull();
+  });
+
+  it('returns 404 for unknown product', async () => {
+    const req = makeRequest('GET', 'http://localhost/api/v1/products/unknown/warranty');
+    const res = await getWarranty(req, { params: Promise.resolve({ id: 'unknown' }) });
+    expect(res.status).toBe(404);
+  });
+});
+
+// ── Warranty POST ─────────────────────────────────────────────────────────────
+
+describe('POST /api/v1/products/[id]/warranty', () => {
+  it('registers warranty with valid payload', async () => {
+    const req = makeRequest('POST', 'http://localhost/api/v1/products/prod-002/warranty', {
+      durationSeconds: 365 * 24 * 3600,
+      terms: '1-year warranty',
+      termsRef: 'ipfs://QmDoc',
+      issuer: 'GOWNER456',
+    });
+    const res = await postWarranty(req, { params: Promise.resolve({ id: 'prod-002' }) });
+    expect(res.status).toBe(201);
+    const data = await res.json();
+    expect(data.warranty.productId).toBe('prod-002');
+    expect(data.warranty.voided).toBe(false);
+  });
+
+  it('registers lifetime warranty when durationSeconds is 0', async () => {
+    const req = makeRequest('POST', 'http://localhost/api/v1/products/prod-002/warranty', {
+      durationSeconds: 0,
+      terms: 'Lifetime warranty',
+      termsRef: '',
+      issuer: 'GOWNER456',
+    });
+    const res = await postWarranty(req, { params: Promise.resolve({ id: 'prod-002' }) });
+    expect(res.status).toBe(201);
+    const data = await res.json();
+    expect(data.warranty.durationSeconds).toBe(0);
+  });
+
+  it('returns 400 when durationSeconds is negative', async () => {
+    const req = makeRequest('POST', 'http://localhost/api/v1/products/prod-002/warranty', {
+      durationSeconds: -1,
+    });
+    const res = await postWarranty(req, { params: Promise.resolve({ id: 'prod-002' }) });
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 when terms exceeds 1024 characters', async () => {
+    const req = makeRequest('POST', 'http://localhost/api/v1/products/prod-002/warranty', {
+      durationSeconds: 0,
+      terms: 'x'.repeat(1025),
+    });
+    const res = await postWarranty(req, { params: Promise.resolve({ id: 'prod-002' }) });
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 404 for unknown product', async () => {
+    const req = makeRequest('POST', 'http://localhost/api/v1/products/unknown/warranty', {
+      durationSeconds: 0,
+    });
+    const res = await postWarranty(req, { params: Promise.resolve({ id: 'unknown' }) });
+    expect(res.status).toBe(404);
+  });
+});
+
+// ── Claims GET ────────────────────────────────────────────────────────────────
+
+describe('GET /api/v1/products/[id]/warranty/claims', () => {
+  it('returns empty claims list for product with no claims', async () => {
+    const req = makeRequest('GET', 'http://localhost/api/v1/products/prod-001/warranty/claims');
+    const res = await getClaims(req, { params: Promise.resolve({ id: 'prod-001' }) });
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.items).toEqual([]);
+    expect(data.total).toBe(0);
+  });
+
+  it('returns 404 for unknown product', async () => {
+    const req = makeRequest('GET', 'http://localhost/api/v1/products/unknown/warranty/claims');
+    const res = await getClaims(req, { params: Promise.resolve({ id: 'unknown' }) });
+    expect(res.status).toBe(404);
+  });
+});
+
+// ── Claims POST ───────────────────────────────────────────────────────────────
+
+describe('POST /api/v1/products/[id]/warranty/claims', () => {
+  it('files a claim with valid payload', async () => {
+    const req = makeRequest(
+      'POST',
+      'http://localhost/api/v1/products/prod-001/warranty/claims',
+      {
+        description: 'Product defective on arrival',
+        claimant: 'GCUSTOMER123',
+        proofRef: 'ipfs://QmProof',
+      },
+    );
+    const res = await postClaim(req, { params: Promise.resolve({ id: 'prod-001' }) });
+    expect(res.status).toBe(201);
+    const data = await res.json();
+    expect(data.status).toBe('Pending');
+    expect(data.description).toBe('Product defective on arrival');
+    expect(data.claimId).toBeTruthy();
+  });
+
+  it('returns 400 when description is missing', async () => {
+    const req = makeRequest(
+      'POST',
+      'http://localhost/api/v1/products/prod-001/warranty/claims',
+      { claimant: 'GCUSTOMER123' },
+    );
+    const res = await postClaim(req, { params: Promise.resolve({ id: 'prod-001' }) });
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 when claimant is missing', async () => {
+    const req = makeRequest(
+      'POST',
+      'http://localhost/api/v1/products/prod-001/warranty/claims',
+      { description: 'Broken' },
+    );
+    const res = await postClaim(req, { params: Promise.resolve({ id: 'prod-001' }) });
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 when product has no warranty', async () => {
+    const req = makeRequest(
+      'POST',
+      'http://localhost/api/v1/products/prod-002/warranty/claims',
+      { description: 'Broken', claimant: 'GCUSTOMER123' },
+    );
+    const res = await postClaim(req, { params: Promise.resolve({ id: 'prod-002' }) });
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 404 for unknown product', async () => {
+    const req = makeRequest(
+      'POST',
+      'http://localhost/api/v1/products/unknown/warranty/claims',
+      { description: 'Broken', claimant: 'GCUSTOMER123' },
+    );
+    const res = await postClaim(req, { params: Promise.resolve({ id: 'unknown' }) });
+    expect(res.status).toBe(404);
+  });
+});

--- a/frontend/app/[locale]/(app)/products/[id]/page.tsx
+++ b/frontend/app/[locale]/(app)/products/[id]/page.tsx
@@ -1,7 +1,7 @@
 import { notFound } from 'next/navigation';
 import Link from 'next/link';
 import Image from 'next/image';
-import { getProductById, getEventsByProductId } from '@/lib/mock/products';
+import { getProductById, getEventsByProductId, getAllProducts } from '@/lib/mock/products';
 import ProductQRCode from '@/components/products/ProductQRCode';
 import ProductActions from '@/components/products/ProductActions';
 import { AuthorizedActorsPanel } from '@/components/products/AuthorizedActorsPanel';
@@ -11,6 +11,8 @@ import { DownloadCertificateButton } from '@/components/products/DownloadCertifi
 import { LazyEventMap } from '@/components/lazy/LazyEventMap';
 import { SustainabilityBadge } from '@/components/products/SustainabilityBadge';
 import { CertificationsPanel } from '@/components/products/CertificationBadge';
+import { AssemblyPanel } from '@/components/products/AssemblyPanel';
+import { WarrantyPanel } from '@/components/products/WarrantyPanel';
 import { getCategoryLabel, getSubcategoryLabel } from '@/lib/taxonomy';
 
 interface Props {
@@ -22,6 +24,7 @@ export default function ProductDetailPage({ params }: Props) {
   if (!product) notFound();
   const p = product!;
   const events = getEventsByProductId(p.id);
+  const allProducts = getAllProducts();
   const registeredAt = new Date(p.timestamp).toLocaleString();
 
   return (
@@ -130,6 +133,27 @@ export default function ProductDetailPage({ params }: Props) {
       <section className="border border-[var(--card-border)] bg-[var(--card)] rounded-xl p-6 mb-6">
         <h2 className="text-base font-semibold mb-4 text-[var(--foreground)]">Certifications</h2>
         <CertificationsPanel certifications={p.certifications ?? []} productId={p.id} />
+      </section>
+
+      {/* Assembly Structure */}
+      <section className="border border-[var(--card-border)] bg-[var(--card)] rounded-xl p-6 mb-6">
+        <AssemblyPanel
+          productId={p.id}
+          assembly={p.assembly}
+          allProducts={allProducts}
+          isOwner={false}
+        />
+      </section>
+
+      {/* Warranty */}
+      <section className="border border-[var(--card-border)] bg-[var(--card)] rounded-xl p-6 mb-6">
+        <WarrantyPanel
+          productId={p.id}
+          productTimestamp={p.timestamp}
+          warranty={p.warranty}
+          warrantyClaims={p.warrantyClaims}
+          isOwner={false}
+        />
       </section>
 
       {/* Event Map */}

--- a/frontend/app/api/v1/products/[id]/assembly/route.ts
+++ b/frontend/app/api/v1/products/[id]/assembly/route.ts
@@ -1,0 +1,145 @@
+/**
+ * GET  /api/v1/products/[id]/assembly  – get assembly record for a product
+ * POST /api/v1/products/[id]/assembly  – register/update assembly relationship
+ *
+ * Authentication: x-api-key (partner or internal)
+ * Rate limiting: partner tier
+ * Idempotency: POST requests via Idempotency-Key header
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { withCors, handleOptions } from '@/lib/api/cors';
+import { apiError, withCorrelationId, ErrorCode } from '@/lib/api/errors';
+import { applyRateLimit, RATE_LIMIT_PRESETS } from '@/lib/api/rateLimit';
+import { authenticateApiRequest } from '@/lib/api/auth';
+import { withIdempotency } from '@/lib/api/idempotency';
+import { getProductById, MOCK_PRODUCTS } from '@/lib/mock/products';
+import { recordRequest } from '@/lib/api/metrics';
+import type { ProductAssembly } from '@/lib/types';
+
+export function OPTIONS(request: NextRequest) {
+  return handleOptions(request);
+}
+
+async function getAssembly(
+  req: NextRequest,
+  productId: string,
+): Promise<NextResponse> {
+  const product = getProductById(productId);
+  if (!product) {
+    return apiError(req, 404, ErrorCode.VALIDATION_ERROR, `Product not found: ${productId}`);
+  }
+
+  if (!product.assembly) {
+    return withCors(
+      req,
+      withCorrelationId(req, NextResponse.json({ assembly: null }, { status: 200 })),
+    );
+  }
+
+  return withCors(
+    req,
+    withCorrelationId(req, NextResponse.json({ assembly: product.assembly }, { status: 200 })),
+  );
+}
+
+async function registerAssembly(
+  req: NextRequest,
+  productId: string,
+  rawBody: string,
+): Promise<NextResponse> {
+  const product = getProductById(productId);
+  if (!product) {
+    return apiError(req, 404, ErrorCode.VALIDATION_ERROR, `Product not found: ${productId}`);
+  }
+
+  let payload: unknown;
+  try {
+    payload = JSON.parse(rawBody);
+  } catch {
+    return apiError(req, 400, ErrorCode.INVALID_PAYLOAD, 'Invalid JSON');
+  }
+
+  const body = payload as Record<string, unknown>;
+
+  if (!Array.isArray(body.componentIds) || body.componentIds.length === 0) {
+    return apiError(req, 400, ErrorCode.MISSING_FIELDS, 'componentIds must be a non-empty array');
+  }
+
+  if (!body.componentIds.every((id: unknown) => typeof id === 'string')) {
+    return apiError(req, 400, ErrorCode.VALIDATION_ERROR, 'componentIds must be string[]');
+  }
+
+  if (body.componentIds.length > 50) {
+    return apiError(req, 400, ErrorCode.VALIDATION_ERROR, 'componentIds exceeds maximum of 50');
+  }
+
+  // Validate all component products exist
+  for (const cid of body.componentIds as string[]) {
+    if (!getProductById(cid)) {
+      return apiError(req, 400, ErrorCode.VALIDATION_ERROR, `Component product not found: ${cid}`);
+    }
+  }
+
+  const description = typeof body.description === 'string' ? body.description : '';
+  const registeredBy = typeof body.registeredBy === 'string' ? body.registeredBy : 'unknown';
+
+  const assembly: ProductAssembly = {
+    parentId: productId,
+    componentIds: body.componentIds as string[],
+    registeredBy,
+    registeredAt: Date.now(),
+    description,
+  };
+
+  // TODO: persist to database / submit to contract
+  const idx = MOCK_PRODUCTS.findIndex((p) => p.id === productId);
+  if (idx !== -1) {
+    MOCK_PRODUCTS[idx] = { ...MOCK_PRODUCTS[idx], assembly };
+  }
+
+  return withCors(
+    req,
+    withCorrelationId(req, NextResponse.json({ assembly }, { status: 201 })),
+  );
+}
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+): Promise<NextResponse> {
+  const start = Date.now();
+  const limited = applyRateLimit(request, 'GET /api/v1/products/[id]/assembly', RATE_LIMIT_PRESETS.publicRead);
+  if (limited) { recordRequest('GET /api/v1/products/[id]/assembly', 429, Date.now() - start); return limited; }
+
+  const auth = await authenticateApiRequest(request, 'partner');
+  if (auth.error) { recordRequest('GET /api/v1/products/[id]/assembly', 401, Date.now() - start); return auth.error; }
+
+  const { id } = await params;
+  if (!id) return apiError(request, 400, ErrorCode.VALIDATION_ERROR, 'Invalid product ID');
+
+  const response = await getAssembly(request, id);
+  recordRequest('GET /api/v1/products/[id]/assembly', response.status, Date.now() - start);
+  return response;
+}
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+): Promise<NextResponse> {
+  const start = Date.now();
+  const limited = applyRateLimit(request, 'POST /api/v1/products/[id]/assembly', RATE_LIMIT_PRESETS.default);
+  if (limited) { recordRequest('POST /api/v1/products/[id]/assembly', 429, Date.now() - start); return limited; }
+
+  const auth = await authenticateApiRequest(request, 'partner');
+  if (auth.error) { recordRequest('POST /api/v1/products/[id]/assembly', 401, Date.now() - start); return auth.error; }
+
+  const { id } = await params;
+  if (!id) return apiError(request, 400, ErrorCode.VALIDATION_ERROR, 'Invalid product ID');
+
+  const response = await withIdempotency(request, (req, rawBody) =>
+    registerAssembly(req, id, rawBody),
+  );
+  recordRequest('POST /api/v1/products/[id]/assembly', response.status, Date.now() - start);
+  return response;
+}

--- a/frontend/app/api/v1/products/[id]/warranty/claims/route.ts
+++ b/frontend/app/api/v1/products/[id]/warranty/claims/route.ts
@@ -1,0 +1,147 @@
+/**
+ * GET  /api/v1/products/[id]/warranty/claims  – list warranty claims
+ * POST /api/v1/products/[id]/warranty/claims  – file a new warranty claim
+ *
+ * Authentication: x-api-key (partner or internal)
+ * Rate limiting: partner tier
+ * Idempotency: POST requests via Idempotency-Key header
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { withCors, handleOptions } from '@/lib/api/cors';
+import { apiError, withCorrelationId, ErrorCode } from '@/lib/api/errors';
+import { applyRateLimit, RATE_LIMIT_PRESETS } from '@/lib/api/rateLimit';
+import { authenticateApiRequest } from '@/lib/api/auth';
+import { withIdempotency } from '@/lib/api/idempotency';
+import { getProductById, MOCK_PRODUCTS } from '@/lib/mock/products';
+import { recordRequest } from '@/lib/api/metrics';
+import type { WarrantyClaim, PaginatedResponse } from '@/lib/types';
+
+export function OPTIONS(request: NextRequest) {
+  return handleOptions(request);
+}
+
+async function listClaims(req: NextRequest, productId: string): Promise<NextResponse> {
+  const product = getProductById(productId);
+  if (!product) {
+    return apiError(req, 404, ErrorCode.VALIDATION_ERROR, `Product not found: ${productId}`);
+  }
+
+  const offset = parseInt(req.nextUrl.searchParams.get('offset') ?? '0', 10);
+  const limit = Math.min(parseInt(req.nextUrl.searchParams.get('limit') ?? '50', 10), 100);
+
+  const allClaims = product.warrantyClaims ?? [];
+  const items = allClaims.slice(offset, offset + limit);
+
+  const response: PaginatedResponse<WarrantyClaim> = {
+    items,
+    total: allClaims.length,
+    offset,
+    limit,
+  };
+
+  return withCors(req, withCorrelationId(req, NextResponse.json(response, { status: 200 })));
+}
+
+async function fileClaim(
+  req: NextRequest,
+  productId: string,
+  rawBody: string,
+): Promise<NextResponse> {
+  const product = getProductById(productId);
+  if (!product) {
+    return apiError(req, 404, ErrorCode.VALIDATION_ERROR, `Product not found: ${productId}`);
+  }
+
+  if (!product.warranty) {
+    return apiError(req, 400, ErrorCode.VALIDATION_ERROR, 'No warranty registered for this product');
+  }
+
+  if (product.warranty.voided) {
+    return apiError(req, 400, ErrorCode.VALIDATION_ERROR, 'Warranty has been voided');
+  }
+
+  let payload: unknown;
+  try {
+    payload = JSON.parse(rawBody);
+  } catch {
+    return apiError(req, 400, ErrorCode.INVALID_PAYLOAD, 'Invalid JSON');
+  }
+
+  const body = payload as Record<string, unknown>;
+
+  if (typeof body.description !== 'string' || !body.description.trim()) {
+    return apiError(req, 400, ErrorCode.MISSING_FIELDS, 'Missing or invalid: description');
+  }
+  if (typeof body.claimant !== 'string' || !body.claimant.trim()) {
+    return apiError(req, 400, ErrorCode.MISSING_FIELDS, 'Missing or invalid: claimant');
+  }
+
+  const proofRef = typeof body.proofRef === 'string' ? body.proofRef : '';
+  if (proofRef.length > 512) {
+    return apiError(req, 400, ErrorCode.VALIDATION_ERROR, 'proofRef exceeds 512 characters');
+  }
+
+  const claim: WarrantyClaim = {
+    claimId: `claim-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`,
+    productId,
+    claimant: body.claimant as string,
+    filedAt: Date.now(),
+    description: body.description as string,
+    proofRef,
+    status: 'Pending',
+    updatedAt: Date.now(),
+  };
+
+  // TODO: persist to database / submit to contract
+  const idx = MOCK_PRODUCTS.findIndex((p) => p.id === productId);
+  if (idx !== -1) {
+    const existing = MOCK_PRODUCTS[idx].warrantyClaims ?? [];
+    MOCK_PRODUCTS[idx] = {
+      ...MOCK_PRODUCTS[idx],
+      warrantyClaims: [...existing, claim],
+    };
+  }
+
+  return withCors(req, withCorrelationId(req, NextResponse.json(claim, { status: 201 })));
+}
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+): Promise<NextResponse> {
+  const start = Date.now();
+  const limited = applyRateLimit(request, 'GET /api/v1/products/[id]/warranty/claims', RATE_LIMIT_PRESETS.publicRead);
+  if (limited) { recordRequest('GET /api/v1/products/[id]/warranty/claims', 429, Date.now() - start); return limited; }
+
+  const auth = await authenticateApiRequest(request, 'partner');
+  if (auth.error) { recordRequest('GET /api/v1/products/[id]/warranty/claims', 401, Date.now() - start); return auth.error; }
+
+  const { id } = await params;
+  if (!id) return apiError(request, 400, ErrorCode.VALIDATION_ERROR, 'Invalid product ID');
+
+  const response = await listClaims(request, id);
+  recordRequest('GET /api/v1/products/[id]/warranty/claims', response.status, Date.now() - start);
+  return response;
+}
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+): Promise<NextResponse> {
+  const start = Date.now();
+  const limited = applyRateLimit(request, 'POST /api/v1/products/[id]/warranty/claims', RATE_LIMIT_PRESETS.default);
+  if (limited) { recordRequest('POST /api/v1/products/[id]/warranty/claims', 429, Date.now() - start); return limited; }
+
+  const auth = await authenticateApiRequest(request, 'partner');
+  if (auth.error) { recordRequest('POST /api/v1/products/[id]/warranty/claims', 401, Date.now() - start); return auth.error; }
+
+  const { id } = await params;
+  if (!id) return apiError(request, 400, ErrorCode.VALIDATION_ERROR, 'Invalid product ID');
+
+  const response = await withIdempotency(request, (req, rawBody) =>
+    fileClaim(req, id, rawBody),
+  );
+  recordRequest('POST /api/v1/products/[id]/warranty/claims', response.status, Date.now() - start);
+  return response;
+}

--- a/frontend/app/api/v1/products/[id]/warranty/route.ts
+++ b/frontend/app/api/v1/products/[id]/warranty/route.ts
@@ -1,0 +1,132 @@
+/**
+ * GET  /api/v1/products/[id]/warranty  – get warranty info for a product
+ * POST /api/v1/products/[id]/warranty  – register warranty metadata
+ *
+ * Authentication: x-api-key (partner or internal)
+ * Rate limiting: partner tier
+ * Idempotency: POST requests via Idempotency-Key header
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { withCors, handleOptions } from '@/lib/api/cors';
+import { apiError, withCorrelationId, ErrorCode } from '@/lib/api/errors';
+import { applyRateLimit, RATE_LIMIT_PRESETS } from '@/lib/api/rateLimit';
+import { authenticateApiRequest } from '@/lib/api/auth';
+import { withIdempotency } from '@/lib/api/idempotency';
+import { getProductById, MOCK_PRODUCTS } from '@/lib/mock/products';
+import { recordRequest } from '@/lib/api/metrics';
+import type { WarrantyInfo } from '@/lib/types';
+
+export function OPTIONS(request: NextRequest) {
+  return handleOptions(request);
+}
+
+async function getWarranty(req: NextRequest, productId: string): Promise<NextResponse> {
+  const product = getProductById(productId);
+  if (!product) {
+    return apiError(req, 404, ErrorCode.VALIDATION_ERROR, `Product not found: ${productId}`);
+  }
+  return withCors(
+    req,
+    withCorrelationId(req, NextResponse.json({ warranty: product.warranty ?? null }, { status: 200 })),
+  );
+}
+
+async function registerWarranty(
+  req: NextRequest,
+  productId: string,
+  rawBody: string,
+): Promise<NextResponse> {
+  const product = getProductById(productId);
+  if (!product) {
+    return apiError(req, 404, ErrorCode.VALIDATION_ERROR, `Product not found: ${productId}`);
+  }
+
+  let payload: unknown;
+  try {
+    payload = JSON.parse(rawBody);
+  } catch {
+    return apiError(req, 400, ErrorCode.INVALID_PAYLOAD, 'Invalid JSON');
+  }
+
+  const body = payload as Record<string, unknown>;
+
+  const durationSeconds =
+    typeof body.durationSeconds === 'number' ? body.durationSeconds : 0;
+  if (durationSeconds < 0) {
+    return apiError(req, 400, ErrorCode.VALIDATION_ERROR, 'durationSeconds must be >= 0');
+  }
+
+  const terms = typeof body.terms === 'string' ? body.terms : '';
+  const termsRef = typeof body.termsRef === 'string' ? body.termsRef : '';
+  const issuer = typeof body.issuer === 'string' ? body.issuer : 'unknown';
+
+  if (terms.length > 1024) {
+    return apiError(req, 400, ErrorCode.VALIDATION_ERROR, 'terms exceeds 1024 characters');
+  }
+  if (termsRef.length > 512) {
+    return apiError(req, 400, ErrorCode.VALIDATION_ERROR, 'termsRef exceeds 512 characters');
+  }
+
+  const warranty: WarrantyInfo = {
+    productId,
+    durationSeconds,
+    issuer,
+    issuedAt: Date.now(),
+    terms,
+    termsRef,
+    voided: false,
+    voidedAt: 0,
+  };
+
+  // TODO: persist to database / submit to contract
+  const idx = MOCK_PRODUCTS.findIndex((p) => p.id === productId);
+  if (idx !== -1) {
+    MOCK_PRODUCTS[idx] = { ...MOCK_PRODUCTS[idx], warranty };
+  }
+
+  return withCors(
+    req,
+    withCorrelationId(req, NextResponse.json({ warranty }, { status: 201 })),
+  );
+}
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+): Promise<NextResponse> {
+  const start = Date.now();
+  const limited = applyRateLimit(request, 'GET /api/v1/products/[id]/warranty', RATE_LIMIT_PRESETS.publicRead);
+  if (limited) { recordRequest('GET /api/v1/products/[id]/warranty', 429, Date.now() - start); return limited; }
+
+  const auth = await authenticateApiRequest(request, 'partner');
+  if (auth.error) { recordRequest('GET /api/v1/products/[id]/warranty', 401, Date.now() - start); return auth.error; }
+
+  const { id } = await params;
+  if (!id) return apiError(request, 400, ErrorCode.VALIDATION_ERROR, 'Invalid product ID');
+
+  const response = await getWarranty(request, id);
+  recordRequest('GET /api/v1/products/[id]/warranty', response.status, Date.now() - start);
+  return response;
+}
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+): Promise<NextResponse> {
+  const start = Date.now();
+  const limited = applyRateLimit(request, 'POST /api/v1/products/[id]/warranty', RATE_LIMIT_PRESETS.default);
+  if (limited) { recordRequest('POST /api/v1/products/[id]/warranty', 429, Date.now() - start); return limited; }
+
+  const auth = await authenticateApiRequest(request, 'partner');
+  if (auth.error) { recordRequest('POST /api/v1/products/[id]/warranty', 401, Date.now() - start); return auth.error; }
+
+  const { id } = await params;
+  if (!id) return apiError(request, 400, ErrorCode.VALIDATION_ERROR, 'Invalid product ID');
+
+  const response = await withIdempotency(request, (req, rawBody) =>
+    registerWarranty(req, id, rawBody),
+  );
+  recordRequest('POST /api/v1/products/[id]/warranty', response.status, Date.now() - start);
+  return response;
+}

--- a/frontend/components/products/AssemblyPanel.tsx
+++ b/frontend/components/products/AssemblyPanel.tsx
@@ -1,0 +1,302 @@
+'use client';
+
+import { useState } from 'react';
+import Link from 'next/link';
+import { Package, ChevronDown, ChevronUp, GitBranch, Plus, X, Loader2 } from 'lucide-react';
+import type { ProductAssembly, Product } from '@/lib/types';
+import { registerAssembly } from '@/lib/stellar/client';
+import { useStore } from '@/lib/state/store';
+import { useToast } from '@/lib/hooks/useToast';
+
+interface Props {
+  productId: string;
+  assembly?: ProductAssembly;
+  /** All products available for selection as components */
+  allProducts?: Product[];
+  /** Whether the current user is the product owner */
+  isOwner?: boolean;
+}
+
+/** Truncate a Stellar address for display */
+function shortAddr(addr: string) {
+  if (addr.length <= 12) return addr;
+  return `${addr.slice(0, 6)}…${addr.slice(-4)}`;
+}
+
+/** Format a Unix-ms timestamp */
+function fmtDate(ts: number) {
+  return new Date(ts).toLocaleDateString(undefined, {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+  });
+}
+
+// ── Component provenance row ──────────────────────────────────────────────────
+
+function ComponentRow({ componentId }: { componentId: string }) {
+  return (
+    <li className="flex items-center gap-3 py-2 border-b border-[var(--card-border)] last:border-0">
+      <span className="flex-shrink-0 w-7 h-7 rounded-lg bg-violet-500/10 flex items-center justify-center">
+        <Package size={14} className="text-violet-500" aria-hidden />
+      </span>
+      <Link
+        href={`/products/${componentId}`}
+        className="font-mono text-xs text-violet-500 hover:underline truncate flex-1"
+      >
+        {componentId}
+      </Link>
+      <Link
+        href={`/products/${componentId}`}
+        className="text-xs text-[var(--muted)] hover:text-[var(--foreground)] transition-colors shrink-0"
+        aria-label={`View provenance for ${componentId}`}
+      >
+        View provenance →
+      </Link>
+    </li>
+  );
+}
+
+// ── Register assembly form ────────────────────────────────────────────────────
+
+interface RegisterFormProps {
+  productId: string;
+  allProducts: Product[];
+  onSuccess: (assembly: ProductAssembly) => void;
+  onCancel: () => void;
+}
+
+function RegisterAssemblyForm({ productId, allProducts, onSuccess, onCancel }: RegisterFormProps) {
+  const { walletAddress } = useStore();
+  const toast = useToast();
+  const [selectedIds, setSelectedIds] = useState<string[]>([]);
+  const [description, setDescription] = useState('');
+  const [pending, setPending] = useState(false);
+
+  const eligible = allProducts.filter((p) => p.id !== productId);
+
+  function toggleComponent(id: string) {
+    setSelectedIds((prev) =>
+      prev.includes(id) ? prev.filter((x) => x !== id) : [...prev, id],
+    );
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!walletAddress) {
+      toast.error('Wallet not connected', 'Connect your Freighter wallet first.');
+      return;
+    }
+    if (selectedIds.length === 0) {
+      toast.error('No components selected', 'Select at least one component product.');
+      return;
+    }
+
+    setPending(true);
+    const toastId = toast.loading('Registering assembly on-chain…');
+    try {
+      await registerAssembly(productId, selectedIds, description, walletAddress);
+      toast.dismiss(toastId);
+      toast.success('Assembly registered', 'Component relationships saved on-chain.');
+      onSuccess({
+        parentId: productId,
+        componentIds: selectedIds,
+        registeredBy: walletAddress,
+        registeredAt: Date.now(),
+        description,
+      });
+    } catch (err) {
+      toast.dismiss(toastId);
+      toast.error('Registration failed', err instanceof Error ? err.message : 'Unknown error');
+    } finally {
+      setPending(false);
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="mt-4 flex flex-col gap-4">
+      <div>
+        <p className="text-xs font-medium text-[var(--foreground)] mb-2">
+          Select component products
+        </p>
+        {eligible.length === 0 ? (
+          <p className="text-xs text-[var(--muted)]">No other products available.</p>
+        ) : (
+          <ul className="max-h-48 overflow-y-auto border border-[var(--card-border)] rounded-lg divide-y divide-[var(--card-border)]">
+            {eligible.map((p) => (
+              <li key={p.id}>
+                <label className="flex items-center gap-3 px-3 py-2 cursor-pointer hover:bg-[var(--muted-bg)] transition-colors">
+                  <input
+                    type="checkbox"
+                    checked={selectedIds.includes(p.id)}
+                    onChange={() => toggleComponent(p.id)}
+                    className="w-4 h-4 accent-violet-600"
+                  />
+                  <span className="flex-1 min-w-0">
+                    <span className="text-sm font-medium text-[var(--foreground)] block truncate">
+                      {p.name}
+                    </span>
+                    <span className="font-mono text-xs text-[var(--muted)]">{p.id}</span>
+                  </span>
+                </label>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+
+      <div className="flex flex-col gap-1">
+        <label htmlFor="assembly-description" className="text-xs font-medium text-[var(--foreground)]">
+          Description{' '}
+          <span className="text-[var(--muted)] font-normal">(optional)</span>
+        </label>
+        <textarea
+          id="assembly-description"
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+          rows={2}
+          maxLength={4096}
+          placeholder="Describe how these components are assembled…"
+          className="px-3 py-2 rounded-lg border border-[var(--card-border)] bg-[var(--card)] text-sm focus:outline-none focus:ring-2 focus:ring-violet-500 resize-none"
+        />
+      </div>
+
+      <div className="flex gap-2">
+        <button
+          type="button"
+          onClick={onCancel}
+          disabled={pending}
+          className="flex-1 px-3 py-2 rounded-lg border border-[var(--card-border)] text-sm font-medium hover:bg-[var(--muted-bg)] transition-colors disabled:opacity-50"
+        >
+          Cancel
+        </button>
+        <button
+          type="submit"
+          disabled={pending || selectedIds.length === 0}
+          className="flex-1 px-3 py-2 rounded-lg bg-violet-600 hover:bg-violet-700 text-white text-sm font-medium transition-colors disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2"
+        >
+          {pending ? (
+            <>
+              <Loader2 size={14} className="animate-spin" aria-hidden />
+              Saving…
+            </>
+          ) : (
+            'Save Assembly'
+          )}
+        </button>
+      </div>
+    </form>
+  );
+}
+
+// ── Main panel ────────────────────────────────────────────────────────────────
+
+export function AssemblyPanel({ productId, assembly: initialAssembly, allProducts = [], isOwner = false }: Props) {
+  const [assembly, setAssembly] = useState<ProductAssembly | undefined>(initialAssembly);
+  const [expanded, setExpanded] = useState(true);
+  const [showForm, setShowForm] = useState(false);
+
+  const hasAssembly = assembly && assembly.componentIds.length > 0;
+
+  return (
+    <div>
+      {/* Header */}
+      <button
+        type="button"
+        onClick={() => setExpanded((v) => !v)}
+        className="flex items-center justify-between w-full text-left group"
+        aria-expanded={expanded}
+      >
+        <div className="flex items-center gap-2">
+          <GitBranch size={16} className="text-violet-500" aria-hidden />
+          <span className="text-sm font-medium text-[var(--foreground)]">
+            Assembly Structure
+          </span>
+          {hasAssembly && (
+            <span className="text-xs px-2 py-0.5 rounded-full bg-violet-500/10 text-violet-500 font-medium">
+              {assembly.componentIds.length} component{assembly.componentIds.length !== 1 ? 's' : ''}
+            </span>
+          )}
+        </div>
+        {expanded ? (
+          <ChevronUp size={16} className="text-[var(--muted)]" aria-hidden />
+        ) : (
+          <ChevronDown size={16} className="text-[var(--muted)]" aria-hidden />
+        )}
+      </button>
+
+      {expanded && (
+        <div className="mt-4">
+          {hasAssembly ? (
+            <>
+              {/* Assembly metadata */}
+              <div className="mb-3 text-xs text-[var(--muted)] space-y-1">
+                {assembly.description && (
+                  <p className="text-[var(--foreground)] text-sm">{assembly.description}</p>
+                )}
+                <p>
+                  Registered by{' '}
+                  <span className="font-mono">{shortAddr(assembly.registeredBy)}</span>
+                  {' · '}
+                  {fmtDate(assembly.registeredAt)}
+                </p>
+              </div>
+
+              {/* Component list */}
+              <ul className="mb-3" aria-label="Component products">
+                {assembly.componentIds.map((id) => (
+                  <ComponentRow key={id} componentId={id} />
+                ))}
+              </ul>
+
+              {/* Provenance note */}
+              <p className="text-xs text-[var(--muted)] bg-[var(--muted-bg)] rounded-lg px-3 py-2">
+                Each component carries its own on-chain provenance trail. Click a component to
+                inspect its full supply-chain history.
+              </p>
+
+              {/* Owner: allow updating */}
+              {isOwner && !showForm && (
+                <button
+                  type="button"
+                  onClick={() => setShowForm(true)}
+                  className="mt-3 flex items-center gap-1.5 text-xs text-violet-500 hover:underline"
+                >
+                  <Plus size={12} aria-hidden /> Update assembly
+                </button>
+              )}
+            </>
+          ) : (
+            <p className="text-sm text-[var(--muted)]">
+              No assembly relationship registered for this product.
+            </p>
+          )}
+
+          {/* Register / update form */}
+          {isOwner && showForm && (
+            <RegisterAssemblyForm
+              productId={productId}
+              allProducts={allProducts}
+              onSuccess={(a) => {
+                setAssembly(a);
+                setShowForm(false);
+              }}
+              onCancel={() => setShowForm(false)}
+            />
+          )}
+
+          {/* Show register button when no assembly yet */}
+          {isOwner && !hasAssembly && !showForm && (
+            <button
+              type="button"
+              onClick={() => setShowForm(true)}
+              className="mt-3 flex items-center gap-1.5 text-xs text-violet-500 hover:underline"
+            >
+              <Plus size={12} aria-hidden /> Register assembly
+            </button>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/components/products/WarrantyPanel.tsx
+++ b/frontend/components/products/WarrantyPanel.tsx
@@ -1,0 +1,480 @@
+'use client';
+
+import { useState } from 'react';
+import { Shield, ShieldOff, ShieldCheck, ChevronDown, ChevronUp, Plus, Loader2, ExternalLink, Clock, AlertTriangle } from 'lucide-react';
+import type { WarrantyInfo, WarrantyClaim, ClaimStatus } from '@/lib/types';
+import { registerWarranty, fileWarrantyClaim, updateClaimStatus, voidWarranty } from '@/lib/stellar/client';
+import { useStore } from '@/lib/state/store';
+import { useToast } from '@/lib/hooks/useToast';
+
+interface Props {
+  productId: string;
+  productTimestamp: number;
+  warranty?: WarrantyInfo;
+  warrantyClaims?: WarrantyClaim[];
+  isOwner?: boolean;
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function fmtDate(ts: number) {
+  return new Date(ts).toLocaleDateString(undefined, {
+    year: 'numeric', month: 'short', day: 'numeric',
+  });
+}
+
+function fmtDuration(seconds: number): string {
+  if (seconds === 0) return 'Lifetime';
+  const years = Math.floor(seconds / (365 * 24 * 3600));
+  const months = Math.floor((seconds % (365 * 24 * 3600)) / (30 * 24 * 3600));
+  const days = Math.floor((seconds % (30 * 24 * 3600)) / (24 * 3600));
+  const parts: string[] = [];
+  if (years > 0) parts.push(`${years} year${years !== 1 ? 's' : ''}`);
+  if (months > 0) parts.push(`${months} month${months !== 1 ? 's' : ''}`);
+  if (days > 0 && years === 0) parts.push(`${days} day${days !== 1 ? 's' : ''}`);
+  return parts.join(', ') || '< 1 day';
+}
+
+function isActive(warranty: WarrantyInfo, productTimestamp: number): boolean {
+  if (warranty.voided) return false;
+  if (warranty.durationSeconds === 0) return true;
+  const expiryMs = productTimestamp + warranty.durationSeconds * 1000;
+  return Date.now() <= expiryMs;
+}
+
+function expiryDate(warranty: WarrantyInfo, productTimestamp: number): string | null {
+  if (warranty.durationSeconds === 0) return null;
+  return fmtDate(productTimestamp + warranty.durationSeconds * 1000);
+}
+
+const STATUS_CONFIG: Record<ClaimStatus, { label: string; className: string }> = {
+  Pending:  { label: 'Pending',  className: 'bg-amber-500/10 text-amber-600' },
+  Approved: { label: 'Approved', className: 'bg-blue-500/10 text-blue-600' },
+  Rejected: { label: 'Rejected', className: 'bg-red-500/10 text-red-500' },
+  Resolved: { label: 'Resolved', className: 'bg-green-500/10 text-green-600' },
+};
+
+// ── Warranty status badge ─────────────────────────────────────────────────────
+
+function WarrantyStatusBadge({ warranty, productTimestamp }: { warranty: WarrantyInfo; productTimestamp: number }) {
+  if (warranty.voided) {
+    return (
+      <span className="inline-flex items-center gap-1 text-xs px-2 py-0.5 rounded-full bg-[var(--muted-bg)] text-[var(--muted)] font-medium">
+        <ShieldOff size={11} aria-hidden /> Voided
+      </span>
+    );
+  }
+  if (isActive(warranty, productTimestamp)) {
+    return (
+      <span className="inline-flex items-center gap-1 text-xs px-2 py-0.5 rounded-full bg-green-500/10 text-green-600 font-medium">
+        <ShieldCheck size={11} aria-hidden /> Active
+      </span>
+    );
+  }
+  return (
+    <span className="inline-flex items-center gap-1 text-xs px-2 py-0.5 rounded-full bg-amber-500/10 text-amber-600 font-medium">
+      <AlertTriangle size={11} aria-hidden /> Expired
+    </span>
+  );
+}
+
+// ── Register warranty form ────────────────────────────────────────────────────
+
+interface RegisterWarrantyFormProps {
+  productId: string;
+  onSuccess: (w: WarrantyInfo) => void;
+  onCancel: () => void;
+}
+
+function RegisterWarrantyForm({ productId, onSuccess, onCancel }: RegisterWarrantyFormProps) {
+  const { walletAddress } = useStore();
+  const toast = useToast();
+  const [durationYears, setDurationYears] = useState('1');
+  const [isLifetime, setIsLifetime] = useState(false);
+  const [terms, setTerms] = useState('');
+  const [termsRef, setTermsRef] = useState('');
+  const [pending, setPending] = useState(false);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!walletAddress) {
+      toast.error('Wallet not connected', 'Connect your Freighter wallet first.');
+      return;
+    }
+    const durationSeconds = isLifetime ? 0 : parseInt(durationYears, 10) * 365 * 24 * 3600;
+    setPending(true);
+    const toastId = toast.loading('Registering warranty on-chain…');
+    try {
+      await registerWarranty(productId, durationSeconds, terms, termsRef, walletAddress);
+      toast.dismiss(toastId);
+      toast.success('Warranty registered', 'Warranty metadata saved on-chain.');
+      onSuccess({
+        productId,
+        durationSeconds,
+        issuer: walletAddress,
+        issuedAt: Date.now(),
+        terms,
+        termsRef,
+        voided: false,
+        voidedAt: 0,
+      });
+    } catch (err) {
+      toast.dismiss(toastId);
+      toast.error('Registration failed', err instanceof Error ? err.message : 'Unknown error');
+    } finally {
+      setPending(false);
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="mt-4 flex flex-col gap-3">
+      <div className="flex items-center gap-3">
+        <label className="flex items-center gap-2 cursor-pointer text-sm">
+          <input type="checkbox" checked={isLifetime} onChange={(e) => setIsLifetime(e.target.checked)} className="w-4 h-4 accent-violet-600" />
+          Lifetime warranty
+        </label>
+      </div>
+      {!isLifetime && (
+        <div className="flex flex-col gap-1">
+          <label htmlFor="warranty-duration" className="text-xs font-medium">Duration (years)</label>
+          <input id="warranty-duration" type="number" min="1" max="99" value={durationYears}
+            onChange={(e) => setDurationYears(e.target.value)}
+            className="px-3 py-2 rounded-lg border border-[var(--card-border)] bg-[var(--card)] text-sm focus:outline-none focus:ring-2 focus:ring-violet-500 w-32" />
+        </div>
+      )}
+      <div className="flex flex-col gap-1">
+        <label htmlFor="warranty-terms" className="text-xs font-medium">Terms <span className="text-[var(--muted)] font-normal">(optional)</span></label>
+        <textarea id="warranty-terms" value={terms} onChange={(e) => setTerms(e.target.value)}
+          rows={2} maxLength={1024} placeholder="Short warranty terms summary…"
+          className="px-3 py-2 rounded-lg border border-[var(--card-border)] bg-[var(--card)] text-sm focus:outline-none focus:ring-2 focus:ring-violet-500 resize-none" />
+      </div>
+      <div className="flex flex-col gap-1">
+        <label htmlFor="warranty-ref" className="text-xs font-medium">Document reference <span className="text-[var(--muted)] font-normal">(IPFS CID or URL, optional)</span></label>
+        <input id="warranty-ref" type="text" value={termsRef} onChange={(e) => setTermsRef(e.target.value)}
+          maxLength={512} placeholder="ipfs://Qm… or https://…"
+          className="px-3 py-2 rounded-lg border border-[var(--card-border)] bg-[var(--card)] text-sm focus:outline-none focus:ring-2 focus:ring-violet-500" />
+      </div>
+      <div className="flex gap-2">
+        <button type="button" onClick={onCancel} disabled={pending}
+          className="flex-1 px-3 py-2 rounded-lg border border-[var(--card-border)] text-sm font-medium hover:bg-[var(--muted-bg)] transition-colors disabled:opacity-50">
+          Cancel
+        </button>
+        <button type="submit" disabled={pending}
+          className="flex-1 px-3 py-2 rounded-lg bg-violet-600 hover:bg-violet-700 text-white text-sm font-medium transition-colors disabled:opacity-50 flex items-center justify-center gap-2">
+          {pending ? <><Loader2 size={14} className="animate-spin" aria-hidden />Saving…</> : 'Register Warranty'}
+        </button>
+      </div>
+    </form>
+  );
+}
+
+// ── File claim form ───────────────────────────────────────────────────────────
+
+interface FileClaimFormProps {
+  productId: string;
+  onSuccess: (claim: WarrantyClaim) => void;
+  onCancel: () => void;
+}
+
+function FileClaimForm({ productId, onSuccess, onCancel }: FileClaimFormProps) {
+  const { walletAddress } = useStore();
+  const toast = useToast();
+  const [description, setDescription] = useState('');
+  const [proofRef, setProofRef] = useState('');
+  const [pending, setPending] = useState(false);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!walletAddress) {
+      toast.error('Wallet not connected', 'Connect your Freighter wallet first.');
+      return;
+    }
+    if (!description.trim()) {
+      toast.error('Description required', 'Please describe the issue.');
+      return;
+    }
+    const claimId = `claim-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`;
+    setPending(true);
+    const toastId = toast.loading('Filing warranty claim on-chain…');
+    try {
+      await fileWarrantyClaim(productId, claimId, description, proofRef, walletAddress);
+      toast.dismiss(toastId);
+      toast.success('Claim filed', 'Your warranty claim has been recorded on-chain.');
+      onSuccess({
+        claimId,
+        productId,
+        claimant: walletAddress,
+        filedAt: Date.now(),
+        description,
+        proofRef,
+        status: 'Pending',
+        updatedAt: Date.now(),
+      });
+    } catch (err) {
+      toast.dismiss(toastId);
+      toast.error('Claim failed', err instanceof Error ? err.message : 'Unknown error');
+    } finally {
+      setPending(false);
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="mt-4 flex flex-col gap-3">
+      <div className="flex flex-col gap-1">
+        <label htmlFor="claim-description" className="text-xs font-medium">Issue description</label>
+        <textarea id="claim-description" value={description} onChange={(e) => setDescription(e.target.value)}
+          rows={3} maxLength={4096} required placeholder="Describe the defect or issue…"
+          className="px-3 py-2 rounded-lg border border-[var(--card-border)] bg-[var(--card)] text-sm focus:outline-none focus:ring-2 focus:ring-violet-500 resize-none" />
+      </div>
+      <div className="flex flex-col gap-1">
+        <label htmlFor="claim-proof" className="text-xs font-medium">Proof reference <span className="text-[var(--muted)] font-normal">(IPFS CID or URL, optional)</span></label>
+        <input id="claim-proof" type="text" value={proofRef} onChange={(e) => setProofRef(e.target.value)}
+          maxLength={512} placeholder="ipfs://Qm… or https://…"
+          className="px-3 py-2 rounded-lg border border-[var(--card-border)] bg-[var(--card)] text-sm focus:outline-none focus:ring-2 focus:ring-violet-500" />
+      </div>
+      <div className="flex gap-2">
+        <button type="button" onClick={onCancel} disabled={pending}
+          className="flex-1 px-3 py-2 rounded-lg border border-[var(--card-border)] text-sm font-medium hover:bg-[var(--muted-bg)] transition-colors disabled:opacity-50">
+          Cancel
+        </button>
+        <button type="submit" disabled={pending}
+          className="flex-1 px-3 py-2 rounded-lg bg-violet-600 hover:bg-violet-700 text-white text-sm font-medium transition-colors disabled:opacity-50 flex items-center justify-center gap-2">
+          {pending ? <><Loader2 size={14} className="animate-spin" aria-hidden />Filing…</> : 'File Claim'}
+        </button>
+      </div>
+    </form>
+  );
+}
+
+// ── Claims list ───────────────────────────────────────────────────────────────
+
+interface ClaimsListProps {
+  claims: WarrantyClaim[];
+  productId: string;
+  isOwner: boolean;
+  onStatusUpdate: (claimId: string, status: ClaimStatus) => void;
+}
+
+function ClaimsList({ claims, productId, isOwner, onStatusUpdate }: ClaimsListProps) {
+  const { walletAddress } = useStore();
+  const toast = useToast();
+  const [updatingId, setUpdatingId] = useState<string | null>(null);
+
+  async function handleStatusChange(claimId: string, newStatus: ClaimStatus) {
+    if (!walletAddress) return;
+    setUpdatingId(claimId);
+    const toastId = toast.loading('Updating claim status…');
+    try {
+      await updateClaimStatus(productId, claimId, newStatus, walletAddress);
+      toast.dismiss(toastId);
+      toast.success('Status updated', `Claim marked as ${newStatus}.`);
+      onStatusUpdate(claimId, newStatus);
+    } catch (err) {
+      toast.dismiss(toastId);
+      toast.error('Update failed', err instanceof Error ? err.message : 'Unknown error');
+    } finally {
+      setUpdatingId(null);
+    }
+  }
+
+  if (claims.length === 0) {
+    return <p className="text-sm text-[var(--muted)]">No claims filed yet.</p>;
+  }
+
+  return (
+    <ul className="space-y-3" aria-label="Warranty claims">
+      {claims.map((claim) => {
+        const cfg = STATUS_CONFIG[claim.status];
+        return (
+          <li key={claim.claimId} className="border border-[var(--card-border)] rounded-lg p-3 text-sm">
+            <div className="flex items-start justify-between gap-2 mb-1">
+              <span className="font-mono text-xs text-[var(--muted)] truncate">{claim.claimId}</span>
+              <span className={`shrink-0 text-xs px-2 py-0.5 rounded-full font-medium ${cfg.className}`}>
+                {cfg.label}
+              </span>
+            </div>
+            <p className="text-[var(--foreground)] mb-1">{claim.description}</p>
+            {claim.proofRef && (
+              <a href={claim.proofRef} target="_blank" rel="noopener noreferrer"
+                className="inline-flex items-center gap-1 text-xs text-violet-500 hover:underline mb-1">
+                <ExternalLink size={11} aria-hidden /> View proof
+              </a>
+            )}
+            <p className="text-xs text-[var(--muted)]">
+              Filed {fmtDate(claim.filedAt)} · Updated {fmtDate(claim.updatedAt)}
+            </p>
+            {isOwner && claim.status === 'Pending' && (
+              <div className="flex gap-2 mt-2">
+                {(['Approved', 'Rejected', 'Resolved'] as ClaimStatus[]).map((s) => (
+                  <button key={s} type="button" disabled={updatingId === claim.claimId}
+                    onClick={() => handleStatusChange(claim.claimId, s)}
+                    className="px-2 py-1 rounded text-xs border border-[var(--card-border)] hover:bg-[var(--muted-bg)] transition-colors disabled:opacity-50">
+                    {s}
+                  </button>
+                ))}
+              </div>
+            )}
+          </li>
+        );
+      })}
+    </ul>
+  );
+}
+
+// ── Main panel ────────────────────────────────────────────────────────────────
+
+export function WarrantyPanel({
+  productId,
+  productTimestamp,
+  warranty: initialWarranty,
+  warrantyClaims: initialClaims = [],
+  isOwner = false,
+}: Props) {
+  const [warranty, setWarranty] = useState<WarrantyInfo | undefined>(initialWarranty);
+  const [claims, setClaims] = useState<WarrantyClaim[]>(initialClaims);
+  const [expanded, setExpanded] = useState(true);
+  const [showRegisterForm, setShowRegisterForm] = useState(false);
+  const [showClaimForm, setShowClaimForm] = useState(false);
+  const [voidingPending, setVoidingPending] = useState(false);
+  const { walletAddress } = useStore();
+  const toast = useToast();
+
+  const active = warranty ? isActive(warranty, productTimestamp) : false;
+  const expiry = warranty ? expiryDate(warranty, productTimestamp) : null;
+
+  async function handleVoid() {
+    if (!walletAddress || !warranty) return;
+    setVoidingPending(true);
+    const toastId = toast.loading('Voiding warranty on-chain…');
+    try {
+      await voidWarranty(productId, walletAddress);
+      toast.dismiss(toastId);
+      toast.success('Warranty voided', 'The warranty has been voided on-chain.');
+      setWarranty({ ...warranty, voided: true, voidedAt: Date.now() });
+    } catch (err) {
+      toast.dismiss(toastId);
+      toast.error('Void failed', err instanceof Error ? err.message : 'Unknown error');
+    } finally {
+      setVoidingPending(false);
+    }
+  }
+
+  function handleClaimStatusUpdate(claimId: string, status: ClaimStatus) {
+    setClaims((prev) =>
+      prev.map((c) => (c.claimId === claimId ? { ...c, status, updatedAt: Date.now() } : c)),
+    );
+  }
+
+  return (
+    <div>
+      {/* Header */}
+      <button type="button" onClick={() => setExpanded((v) => !v)}
+        className="flex items-center justify-between w-full text-left" aria-expanded={expanded}>
+        <div className="flex items-center gap-2">
+          <Shield size={16} className="text-violet-500" aria-hidden />
+          <span className="text-sm font-medium text-[var(--foreground)]">Warranty</span>
+          {warranty && <WarrantyStatusBadge warranty={warranty} productTimestamp={productTimestamp} />}
+        </div>
+        {expanded ? <ChevronUp size={16} className="text-[var(--muted)]" aria-hidden /> : <ChevronDown size={16} className="text-[var(--muted)]" aria-hidden />}
+      </button>
+
+      {expanded && (
+        <div className="mt-4 space-y-4">
+          {warranty ? (
+            <>
+              {/* Warranty details */}
+              <dl className="grid grid-cols-1 sm:grid-cols-2 gap-3 text-sm">
+                <div>
+                  <dt className="text-xs text-[var(--muted)]">Coverage</dt>
+                  <dd className="font-medium mt-0.5">{fmtDuration(warranty.durationSeconds)}</dd>
+                </div>
+                {expiry && (
+                  <div>
+                    <dt className="text-xs text-[var(--muted)]">Expires</dt>
+                    <dd className="font-medium mt-0.5 flex items-center gap-1">
+                      <Clock size={12} aria-hidden className="text-[var(--muted)]" />
+                      {expiry}
+                    </dd>
+                  </div>
+                )}
+                <div>
+                  <dt className="text-xs text-[var(--muted)]">Issued</dt>
+                  <dd className="font-medium mt-0.5">{fmtDate(warranty.issuedAt)}</dd>
+                </div>
+                {warranty.voided && (
+                  <div>
+                    <dt className="text-xs text-[var(--muted)]">Voided</dt>
+                    <dd className="font-medium mt-0.5 text-[var(--muted)]">{fmtDate(warranty.voidedAt)}</dd>
+                  </div>
+                )}
+                {warranty.terms && (
+                  <div className="sm:col-span-2">
+                    <dt className="text-xs text-[var(--muted)]">Terms</dt>
+                    <dd className="mt-0.5 text-[var(--foreground)]">{warranty.terms}</dd>
+                  </div>
+                )}
+                {warranty.termsRef && (
+                  <div className="sm:col-span-2">
+                    <dt className="text-xs text-[var(--muted)]">Document</dt>
+                    <dd className="mt-0.5">
+                      <a href={warranty.termsRef} target="_blank" rel="noopener noreferrer"
+                        className="inline-flex items-center gap-1 text-xs text-violet-500 hover:underline">
+                        <ExternalLink size={11} aria-hidden /> {warranty.termsRef}
+                      </a>
+                    </dd>
+                  </div>
+                )}
+              </dl>
+
+              {/* Owner actions */}
+              {isOwner && !warranty.voided && (
+                <button type="button" onClick={handleVoid} disabled={voidingPending}
+                  className="flex items-center gap-1.5 text-xs text-red-500 hover:underline disabled:opacity-50">
+                  {voidingPending ? <Loader2 size={12} className="animate-spin" aria-hidden /> : <ShieldOff size={12} aria-hidden />}
+                  Void warranty
+                </button>
+              )}
+
+              {/* Claims section */}
+              <div>
+                <div className="flex items-center justify-between mb-2">
+                  <h4 className="text-xs font-semibold text-[var(--foreground)] uppercase tracking-wide">
+                    Claims ({claims.length})
+                  </h4>
+                  {active && !showClaimForm && (
+                    <button type="button" onClick={() => setShowClaimForm(true)}
+                      className="flex items-center gap-1 text-xs text-violet-500 hover:underline">
+                      <Plus size={11} aria-hidden /> File claim
+                    </button>
+                  )}
+                </div>
+                {showClaimForm && (
+                  <FileClaimForm productId={productId}
+                    onSuccess={(c) => { setClaims((prev) => [...prev, c]); setShowClaimForm(false); }}
+                    onCancel={() => setShowClaimForm(false)} />
+                )}
+                <ClaimsList claims={claims} productId={productId} isOwner={isOwner}
+                  onStatusUpdate={handleClaimStatusUpdate} />
+              </div>
+            </>
+          ) : (
+            <>
+              <p className="text-sm text-[var(--muted)]">No warranty registered for this product.</p>
+              {isOwner && !showRegisterForm && (
+                <button type="button" onClick={() => setShowRegisterForm(true)}
+                  className="flex items-center gap-1.5 text-xs text-violet-500 hover:underline">
+                  <Plus size={12} aria-hidden /> Register warranty
+                </button>
+              )}
+              {showRegisterForm && (
+                <RegisterWarrantyForm productId={productId}
+                  onSuccess={(w) => { setWarranty(w); setShowRegisterForm(false); }}
+                  onCancel={() => setShowRegisterForm(false)} />
+              )}
+            </>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/lib/mock/products.ts
+++ b/frontend/lib/mock/products.ts
@@ -1,4 +1,4 @@
-import type { Product, TrackingEvent } from '@/lib/types';
+import type { Product, TrackingEvent, ProductAssembly, WarrantyInfo, WarrantyClaim } from '@/lib/types';
 
 export const MOCK_PRODUCTS: Product[] = [
   {
@@ -36,6 +36,18 @@ export const MOCK_PRODUCTS: Product[] = [
         revoked: false,
       },
     ],
+    // Warranty: 2-year warranty on the coffee batch
+    warranty: {
+      productId: 'prod-001',
+      durationSeconds: 2 * 365 * 24 * 3600,
+      issuer: 'GABC1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ',
+      issuedAt: 1710000000000,
+      terms: 'Quality guarantee: full refund if product does not meet grade specifications.',
+      termsRef: 'ipfs://QmWarrantyDocCoffeeBeans001',
+      voided: false,
+      voidedAt: 0,
+    },
+    warrantyClaims: [],
   },
   {
     id: 'prod-002',
@@ -66,6 +78,58 @@ export const MOCK_PRODUCTS: Product[] = [
         issuer: 'GACTOR3ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567',
         issuedAt: 1711200000000,
         revoked: false,
+      },
+    ],
+    // No warranty on cocoa batch
+  },
+  {
+    id: 'prod-003',
+    name: 'Premium Chocolate Bar',
+    origin: 'Belgium',
+    owner: 'GABC1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ',
+    timestamp: 1712000000000,
+    active: true,
+    authorizedActors: [
+      'GABC1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ',
+      'GACTOR1ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567',
+    ],
+    ownershipHistory: [
+      { owner: 'GABC1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ', transferredAt: 1712000000000 },
+    ],
+    category: 'food',
+    subcategory: 'confectionery',
+    certifications: [],
+    // Assembly: chocolate bar is assembled from coffee beans + cocoa
+    assembly: {
+      parentId: 'prod-003',
+      componentIds: ['prod-001', 'prod-002'],
+      registeredBy: 'GABC1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ',
+      registeredAt: 1712100000000,
+      description:
+        'Premium chocolate bar assembled from Ethiopian organic coffee beans and Ghanaian fair-trade cocoa.',
+    },
+    // Warranty: 1-year product warranty
+    warranty: {
+      productId: 'prod-003',
+      durationSeconds: 365 * 24 * 3600,
+      issuer: 'GABC1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ',
+      issuedAt: 1712000000000,
+      terms:
+        'Manufacturer warranty: replacement or refund for defective products within 1 year of purchase.',
+      termsRef: 'ipfs://QmWarrantyDocChocolateBar003',
+      voided: false,
+      voidedAt: 0,
+    },
+    warrantyClaims: [
+      {
+        claimId: 'claim-003-001',
+        productId: 'prod-003',
+        claimant: 'GCUSTOMER1ABCDEFGHIJKLMNOPQRSTUVWXYZ123',
+        filedAt: 1712500000000,
+        description: 'Packaging was damaged on arrival. Product quality unaffected.',
+        proofRef: 'ipfs://QmClaimProofDamagedPackaging',
+        status: 'Resolved',
+        updatedAt: 1712600000000,
       },
     ],
   },
@@ -150,6 +214,53 @@ export const MOCK_EVENTS: TrackingEvent[] = [
       sustainable_practices: ['agroforestry', 'no_child_labor'],
       renewable_energy_pct: 50,
       recyclable_packaging: false,
+    }),
+  },
+  // Events for the assembled chocolate bar (prod-003)
+  {
+    productId: 'prod-003',
+    eventType: 'PROCESSING',
+    location: 'Brussels, Belgium',
+    actor: 'GABC1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ',
+    timestamp: 1712000000000,
+    metadata: JSON.stringify({
+      process: 'Conching and tempering',
+      lat: 50.8503,
+      lng: 4.3517,
+      carbon_footprint: 20,
+      sustainable_practices: ['renewable_energy'],
+      renewable_energy_pct: 90,
+      recyclable_packaging: true,
+    }),
+  },
+  {
+    productId: 'prod-003',
+    eventType: 'SHIPPING',
+    location: 'Port of Antwerp, Belgium',
+    actor: 'GACTOR1ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567',
+    timestamp: 1712200000000,
+    metadata: JSON.stringify({
+      vessel: 'MV Cocoa Star',
+      destination: 'New York',
+      lat: 51.2194,
+      lng: 4.4025,
+      carbon_footprint: 35,
+      sustainable_practices: ['carbon_offset'],
+    }),
+  },
+  {
+    productId: 'prod-003',
+    eventType: 'RETAIL',
+    location: 'New York, USA',
+    actor: 'GABC1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ',
+    timestamp: 1712400000000,
+    metadata: JSON.stringify({
+      store: 'Artisan Chocolates NYC',
+      lat: 40.7128,
+      lng: -74.006,
+      carbon_footprint: 3,
+      recyclable_packaging: true,
+      renewable_energy_pct: 100,
     }),
   },
 ];

--- a/frontend/lib/stellar/client.ts
+++ b/frontend/lib/stellar/client.ts
@@ -193,3 +193,151 @@ export async function getActiveDelegations(
   await new Promise((r) => setTimeout(r, 500));
   return [];
 }
+
+// ── Assembly relationship stubs ───────────────────────────────────────────────
+
+/**
+ * Stub: call register_assembly on the Soroban contract.
+ * Registers a parent-child product assembly relationship on-chain.
+ */
+export async function registerAssembly(
+  parentId: string,
+  componentIds: string[],
+  description: string,
+  callerAddress: string,
+): Promise<string> {
+  console.log('registerAssembly', { parentId, componentIds, description, callerAddress });
+  // TODO: build + sign + submit Soroban transaction
+  await new Promise((r) => setTimeout(r, 1200));
+  return `mock_tx_assembly_${Date.now()}`;
+}
+
+/**
+ * Stub: call get_assembly on the Soroban contract.
+ * Returns the assembly record for a parent product, or null if none exists.
+ */
+export async function getAssembly(
+  parentId: string,
+): Promise<import('../types').ProductAssembly | null> {
+  console.log('getAssembly', { parentId });
+  // TODO: read from Soroban contract
+  await new Promise((r) => setTimeout(r, 500));
+  return null;
+}
+
+/**
+ * Stub: call get_parents_of_component on the Soroban contract.
+ * Returns all parent product IDs that reference the given component.
+ */
+export async function getParentsOfComponent(
+  componentId: string,
+  candidateParentIds: string[],
+): Promise<string[]> {
+  console.log('getParentsOfComponent', { componentId, candidateParentIds });
+  // TODO: read from Soroban contract
+  await new Promise((r) => setTimeout(r, 500));
+  return [];
+}
+
+// ── Warranty stubs ────────────────────────────────────────────────────────────
+
+/**
+ * Stub: call register_warranty on the Soroban contract.
+ * Registers warranty metadata for a product on-chain.
+ */
+export async function registerWarranty(
+  productId: string,
+  durationSeconds: number,
+  terms: string,
+  termsRef: string,
+  callerAddress: string,
+): Promise<string> {
+  console.log('registerWarranty', { productId, durationSeconds, terms, termsRef, callerAddress });
+  // TODO: build + sign + submit Soroban transaction
+  await new Promise((r) => setTimeout(r, 1200));
+  return `mock_tx_warranty_${Date.now()}`;
+}
+
+/**
+ * Stub: call get_warranty on the Soroban contract.
+ * Returns warranty metadata for a product, or null if none exists.
+ */
+export async function getWarranty(
+  productId: string,
+): Promise<import('../types').WarrantyInfo | null> {
+  console.log('getWarranty', { productId });
+  // TODO: read from Soroban contract
+  await new Promise((r) => setTimeout(r, 500));
+  return null;
+}
+
+/**
+ * Stub: call void_warranty on the Soroban contract.
+ * Voids the warranty for a product (owner-only).
+ */
+export async function voidWarranty(
+  productId: string,
+  callerAddress: string,
+): Promise<string> {
+  console.log('voidWarranty', { productId, callerAddress });
+  // TODO: build + sign + submit Soroban transaction
+  await new Promise((r) => setTimeout(r, 1000));
+  return `mock_tx_void_warranty_${Date.now()}`;
+}
+
+/**
+ * Stub: call is_warranty_active on the Soroban contract.
+ * Returns true if the product has an active, non-voided warranty.
+ */
+export async function isWarrantyActive(productId: string): Promise<boolean> {
+  console.log('isWarrantyActive', { productId });
+  // TODO: read from Soroban contract
+  await new Promise((r) => setTimeout(r, 300));
+  return false;
+}
+
+/**
+ * Stub: call file_warranty_claim on the Soroban contract.
+ * Files a warranty claim against a product.
+ */
+export async function fileWarrantyClaim(
+  productId: string,
+  claimId: string,
+  description: string,
+  proofRef: string,
+  callerAddress: string,
+): Promise<string> {
+  console.log('fileWarrantyClaim', { productId, claimId, description, proofRef, callerAddress });
+  // TODO: build + sign + submit Soroban transaction
+  await new Promise((r) => setTimeout(r, 1200));
+  return `mock_tx_claim_${Date.now()}`;
+}
+
+/**
+ * Stub: call list_warranty_claims on the Soroban contract.
+ * Returns all warranty claims for a product.
+ */
+export async function listWarrantyClaims(
+  productId: string,
+): Promise<import('../types').WarrantyClaim[]> {
+  console.log('listWarrantyClaims', { productId });
+  // TODO: read from Soroban contract
+  await new Promise((r) => setTimeout(r, 500));
+  return [];
+}
+
+/**
+ * Stub: call update_claim_status on the Soroban contract.
+ * Updates the status of a warranty claim (owner-only).
+ */
+export async function updateClaimStatus(
+  productId: string,
+  claimId: string,
+  newStatus: import('../types').ClaimStatus,
+  callerAddress: string,
+): Promise<string> {
+  console.log('updateClaimStatus', { productId, claimId, newStatus, callerAddress });
+  // TODO: build + sign + submit Soroban transaction
+  await new Promise((r) => setTimeout(r, 1000));
+  return `mock_tx_claim_status_${Date.now()}`;
+}

--- a/frontend/lib/types/index.ts
+++ b/frontend/lib/types/index.ts
@@ -6,7 +6,7 @@ export interface TemplateStage {
   eventType: EventType;
 }
 
-export type ActorRole = "Producer" | "Processor" | "Shipper" | "Retailer" | "Any";
+export type ActorRole = 'Producer' | 'Processor' | 'Shipper' | 'Retailer' | 'Any';
 
 export interface OwnershipRecord {
   owner: string;
@@ -23,6 +23,92 @@ export interface AuthPolicy {
   roles: ActorRoleAssignment[];
 }
 
+// ── Lifecycle (#404) ──────────────────────────────────────────────────────────
+
+export type LifecycleStage =
+  | 'Registered'
+  | 'Harvested'
+  | 'Processing'
+  | 'Shipping'
+  | 'Retail'
+  | 'Sold'
+  | 'Recalled'
+  | 'Deactivated';
+
+// ── Certifications (#428) ─────────────────────────────────────────────────────
+
+export interface Certification {
+  id: string;
+  productId: string;
+  certType: string;
+  issuer: string;
+  issuedAt: number;
+  revoked: boolean;
+  revokedAt?: number;
+}
+
+// ── Assembly relationships ────────────────────────────────────────────────────
+
+/** Parent-child product assembly relationship. */
+export interface ProductAssembly {
+  /** ID of the parent (assembled) product. */
+  parentId: string;
+  /** Ordered list of component product IDs. */
+  componentIds: string[];
+  /** Address of the actor who registered this assembly. */
+  registeredBy: string;
+  /** Unix ms timestamp when the assembly was registered. */
+  registeredAt: number;
+  /** Optional description of the assembly process. */
+  description: string;
+}
+
+// ── Warranty ──────────────────────────────────────────────────────────────────
+
+export type ClaimStatus = 'Pending' | 'Approved' | 'Rejected' | 'Resolved';
+
+/** Warranty metadata stored on-chain for a product. */
+export interface WarrantyInfo {
+  /** ID of the product this warranty covers. */
+  productId: string;
+  /** Warranty duration in seconds from product registration. 0 = lifetime. */
+  durationSeconds: number;
+  /** Address of the actor who registered the warranty. */
+  issuer: string;
+  /** Unix ms timestamp when the warranty was registered. */
+  issuedAt: number;
+  /** Short human-readable warranty terms. */
+  terms: string;
+  /** Off-chain reference to the full warranty document (IPFS CID, URL, etc.). */
+  termsRef: string;
+  /** Whether this warranty has been voided. */
+  voided: boolean;
+  /** Unix ms timestamp when the warranty was voided (0 if not voided). */
+  voidedAt: number;
+}
+
+/** A warranty claim filed against a product. */
+export interface WarrantyClaim {
+  /** Stable unique identifier for this claim. */
+  claimId: string;
+  /** ID of the product the claim is filed against. */
+  productId: string;
+  /** Address of the claimant. */
+  claimant: string;
+  /** Unix ms timestamp when the claim was filed. */
+  filedAt: number;
+  /** Description of the issue. */
+  description: string;
+  /** Off-chain proof reference (IPFS CID, URL, etc.). */
+  proofRef: string;
+  /** Current status of the claim. */
+  status: ClaimStatus;
+  /** Unix ms timestamp when the claim status was last updated. */
+  updatedAt: number;
+}
+
+// ── Product ───────────────────────────────────────────────────────────────────
+
 export interface Product {
   id: string;
   name: string;
@@ -36,25 +122,6 @@ export interface Product {
   expirationTimestamp?: number;
   /** Whether the product has been marked as spoiled. (#406) */
   spoiled?: boolean;
-  /** true while an on-chain transaction is in-flight */
-  pending?: boolean;
-}
-
-export interface Batch {
-  id: string;
-  name: string;
-  owner: string;
-  productIds: string[];
-  timestamp: number;
-  active: boolean;
-  status?: ProductStatus;
-  authorizedActors: string[];
-  ownershipHistory?: OwnershipRecord[];
-  /** Current lifecycle stage (#404) */
-  lifecycleStage?: LifecycleStage;
-  pending?: boolean;
-  /** Number of signatures required for events (0 or 1 = immediate, >1 = multi-sig) */
-  requiredSignatures?: number;
   /** true while an on-chain transaction is in-flight (#49) */
   pending?: boolean;
   /** Whether this product has been recalled (#393) */
@@ -73,7 +140,37 @@ export interface Batch {
   subcategory?: string;
   /** On-chain certifications attached to this product (#428) */
   certifications?: Certification[];
+  /** Number of signatures required for events (0 or 1 = immediate, >1 = multi-sig) */
+  requiredSignatures?: number;
+  /** Current lifecycle stage (#404) */
+  lifecycleStage?: LifecycleStage;
+  /** Assembly relationship — present if this product is assembled from components. */
+  assembly?: ProductAssembly;
+  /** Warranty metadata — present if a warranty has been registered. */
+  warranty?: WarrantyInfo;
+  /** Warranty claims filed against this product. */
+  warrantyClaims?: WarrantyClaim[];
 }
+
+// ── Batch (#405) ──────────────────────────────────────────────────────────────
+
+export interface Batch {
+  id: string;
+  name: string;
+  owner: string;
+  productIds: string[];
+  timestamp: number;
+  active: boolean;
+  status?: ProductStatus;
+  authorizedActors: string[];
+  ownershipHistory?: OwnershipRecord[];
+  lifecycleStage?: LifecycleStage;
+  /** true while an on-chain transaction is in-flight (#49) */
+  pending?: boolean;
+  requiredSignatures?: number;
+}
+
+// ── Tracking events ───────────────────────────────────────────────────────────
 
 export interface TrackingEvent {
   productId: string;
@@ -84,7 +181,23 @@ export interface TrackingEvent {
   metadata: string;
   stableId?: string;
   pending?: boolean;
+  schemaVersion?: number;
 }
+
+// ── Pending events (#394) ─────────────────────────────────────────────────────
+
+/** Pending event awaiting multi-party approval (#394) */
+export interface PendingEvent {
+  pendingEventId: number;
+  productId: string;
+  event: TrackingEvent;
+  approvals: string[];
+  requiredSignatures: number;
+  createdAt: number;
+  expiration?: number;
+}
+
+// ── Transfer escrow (#396) ────────────────────────────────────────────────────
 
 /** Pending ownership transfer escrow (#396) */
 export interface TransferEscrow {
@@ -95,41 +208,23 @@ export interface TransferEscrow {
   disputed: boolean;
 }
 
-/** Pending event awaiting multi-party approval (#394) */
-export interface PendingEvent {
-  productId: string;
-  submitter: string;
-  location: string;
-  eventType: EventType;
-  metadata: string;
-  submittedAt: number;
-  requiredApprovers: string[];
-  approvals: string[];
-  rejected: boolean;
-  expiresAt: number;
-}
+// ── Pagination ────────────────────────────────────────────────────────────────
 
 export interface EventPage {
   events: TrackingEvent[];
-  /** Stable deterministic event ID — SHA-256 hex (#386) */
-  stableId?: string;
-  /** true while an on-chain transaction is in-flight (#49) */
-  pending?: boolean;
-  /** Schema version of this record (#392) */
-  schemaVersion?: number;
+  total: number;
+  offset: number;
+  limit: number;
 }
 
-export interface EventPage {
-  events: TrackingEvent[];
-export interface PendingEvent {
-  pendingEventId: number;
-  productId: string;
-  event: TrackingEvent;
-  approvals: string[];
-  requiredSignatures: number;
-  createdAt: number;
-  expiration?: number;
+export interface PaginatedResponse<T> {
+  items: T[];
+  total: number;
+  offset: number;
+  limit: number;
 }
+
+// ── Notifications ─────────────────────────────────────────────────────────────
 
 export type NotificationType =
   | 'TRACKING_EVENT'
@@ -153,6 +248,8 @@ export interface Notification {
   message?: string;
 }
 
+// ── Misc ──────────────────────────────────────────────────────────────────────
+
 export interface TransactionResult {
   hash: string;
   status: 'success' | 'failed' | 'pending';
@@ -165,18 +262,13 @@ export interface ContractError {
   message: string;
 }
 
-export interface PaginatedResponse<T> {
-  items: T[];
-  total: number;
-  offset: number;
-  limit: number;
-}
-
 export interface EventFilter {
   eventType?: EventType | null;
   actor?: string | null;
   fromTimestamp?: number | null;
   toTimestamp?: number | null;
+}
+
 export interface Rating {
   id: string;
   productId: string;
@@ -184,4 +276,12 @@ export interface Rating {
   stars: number;
   comment: string | null;
   timestamp: number;
+}
+
+export interface Delegation {
+  id: number;
+  productId: string;
+  delegatee: string;
+  expiresAt: number;
+  active: boolean;
 }

--- a/smart-contract/contracts/src/assembly_warranty.rs
+++ b/smart-contract/contracts/src/assembly_warranty.rs
@@ -1,0 +1,545 @@
+/// assembly_warranty.rs
+///
+/// Product assembly relationships (parent-child) and warranty tracking.
+///
+/// # Assembly
+/// A parent product can reference one or more component products. The
+/// relationship is stored as a [`ProductAssembly`] record keyed by the parent
+/// product ID. Components carry their own provenance chains; the assembly
+/// record aggregates them under a single parent.
+///
+/// # Warranty
+/// A product can have warranty metadata stored on-chain. Warranty claims are
+/// linked to the product's provenance and stored as [`WarrantyClaim`] records.
+
+#![allow(unused_imports)]
+use soroban_sdk::{contracttype, Address, Env, String, Vec, Symbol};
+
+use crate::{DataKey, Error, Product, MAX_ID_LEN, MAX_METADATA_LEN};
+
+// ── Size limits ───────────────────────────────────────────────────────────────
+
+/// Maximum number of component products in a single assembly.
+pub const MAX_ASSEMBLY_COMPONENTS: u32 = 50;
+
+/// Maximum length of a warranty terms string.
+pub const MAX_WARRANTY_TERMS_LEN: u32 = 1024;
+
+/// Maximum length of a claim proof reference (e.g. IPFS CID or URL).
+pub const MAX_CLAIM_PROOF_LEN: u32 = 512;
+
+// ── Data types ────────────────────────────────────────────────────────────────
+
+/// Represents a parent-child product assembly relationship.
+///
+/// A parent product is assembled from one or more component products. Each
+/// component carries its own provenance chain. The assembly record stores the
+/// ordered list of component IDs and an optional description of the assembly
+/// process.
+///
+/// # Storage
+/// Stored under [`DataKey::Assembly`] keyed by the parent product ID.
+/// Persistent storage — survives ledger expiry.
+#[contracttype]
+#[derive(Clone)]
+pub struct ProductAssembly {
+    /// ID of the parent (assembled) product.
+    pub parent_id: String,
+    /// Ordered list of component product IDs.
+    pub component_ids: Vec<String>,
+    /// Address of the actor who registered this assembly relationship.
+    pub registered_by: Address,
+    /// Ledger timestamp when the assembly was registered.
+    pub registered_at: u64,
+    /// Optional free-form description of the assembly process.
+    pub description: String,
+}
+
+/// Warranty metadata for a product.
+///
+/// Stored on-chain alongside the product. Warranty coverage is defined by
+/// `duration_seconds` from the product's registration timestamp. The
+/// `terms_ref` field can hold an IPFS CID or URL pointing to the full
+/// warranty document stored off-chain.
+///
+/// # Storage
+/// Stored under [`DataKey::Warranty`] keyed by the product ID.
+#[contracttype]
+#[derive(Clone)]
+pub struct WarrantyInfo {
+    /// ID of the product this warranty covers.
+    pub product_id: String,
+    /// Warranty duration in seconds from product registration timestamp.
+    /// 0 means no expiry (lifetime warranty).
+    pub duration_seconds: u64,
+    /// Address of the actor who registered the warranty (typically the owner).
+    pub issuer: Address,
+    /// Ledger timestamp when the warranty was registered.
+    pub issued_at: u64,
+    /// Short human-readable summary of warranty terms (max 1024 bytes).
+    pub terms: String,
+    /// Off-chain reference to the full warranty document (IPFS CID, URL, etc.).
+    /// Max 512 bytes.
+    pub terms_ref: String,
+    /// Whether this warranty has been voided.
+    pub voided: bool,
+    /// Ledger timestamp when the warranty was voided (0 if not voided).
+    pub voided_at: u64,
+}
+
+/// A warranty claim filed against a product.
+///
+/// Claims are append-only. Each claim references the product's provenance
+/// (via `provenance_ref`) and optionally includes a proof document reference.
+///
+/// # Storage
+/// Stored as a `Vec<WarrantyClaim>` under [`DataKey::WarrantyClaims`] keyed
+/// by the product ID.
+#[contracttype]
+#[derive(Clone)]
+pub struct WarrantyClaim {
+    /// Stable unique identifier for this claim (caller-supplied).
+    pub claim_id: String,
+    /// ID of the product the claim is filed against.
+    pub product_id: String,
+    /// Address of the claimant.
+    pub claimant: Address,
+    /// Ledger timestamp when the claim was filed.
+    pub filed_at: u64,
+    /// Short description of the issue (stored in metadata JSON, max 4096 bytes).
+    pub description: String,
+    /// Off-chain proof reference (IPFS CID, URL, etc.). Max 512 bytes.
+    pub proof_ref: String,
+    /// Current status of the claim.
+    pub status: ClaimStatus,
+    /// Ledger timestamp when the claim status was last updated.
+    pub updated_at: u64,
+}
+
+/// Lifecycle status of a warranty claim.
+#[contracttype]
+#[derive(Clone, PartialEq, Debug)]
+pub enum ClaimStatus {
+    /// Claim has been filed and is awaiting review.
+    Pending,
+    /// Claim has been approved by the product owner.
+    Approved,
+    /// Claim has been rejected by the product owner.
+    Rejected,
+    /// Claim has been resolved (repair/replacement completed).
+    Resolved,
+}
+
+// ── Storage key extensions ────────────────────────────────────────────────────
+// These variants are added to the existing DataKey enum in lib.rs via
+// the assembly_warranty module. They are declared here for documentation
+// purposes; the actual DataKey enum in lib.rs must include them.
+//
+// DataKey::Assembly(String)        — ProductAssembly keyed by parent_id
+// DataKey::Warranty(String)        — WarrantyInfo keyed by product_id
+// DataKey::WarrantyClaims(String)  — Vec<WarrantyClaim> keyed by product_id
+
+// ── Assembly helpers ──────────────────────────────────────────────────────────
+
+/// Register or replace the assembly relationship for a parent product.
+///
+/// # Authorization
+/// Requires the parent product owner's auth.
+///
+/// # Panics
+/// - `"parent product not found"` — if `parent_id` is not registered.
+/// - `"component product not found: <id>"` — if any component ID is not registered.
+/// - `"assembly exceeds maximum component count"` — if more than 50 components.
+/// - `"description exceeds max length"` — if description > 4096 bytes.
+pub fn register_assembly(
+    env: &Env,
+    parent_id: String,
+    component_ids: Vec<String>,
+    description: String,
+    caller: Address,
+) -> Result<ProductAssembly, Error> {
+    // Validate parent exists
+    let parent: Product = env
+        .storage()
+        .persistent()
+        .get(&DataKey::Product(parent_id.clone()))
+        .ok_or(Error::ProductNotFound)?;
+
+    // Only owner may register assembly
+    if parent.owner != caller {
+        return Err(Error::NotAuthorized);
+    }
+    caller.require_auth();
+
+    // Validate component count
+    if component_ids.len() > MAX_ASSEMBLY_COMPONENTS {
+        panic!("assembly exceeds maximum component count");
+    }
+
+    // Validate description length
+    if description.len() > MAX_METADATA_LEN {
+        panic!("description exceeds max length");
+    }
+
+    // Validate all components exist
+    for i in 0..component_ids.len() {
+        let cid = component_ids.get(i).unwrap();
+        if !env.storage().persistent().has(&DataKey::Product(cid.clone())) {
+            panic!("component product not found");
+        }
+    }
+
+    let assembly = ProductAssembly {
+        parent_id: parent_id.clone(),
+        component_ids,
+        registered_by: caller,
+        registered_at: env.ledger().timestamp(),
+        description,
+    };
+
+    env.storage()
+        .persistent()
+        .set(&DataKey::Assembly(parent_id.clone()), &assembly);
+
+    env.events().publish(
+        (Symbol::new(env, "assembly_registered"), parent_id),
+        assembly.clone(),
+    );
+
+    Ok(assembly)
+}
+
+/// Retrieve the assembly record for a parent product.
+///
+/// Returns `None` if no assembly has been registered for this product.
+pub fn get_assembly(env: &Env, parent_id: String) -> Option<ProductAssembly> {
+    env.storage()
+        .persistent()
+        .get(&DataKey::Assembly(parent_id))
+}
+
+/// Return all parent product IDs that reference `component_id` as a component.
+///
+/// This is a linear scan over all assemblies stored under the provided
+/// `parent_ids` hint list. In a production system this would be maintained
+/// as a reverse index; here we accept a caller-supplied list of candidate
+/// parent IDs to keep storage costs bounded.
+pub fn get_parents_of_component(
+    env: &Env,
+    component_id: String,
+    candidate_parent_ids: Vec<String>,
+) -> Vec<String> {
+    let mut parents = Vec::new(env);
+    for i in 0..candidate_parent_ids.len() {
+        let pid = candidate_parent_ids.get(i).unwrap();
+        if let Some(assembly) = env
+            .storage()
+            .persistent()
+            .get::<DataKey, ProductAssembly>(&DataKey::Assembly(pid.clone()))
+        {
+            if assembly.component_ids.contains(&component_id) {
+                parents.push_back(pid);
+            }
+        }
+    }
+    parents
+}
+
+// ── Warranty helpers ──────────────────────────────────────────────────────────
+
+/// Register warranty metadata for a product.
+///
+/// # Authorization
+/// Requires the product owner's auth.
+///
+/// # Panics
+/// - `"product not found"` — if `product_id` is not registered.
+/// - `"terms exceeds max length"` — if terms > 1024 bytes.
+/// - `"terms_ref exceeds max length"` — if terms_ref > 512 bytes.
+pub fn register_warranty(
+    env: &Env,
+    product_id: String,
+    duration_seconds: u64,
+    terms: String,
+    terms_ref: String,
+    caller: Address,
+) -> Result<WarrantyInfo, Error> {
+    let product: Product = env
+        .storage()
+        .persistent()
+        .get(&DataKey::Product(product_id.clone()))
+        .ok_or(Error::ProductNotFound)?;
+
+    if product.owner != caller {
+        return Err(Error::NotAuthorized);
+    }
+    caller.require_auth();
+
+    if terms.len() > MAX_WARRANTY_TERMS_LEN {
+        panic!("terms exceeds max length");
+    }
+    if terms_ref.len() > MAX_CLAIM_PROOF_LEN {
+        panic!("terms_ref exceeds max length");
+    }
+
+    let warranty = WarrantyInfo {
+        product_id: product_id.clone(),
+        duration_seconds,
+        issuer: caller,
+        issued_at: env.ledger().timestamp(),
+        terms,
+        terms_ref,
+        voided: false,
+        voided_at: 0,
+    };
+
+    env.storage()
+        .persistent()
+        .set(&DataKey::Warranty(product_id.clone()), &warranty);
+
+    env.events().publish(
+        (Symbol::new(env, "warranty_registered"), product_id),
+        warranty.clone(),
+    );
+
+    Ok(warranty)
+}
+
+/// Retrieve warranty metadata for a product.
+///
+/// Returns `None` if no warranty has been registered.
+pub fn get_warranty(env: &Env, product_id: String) -> Option<WarrantyInfo> {
+    env.storage()
+        .persistent()
+        .get(&DataKey::Warranty(product_id))
+}
+
+/// Void a warranty. Owner-only.
+///
+/// # Panics
+/// - `"product not found"` — if `product_id` is not registered.
+/// - `"no warranty registered"` — if no warranty exists for this product.
+pub fn void_warranty(
+    env: &Env,
+    product_id: String,
+    caller: Address,
+) -> Result<WarrantyInfo, Error> {
+    let product: Product = env
+        .storage()
+        .persistent()
+        .get(&DataKey::Product(product_id.clone()))
+        .ok_or(Error::ProductNotFound)?;
+
+    if product.owner != caller {
+        return Err(Error::NotAuthorized);
+    }
+    caller.require_auth();
+
+    let mut warranty: WarrantyInfo = env
+        .storage()
+        .persistent()
+        .get(&DataKey::Warranty(product_id.clone()))
+        .ok_or_else(|| panic!("no warranty registered"))?;
+
+    warranty.voided = true;
+    warranty.voided_at = env.ledger().timestamp();
+
+    env.storage()
+        .persistent()
+        .set(&DataKey::Warranty(product_id.clone()), &warranty);
+
+    env.events().publish(
+        (Symbol::new(env, "warranty_voided"), product_id),
+        warranty.clone(),
+    );
+
+    Ok(warranty)
+}
+
+/// Check whether a product's warranty is currently active.
+///
+/// Returns `true` if:
+/// - A warranty exists for the product, AND
+/// - The warranty has not been voided, AND
+/// - Either `duration_seconds == 0` (lifetime) OR the current ledger time
+///   is within `product.timestamp + duration_seconds`.
+pub fn is_warranty_active(env: &Env, product_id: String) -> bool {
+    let product: Product = match env
+        .storage()
+        .persistent()
+        .get(&DataKey::Product(product_id.clone()))
+    {
+        Some(p) => p,
+        None => return false,
+    };
+
+    let warranty: WarrantyInfo = match env
+        .storage()
+        .persistent()
+        .get(&DataKey::Warranty(product_id))
+    {
+        Some(w) => w,
+        None => return false,
+    };
+
+    if warranty.voided {
+        return false;
+    }
+
+    if warranty.duration_seconds == 0 {
+        return true; // lifetime warranty
+    }
+
+    let expiry = product.timestamp + warranty.duration_seconds;
+    env.ledger().timestamp() <= expiry
+}
+
+// ── Warranty claim helpers ────────────────────────────────────────────────────
+
+/// File a warranty claim against a product.
+///
+/// # Authorization
+/// Any address may file a claim (the claimant self-authorizes).
+///
+/// # Panics
+/// - `"product not found"` — if `product_id` is not registered.
+/// - `"no warranty registered"` — if no warranty exists.
+/// - `"warranty is voided"` — if the warranty has been voided.
+/// - `"claim_id exceeds max length"` — if claim_id > 128 bytes.
+/// - `"description exceeds max length"` — if description > 4096 bytes.
+/// - `"proof_ref exceeds max length"` — if proof_ref > 512 bytes.
+pub fn file_warranty_claim(
+    env: &Env,
+    product_id: String,
+    claim_id: String,
+    description: String,
+    proof_ref: String,
+    claimant: Address,
+) -> Result<WarrantyClaim, Error> {
+    // Validate product exists
+    if !env
+        .storage()
+        .persistent()
+        .has(&DataKey::Product(product_id.clone()))
+    {
+        return Err(Error::ProductNotFound);
+    }
+
+    // Validate warranty exists and is not voided
+    let warranty: WarrantyInfo = env
+        .storage()
+        .persistent()
+        .get(&DataKey::Warranty(product_id.clone()))
+        .ok_or_else(|| panic!("no warranty registered"))?;
+
+    if warranty.voided {
+        panic!("warranty is voided");
+    }
+
+    claimant.require_auth();
+
+    if claim_id.len() > MAX_ID_LEN {
+        panic!("claim_id exceeds max length");
+    }
+    if description.len() > MAX_METADATA_LEN {
+        panic!("description exceeds max length");
+    }
+    if proof_ref.len() > MAX_CLAIM_PROOF_LEN {
+        panic!("proof_ref exceeds max length");
+    }
+
+    let claim = WarrantyClaim {
+        claim_id: claim_id.clone(),
+        product_id: product_id.clone(),
+        claimant,
+        filed_at: env.ledger().timestamp(),
+        description,
+        proof_ref,
+        status: ClaimStatus::Pending,
+        updated_at: env.ledger().timestamp(),
+    };
+
+    let mut claims: Vec<WarrantyClaim> = env
+        .storage()
+        .persistent()
+        .get(&DataKey::WarrantyClaims(product_id.clone()))
+        .unwrap_or_else(|| Vec::new(env));
+
+    claims.push_back(claim.clone());
+    env.storage()
+        .persistent()
+        .set(&DataKey::WarrantyClaims(product_id.clone()), &claims);
+
+    env.events().publish(
+        (Symbol::new(env, "warranty_claim_filed"), product_id),
+        claim.clone(),
+    );
+
+    Ok(claim)
+}
+
+/// Update the status of a warranty claim. Owner-only.
+///
+/// # Authorization
+/// Requires the product owner's auth.
+///
+/// # Panics
+/// - `"product not found"` — if `product_id` is not registered.
+/// - `"claim not found"` — if no claim with `claim_id` exists.
+pub fn update_claim_status(
+    env: &Env,
+    product_id: String,
+    claim_id: String,
+    new_status: ClaimStatus,
+    caller: Address,
+) -> Result<WarrantyClaim, Error> {
+    let product: Product = env
+        .storage()
+        .persistent()
+        .get(&DataKey::Product(product_id.clone()))
+        .ok_or(Error::ProductNotFound)?;
+
+    if product.owner != caller {
+        return Err(Error::NotAuthorized);
+    }
+    caller.require_auth();
+
+    let mut claims: Vec<WarrantyClaim> = env
+        .storage()
+        .persistent()
+        .get(&DataKey::WarrantyClaims(product_id.clone()))
+        .unwrap_or_else(|| Vec::new(env));
+
+    let mut found_index: Option<u32> = None;
+    for i in 0..claims.len() {
+        if claims.get(i).unwrap().claim_id == claim_id {
+            found_index = Some(i);
+            break;
+        }
+    }
+
+    let idx = found_index.ok_or_else(|| panic!("claim not found"))?;
+    let mut claim = claims.get(idx).unwrap().clone();
+    claim.status = new_status;
+    claim.updated_at = env.ledger().timestamp();
+    claims.set(idx, claim.clone());
+
+    env.storage()
+        .persistent()
+        .set(&DataKey::WarrantyClaims(product_id.clone()), &claims);
+
+    env.events().publish(
+        (Symbol::new(env, "warranty_claim_updated"), product_id),
+        claim.clone(),
+    );
+
+    Ok(claim)
+}
+
+/// Return all warranty claims for a product.
+pub fn list_warranty_claims(env: &Env, product_id: String) -> Vec<WarrantyClaim> {
+    env.storage()
+        .persistent()
+        .get(&DataKey::WarrantyClaims(product_id))
+        .unwrap_or_else(|| Vec::new(env))
+}

--- a/smart-contract/contracts/src/assembly_warranty_tests.rs
+++ b/smart-contract/contracts/src/assembly_warranty_tests.rs
@@ -1,0 +1,662 @@
+/// assembly_warranty_tests.rs
+///
+/// Tests for product assembly relationships and warranty lifecycle.
+
+#![cfg(test)]
+use soroban_sdk::{testutils::Address as _, Address, Env, String, Vec};
+
+use crate::{
+    assembly_warranty::{ClaimStatus, ProductAssembly, WarrantyClaim, WarrantyInfo},
+    SupplyLinkContract, SupplyLinkContractClient,
+};
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+fn setup() -> (Env, Address, SupplyLinkContractClient<'static>) {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, SupplyLinkContract);
+    let owner = Address::generate(&env);
+    let client = SupplyLinkContractClient::new(&env, &contract_id);
+    (env, owner, client)
+}
+
+fn s(env: &Env, val: &str) -> String {
+    String::from_str(env, val)
+}
+
+fn register(client: &SupplyLinkContractClient, env: &Env, id: &str, owner: &Address) {
+    client.register_product(
+        &s(env, id),
+        &s(env, &format!("Product {}", id)),
+        &s(env, "Origin"),
+        owner,
+        &0u32,
+        &s(env, "other"),
+        &s(env, "general"),
+    );
+}
+
+fn add_harvest_event(client: &SupplyLinkContractClient, env: &Env, product_id: &str, owner: &Address) {
+    client.add_tracking_event(
+        &s(env, product_id),
+        owner,
+        &s(env, "Farm"),
+        &s(env, "HARVEST"),
+        &s(env, "{}"),
+    );
+}
+
+// ── Assembly tests ────────────────────────────────────────────────────────────
+
+#[test]
+fn test_register_assembly_success() {
+    let (env, owner, client) = setup();
+
+    // Register parent and two components
+    register(&client, &env, "parent-001", &owner);
+    register(&client, &env, "comp-001", &owner);
+    register(&client, &env, "comp-002", &owner);
+
+    let mut components = Vec::new(&env);
+    components.push_back(s(&env, "comp-001"));
+    components.push_back(s(&env, "comp-002"));
+
+    let assembly = client
+        .register_assembly(
+            &s(&env, "parent-001"),
+            &components,
+            &s(&env, "Assembled from two components"),
+            &owner,
+        )
+        .unwrap();
+
+    assert_eq!(assembly.parent_id, s(&env, "parent-001"));
+    assert_eq!(assembly.component_ids.len(), 2);
+    assert_eq!(assembly.description, s(&env, "Assembled from two components"));
+}
+
+#[test]
+fn test_get_assembly_returns_none_when_not_registered() {
+    let (env, owner, client) = setup();
+    register(&client, &env, "solo-001", &owner);
+
+    let result = client.get_assembly(&s(&env, "solo-001"));
+    assert!(result.is_none());
+}
+
+#[test]
+fn test_get_assembly_returns_registered_assembly() {
+    let (env, owner, client) = setup();
+
+    register(&client, &env, "parent-002", &owner);
+    register(&client, &env, "comp-003", &owner);
+
+    let mut components = Vec::new(&env);
+    components.push_back(s(&env, "comp-003"));
+
+    client
+        .register_assembly(
+            &s(&env, "parent-002"),
+            &components,
+            &s(&env, "Single component assembly"),
+            &owner,
+        )
+        .unwrap();
+
+    let assembly = client.get_assembly(&s(&env, "parent-002")).unwrap();
+    assert_eq!(assembly.component_ids.len(), 1);
+    assert_eq!(assembly.component_ids.get(0).unwrap(), s(&env, "comp-003"));
+}
+
+#[test]
+fn test_register_assembly_replaces_existing() {
+    let (env, owner, client) = setup();
+
+    register(&client, &env, "parent-003", &owner);
+    register(&client, &env, "comp-a", &owner);
+    register(&client, &env, "comp-b", &owner);
+    register(&client, &env, "comp-c", &owner);
+
+    let mut v1 = Vec::new(&env);
+    v1.push_back(s(&env, "comp-a"));
+    client
+        .register_assembly(&s(&env, "parent-003"), &v1, &s(&env, "v1"), &owner)
+        .unwrap();
+
+    let mut v2 = Vec::new(&env);
+    v2.push_back(s(&env, "comp-b"));
+    v2.push_back(s(&env, "comp-c"));
+    client
+        .register_assembly(&s(&env, "parent-003"), &v2, &s(&env, "v2"), &owner)
+        .unwrap();
+
+    let assembly = client.get_assembly(&s(&env, "parent-003")).unwrap();
+    assert_eq!(assembly.component_ids.len(), 2);
+    assert_eq!(assembly.description, s(&env, "v2"));
+}
+
+#[test]
+fn test_get_parents_of_component() {
+    let (env, owner, client) = setup();
+
+    register(&client, &env, "parent-p1", &owner);
+    register(&client, &env, "parent-p2", &owner);
+    register(&client, &env, "shared-comp", &owner);
+
+    let mut c1 = Vec::new(&env);
+    c1.push_back(s(&env, "shared-comp"));
+    client
+        .register_assembly(&s(&env, "parent-p1"), &c1, &s(&env, ""), &owner)
+        .unwrap();
+
+    let mut c2 = Vec::new(&env);
+    c2.push_back(s(&env, "shared-comp"));
+    client
+        .register_assembly(&s(&env, "parent-p2"), &c2, &s(&env, ""), &owner)
+        .unwrap();
+
+    let mut candidates = Vec::new(&env);
+    candidates.push_back(s(&env, "parent-p1"));
+    candidates.push_back(s(&env, "parent-p2"));
+
+    let parents = client.get_parents_of_component(&s(&env, "shared-comp"), &candidates);
+    assert_eq!(parents.len(), 2);
+}
+
+#[test]
+fn test_get_parents_of_component_returns_empty_when_no_match() {
+    let (env, owner, client) = setup();
+
+    register(&client, &env, "parent-x", &owner);
+    register(&client, &env, "comp-x", &owner);
+    register(&client, &env, "unrelated", &owner);
+
+    let mut c = Vec::new(&env);
+    c.push_back(s(&env, "comp-x"));
+    client
+        .register_assembly(&s(&env, "parent-x"), &c, &s(&env, ""), &owner)
+        .unwrap();
+
+    let mut candidates = Vec::new(&env);
+    candidates.push_back(s(&env, "parent-x"));
+
+    let parents = client.get_parents_of_component(&s(&env, "unrelated"), &candidates);
+    assert_eq!(parents.len(), 0);
+}
+
+#[test]
+#[should_panic(expected = "assembly exceeds maximum component count")]
+fn test_register_assembly_exceeds_max_components() {
+    let (env, owner, client) = setup();
+    register(&client, &env, "big-parent", &owner);
+
+    // Build a Vec of 51 IDs — count check fires before product-existence check
+    let mut components = Vec::new(&env);
+    for i in 0..51u32 {
+        // Use a simple pattern; these don't need to be registered products
+        // because the count guard panics first
+        let id_str = match i {
+            0 => "x00", 1 => "x01", 2 => "x02", 3 => "x03", 4 => "x04",
+            5 => "x05", 6 => "x06", 7 => "x07", 8 => "x08", 9 => "x09",
+            10 => "x10", 11 => "x11", 12 => "x12", 13 => "x13", 14 => "x14",
+            15 => "x15", 16 => "x16", 17 => "x17", 18 => "x18", 19 => "x19",
+            20 => "x20", 21 => "x21", 22 => "x22", 23 => "x23", 24 => "x24",
+            25 => "x25", 26 => "x26", 27 => "x27", 28 => "x28", 29 => "x29",
+            30 => "x30", 31 => "x31", 32 => "x32", 33 => "x33", 34 => "x34",
+            35 => "x35", 36 => "x36", 37 => "x37", 38 => "x38", 39 => "x39",
+            40 => "x40", 41 => "x41", 42 => "x42", 43 => "x43", 44 => "x44",
+            45 => "x45", 46 => "x46", 47 => "x47", 48 => "x48", 49 => "x49",
+            _ => "x50",
+        };
+        components.push_back(s(&env, id_str));
+    }
+
+    client
+        .register_assembly(&s(&env, "big-parent"), &components, &s(&env, ""), &owner)
+        .unwrap();
+}
+
+#[test]
+fn test_register_assembly_unauthorized() {
+    let (env, owner, client) = setup();
+    let stranger = Address::generate(&env);
+
+    register(&client, &env, "parent-auth", &owner);
+    register(&client, &env, "comp-auth", &owner);
+
+    let mut components = Vec::new(&env);
+    components.push_back(s(&env, "comp-auth"));
+
+    let result = client.register_assembly(
+        &s(&env, "parent-auth"),
+        &components,
+        &s(&env, ""),
+        &stranger,
+    );
+    assert!(result.is_err());
+}
+
+// ── Warranty tests ────────────────────────────────────────────────────────────
+
+#[test]
+fn test_register_warranty_success() {
+    let (env, owner, client) = setup();
+    register(&client, &env, "warr-001", &owner);
+
+    let warranty = client
+        .register_warranty(
+            &s(&env, "warr-001"),
+            &(365 * 24 * 3600u64), // 1 year
+            &s(&env, "Standard 1-year warranty"),
+            &s(&env, "ipfs://QmWarrantyDoc"),
+            &owner,
+        )
+        .unwrap();
+
+    assert_eq!(warranty.product_id, s(&env, "warr-001"));
+    assert_eq!(warranty.duration_seconds, 365 * 24 * 3600u64);
+    assert!(!warranty.voided);
+    assert_eq!(warranty.voided_at, 0);
+}
+
+#[test]
+fn test_get_warranty_returns_none_when_not_registered() {
+    let (env, owner, client) = setup();
+    register(&client, &env, "no-warr", &owner);
+
+    let result = client.get_warranty(&s(&env, "no-warr"));
+    assert!(result.is_none());
+}
+
+#[test]
+fn test_get_warranty_returns_registered_warranty() {
+    let (env, owner, client) = setup();
+    register(&client, &env, "warr-002", &owner);
+
+    client
+        .register_warranty(
+            &s(&env, "warr-002"),
+            &0u64, // lifetime
+            &s(&env, "Lifetime warranty"),
+            &s(&env, ""),
+            &owner,
+        )
+        .unwrap();
+
+    let warranty = client.get_warranty(&s(&env, "warr-002")).unwrap();
+    assert_eq!(warranty.duration_seconds, 0);
+    assert_eq!(warranty.terms, s(&env, "Lifetime warranty"));
+}
+
+#[test]
+fn test_is_warranty_active_returns_true_for_lifetime() {
+    let (env, owner, client) = setup();
+    register(&client, &env, "warr-lifetime", &owner);
+
+    client
+        .register_warranty(
+            &s(&env, "warr-lifetime"),
+            &0u64,
+            &s(&env, "Lifetime"),
+            &s(&env, ""),
+            &owner,
+        )
+        .unwrap();
+
+    assert!(client.is_warranty_active(&s(&env, "warr-lifetime")));
+}
+
+#[test]
+fn test_is_warranty_active_returns_false_when_no_warranty() {
+    let (env, owner, client) = setup();
+    register(&client, &env, "no-warr-2", &owner);
+
+    assert!(!client.is_warranty_active(&s(&env, "no-warr-2")));
+}
+
+#[test]
+fn test_void_warranty_success() {
+    let (env, owner, client) = setup();
+    register(&client, &env, "warr-void", &owner);
+
+    client
+        .register_warranty(
+            &s(&env, "warr-void"),
+            &(365 * 24 * 3600u64),
+            &s(&env, "1 year"),
+            &s(&env, ""),
+            &owner,
+        )
+        .unwrap();
+
+    let voided = client.void_warranty(&s(&env, "warr-void"), &owner).unwrap();
+    assert!(voided.voided);
+    assert!(voided.voided_at > 0);
+}
+
+#[test]
+fn test_is_warranty_active_returns_false_after_void() {
+    let (env, owner, client) = setup();
+    register(&client, &env, "warr-void-2", &owner);
+
+    client
+        .register_warranty(
+            &s(&env, "warr-void-2"),
+            &0u64,
+            &s(&env, "Lifetime"),
+            &s(&env, ""),
+            &owner,
+        )
+        .unwrap();
+
+    client.void_warranty(&s(&env, "warr-void-2"), &owner).unwrap();
+
+    assert!(!client.is_warranty_active(&s(&env, "warr-void-2")));
+}
+
+#[test]
+fn test_void_warranty_unauthorized() {
+    let (env, owner, client) = setup();
+    let stranger = Address::generate(&env);
+    register(&client, &env, "warr-unauth", &owner);
+
+    client
+        .register_warranty(
+            &s(&env, "warr-unauth"),
+            &0u64,
+            &s(&env, "Lifetime"),
+            &s(&env, ""),
+            &owner,
+        )
+        .unwrap();
+
+    let result = client.void_warranty(&s(&env, "warr-unauth"), &stranger);
+    assert!(result.is_err());
+}
+
+// ── Warranty claim tests ──────────────────────────────────────────────────────
+
+#[test]
+fn test_file_warranty_claim_success() {
+    let (env, owner, client) = setup();
+    let claimant = Address::generate(&env);
+    register(&client, &env, "claim-prod", &owner);
+
+    client
+        .register_warranty(
+            &s(&env, "claim-prod"),
+            &0u64,
+            &s(&env, "Lifetime"),
+            &s(&env, ""),
+            &owner,
+        )
+        .unwrap();
+
+    let claim = client
+        .file_warranty_claim(
+            &s(&env, "claim-prod"),
+            &s(&env, "claim-001"),
+            &s(&env, "Product stopped working after 3 months"),
+            &s(&env, "ipfs://QmProofDoc"),
+            &claimant,
+        )
+        .unwrap();
+
+    assert_eq!(claim.claim_id, s(&env, "claim-001"));
+    assert_eq!(claim.product_id, s(&env, "claim-prod"));
+    assert_eq!(claim.status, ClaimStatus::Pending);
+    assert!(claim.filed_at > 0);
+}
+
+#[test]
+fn test_list_warranty_claims_returns_all_claims() {
+    let (env, owner, client) = setup();
+    let claimant = Address::generate(&env);
+    register(&client, &env, "multi-claim", &owner);
+
+    client
+        .register_warranty(
+            &s(&env, "multi-claim"),
+            &0u64,
+            &s(&env, "Lifetime"),
+            &s(&env, ""),
+            &owner,
+        )
+        .unwrap();
+
+    client
+        .file_warranty_claim(
+            &s(&env, "multi-claim"),
+            &s(&env, "c-001"),
+            &s(&env, "Issue 1"),
+            &s(&env, ""),
+            &claimant,
+        )
+        .unwrap();
+
+    client
+        .file_warranty_claim(
+            &s(&env, "multi-claim"),
+            &s(&env, "c-002"),
+            &s(&env, "Issue 2"),
+            &s(&env, ""),
+            &claimant,
+        )
+        .unwrap();
+
+    let claims = client.list_warranty_claims(&s(&env, "multi-claim"));
+    assert_eq!(claims.len(), 2);
+}
+
+#[test]
+fn test_update_claim_status_to_approved() {
+    let (env, owner, client) = setup();
+    let claimant = Address::generate(&env);
+    register(&client, &env, "status-prod", &owner);
+
+    client
+        .register_warranty(
+            &s(&env, "status-prod"),
+            &0u64,
+            &s(&env, "Lifetime"),
+            &s(&env, ""),
+            &owner,
+        )
+        .unwrap();
+
+    client
+        .file_warranty_claim(
+            &s(&env, "status-prod"),
+            &s(&env, "claim-upd"),
+            &s(&env, "Defective unit"),
+            &s(&env, ""),
+            &claimant,
+        )
+        .unwrap();
+
+    let updated = client
+        .update_claim_status(
+            &s(&env, "status-prod"),
+            &s(&env, "claim-upd"),
+            &ClaimStatus::Approved,
+            &owner,
+        )
+        .unwrap();
+
+    assert_eq!(updated.status, ClaimStatus::Approved);
+}
+
+#[test]
+fn test_update_claim_status_to_resolved() {
+    let (env, owner, client) = setup();
+    let claimant = Address::generate(&env);
+    register(&client, &env, "resolve-prod", &owner);
+
+    client
+        .register_warranty(
+            &s(&env, "resolve-prod"),
+            &0u64,
+            &s(&env, "Lifetime"),
+            &s(&env, ""),
+            &owner,
+        )
+        .unwrap();
+
+    client
+        .file_warranty_claim(
+            &s(&env, "resolve-prod"),
+            &s(&env, "claim-res"),
+            &s(&env, "Broken screen"),
+            &s(&env, "ipfs://QmEvidence"),
+            &claimant,
+        )
+        .unwrap();
+
+    let resolved = client
+        .update_claim_status(
+            &s(&env, "resolve-prod"),
+            &s(&env, "claim-res"),
+            &ClaimStatus::Resolved,
+            &owner,
+        )
+        .unwrap();
+
+    assert_eq!(resolved.status, ClaimStatus::Resolved);
+    assert!(resolved.updated_at > 0);
+}
+
+#[test]
+fn test_update_claim_status_unauthorized() {
+    let (env, owner, client) = setup();
+    let claimant = Address::generate(&env);
+    let stranger = Address::generate(&env);
+    register(&client, &env, "auth-claim-prod", &owner);
+
+    client
+        .register_warranty(
+            &s(&env, "auth-claim-prod"),
+            &0u64,
+            &s(&env, "Lifetime"),
+            &s(&env, ""),
+            &owner,
+        )
+        .unwrap();
+
+    client
+        .file_warranty_claim(
+            &s(&env, "auth-claim-prod"),
+            &s(&env, "claim-auth"),
+            &s(&env, "Issue"),
+            &s(&env, ""),
+            &claimant,
+        )
+        .unwrap();
+
+    let result = client.update_claim_status(
+        &s(&env, "auth-claim-prod"),
+        &s(&env, "claim-auth"),
+        &ClaimStatus::Rejected,
+        &stranger,
+    );
+    assert!(result.is_err());
+}
+
+#[test]
+#[should_panic(expected = "warranty is voided")]
+fn test_file_claim_on_voided_warranty_panics() {
+    let (env, owner, client) = setup();
+    let claimant = Address::generate(&env);
+    register(&client, &env, "voided-claim", &owner);
+
+    client
+        .register_warranty(
+            &s(&env, "voided-claim"),
+            &0u64,
+            &s(&env, "Lifetime"),
+            &s(&env, ""),
+            &owner,
+        )
+        .unwrap();
+
+    client.void_warranty(&s(&env, "voided-claim"), &owner).unwrap();
+
+    // This should panic
+    client
+        .file_warranty_claim(
+            &s(&env, "voided-claim"),
+            &s(&env, "claim-v"),
+            &s(&env, "Too late"),
+            &s(&env, ""),
+            &claimant,
+        )
+        .unwrap();
+}
+
+#[test]
+fn test_list_warranty_claims_empty_when_none_filed() {
+    let (env, owner, client) = setup();
+    register(&client, &env, "empty-claims", &owner);
+
+    client
+        .register_warranty(
+            &s(&env, "empty-claims"),
+            &0u64,
+            &s(&env, "Lifetime"),
+            &s(&env, ""),
+            &owner,
+        )
+        .unwrap();
+
+    let claims = client.list_warranty_claims(&s(&env, "empty-claims"));
+    assert_eq!(claims.len(), 0);
+}
+
+// ── Provenance aggregation test ───────────────────────────────────────────────
+
+/// Verify that component products retain their own event histories after
+/// being registered as part of an assembly.
+#[test]
+fn test_component_provenance_preserved_after_assembly() {
+    let (env, owner, client) = setup();
+
+    register(&client, &env, "assembled-parent", &owner);
+    register(&client, &env, "comp-prov-1", &owner);
+    register(&client, &env, "comp-prov-2", &owner);
+
+    // Add events to components
+    add_harvest_event(&client, &env, "comp-prov-1", &owner);
+    client.add_tracking_event(
+        &s(&env, "comp-prov-2"),
+        &owner,
+        &s(&env, "Factory B"),
+        &s(&env, "PROCESSING"),
+        &s(&env, "{}"),
+    );
+
+    // Register assembly
+    let mut components = Vec::new(&env);
+    components.push_back(s(&env, "comp-prov-1"));
+    components.push_back(s(&env, "comp-prov-2"));
+
+    client
+        .register_assembly(
+            &s(&env, "assembled-parent"),
+            &components,
+            &s(&env, "Final assembly"),
+            &owner,
+        )
+        .unwrap();
+
+    // Component events are still accessible
+    let events1 = client.get_tracking_events(&s(&env, "comp-prov-1"));
+    let events2 = client.get_tracking_events(&s(&env, "comp-prov-2"));
+    assert_eq!(events1.len(), 1);
+    assert_eq!(events2.len(), 1);
+    assert_eq!(events1.get(0).unwrap().event_type, s(&env, "HARVEST"));
+    assert_eq!(events2.get(0).unwrap().event_type, s(&env, "PROCESSING"));
+
+    // Assembly record references both components
+    let assembly = client.get_assembly(&s(&env, "assembled-parent")).unwrap();
+    assert_eq!(assembly.component_ids.len(), 2);
+}

--- a/smart-contract/contracts/src/lib.rs
+++ b/smart-contract/contracts/src/lib.rs
@@ -37,6 +37,8 @@ pub const EVENT_SCHEMA_VERSION: u32 = 2;
 mod tests;
 mod resilience_tests;
 mod compliance_tests;
+pub mod assembly_warranty;
+mod assembly_warranty_tests;
 
 // ── Payload size limits (issue #311) ─────────────────────────────────────────
 // All limits are in bytes (Soroban String::len() returns byte count).
@@ -352,6 +354,17 @@ pub enum DataKey {
     ActorNonce(Address),
     /// Key for the compliance policy of a product. The inner `String` is the product ID.
     CompliancePolicy(String),
+    /// Key for the product assembly record (parent-child relationships).
+    /// The inner `String` is the parent product ID.
+    Assembly(String),
+    /// Key for the warranty metadata of a product.
+    /// The inner `String` is the product ID.
+    Warranty(String),
+    /// Key for the list of warranty claims for a product.
+    /// The inner `String` is the product ID.
+    WarrantyClaims(String),
+    /// Key for the certifications list of a product. (#428)
+    Certifications(String),
 }
 
 // ── Contract ─────────────────────────────────────────────────────────────────
@@ -3604,6 +3617,210 @@ mod rejection_reason_tests {
             .persistent()
             .get(&DataKey::Batch(id))
             .expect("batch not found")
+    }
+
+    // ── Assembly relationships ─────────────────────────────────────────────────
+
+    /// Register or replace the assembly relationship for a parent product.
+    ///
+    /// A parent product is assembled from one or more component products.
+    /// Each component carries its own provenance chain; the assembly record
+    /// aggregates them under a single parent.
+    ///
+    /// # Parameters
+    /// - `parent_id` — ID of the assembled (parent) product.
+    /// - `component_ids` — Ordered list of component product IDs (max 50).
+    /// - `description` — Optional description of the assembly process (max 4096 bytes).
+    /// - `caller` — Must be the parent product owner.
+    ///
+    /// # Authorization
+    /// Requires `caller.require_auth()`. Caller must be the parent product owner.
+    ///
+    /// # Errors
+    /// - [`Error::ProductNotFound`] — if `parent_id` is not registered.
+    /// - [`Error::NotAuthorized`] — if caller is not the parent product owner.
+    ///
+    /// # Panics
+    /// - `"assembly exceeds maximum component count"` — if more than 50 components.
+    /// - `"component product not found"` — if any component ID is not registered.
+    /// - `"description exceeds max length"` — if description > 4096 bytes.
+    ///
+    /// # Emitted Events
+    /// Publishes `("assembly_registered", parent_id)` with the
+    /// [`assembly_warranty::ProductAssembly`] struct as the body.
+    pub fn register_assembly(
+        env: Env,
+        parent_id: String,
+        component_ids: Vec<String>,
+        description: String,
+        caller: Address,
+    ) -> Result<assembly_warranty::ProductAssembly, Error> {
+        assembly_warranty::register_assembly(&env, parent_id, component_ids, description, caller)
+    }
+
+    /// Retrieve the assembly record for a parent product.
+    ///
+    /// Returns `None` if no assembly has been registered for this product.
+    pub fn get_assembly(
+        env: Env,
+        parent_id: String,
+    ) -> Option<assembly_warranty::ProductAssembly> {
+        assembly_warranty::get_assembly(&env, parent_id)
+    }
+
+    /// Return all parent product IDs that reference `component_id` as a component.
+    ///
+    /// Performs a lookup over the provided `candidate_parent_ids` list.
+    /// Callers should supply the set of known parent IDs to search.
+    pub fn get_parents_of_component(
+        env: Env,
+        component_id: String,
+        candidate_parent_ids: Vec<String>,
+    ) -> Vec<String> {
+        assembly_warranty::get_parents_of_component(&env, component_id, candidate_parent_ids)
+    }
+
+    // ── Warranty management ───────────────────────────────────────────────────
+
+    /// Register warranty metadata for a product.
+    ///
+    /// # Parameters
+    /// - `product_id` — ID of the product to attach warranty to.
+    /// - `duration_seconds` — Warranty duration in seconds from product registration.
+    ///   Pass `0` for a lifetime warranty.
+    /// - `terms` — Short human-readable warranty terms (max 1024 bytes).
+    /// - `terms_ref` — Off-chain reference to the full warranty document (max 512 bytes).
+    /// - `caller` — Must be the product owner.
+    ///
+    /// # Authorization
+    /// Requires `caller.require_auth()`. Caller must be the product owner.
+    ///
+    /// # Errors
+    /// - [`Error::ProductNotFound`] — if `product_id` is not registered.
+    /// - [`Error::NotAuthorized`] — if caller is not the product owner.
+    ///
+    /// # Emitted Events
+    /// Publishes `("warranty_registered", product_id)` with the
+    /// [`assembly_warranty::WarrantyInfo`] struct as the body.
+    pub fn register_warranty(
+        env: Env,
+        product_id: String,
+        duration_seconds: u64,
+        terms: String,
+        terms_ref: String,
+        caller: Address,
+    ) -> Result<assembly_warranty::WarrantyInfo, Error> {
+        assembly_warranty::register_warranty(&env, product_id, duration_seconds, terms, terms_ref, caller)
+    }
+
+    /// Retrieve warranty metadata for a product.
+    ///
+    /// Returns `None` if no warranty has been registered.
+    pub fn get_warranty(
+        env: Env,
+        product_id: String,
+    ) -> Option<assembly_warranty::WarrantyInfo> {
+        assembly_warranty::get_warranty(&env, product_id)
+    }
+
+    /// Void a warranty. Owner-only.
+    ///
+    /// Once voided, new claims cannot be filed against this warranty.
+    ///
+    /// # Errors
+    /// - [`Error::ProductNotFound`] — if `product_id` is not registered.
+    /// - [`Error::NotAuthorized`] — if caller is not the product owner.
+    ///
+    /// # Panics
+    /// - `"no warranty registered"` — if no warranty exists for this product.
+    ///
+    /// # Emitted Events
+    /// Publishes `("warranty_voided", product_id)` with the updated
+    /// [`assembly_warranty::WarrantyInfo`] struct as the body.
+    pub fn void_warranty(
+        env: Env,
+        product_id: String,
+        caller: Address,
+    ) -> Result<assembly_warranty::WarrantyInfo, Error> {
+        assembly_warranty::void_warranty(&env, product_id, caller)
+    }
+
+    /// Check whether a product's warranty is currently active.
+    ///
+    /// Returns `true` if a non-voided warranty exists and the current ledger
+    /// time is within the warranty period (or the warranty has no expiry).
+    pub fn is_warranty_active(env: Env, product_id: String) -> bool {
+        assembly_warranty::is_warranty_active(&env, product_id)
+    }
+
+    /// File a warranty claim against a product.
+    ///
+    /// Any address may file a claim. The claim is linked to the product's
+    /// provenance via the `proof_ref` field (e.g. an IPFS CID pointing to
+    /// supporting documentation).
+    ///
+    /// # Parameters
+    /// - `product_id` — ID of the product the claim is filed against.
+    /// - `claim_id` — Caller-supplied unique identifier for this claim (max 128 bytes).
+    /// - `description` — Description of the issue (max 4096 bytes).
+    /// - `proof_ref` — Off-chain proof reference (max 512 bytes).
+    /// - `claimant` — Address of the claimant (self-authorizes).
+    ///
+    /// # Errors
+    /// - [`Error::ProductNotFound`] — if `product_id` is not registered.
+    ///
+    /// # Panics
+    /// - `"no warranty registered"` — if no warranty exists.
+    /// - `"warranty is voided"` — if the warranty has been voided.
+    ///
+    /// # Emitted Events
+    /// Publishes `("warranty_claim_filed", product_id)` with the
+    /// [`assembly_warranty::WarrantyClaim`] struct as the body.
+    pub fn file_warranty_claim(
+        env: Env,
+        product_id: String,
+        claim_id: String,
+        description: String,
+        proof_ref: String,
+        claimant: Address,
+    ) -> Result<assembly_warranty::WarrantyClaim, Error> {
+        assembly_warranty::file_warranty_claim(&env, product_id, claim_id, description, proof_ref, claimant)
+    }
+
+    /// Update the status of a warranty claim. Owner-only.
+    ///
+    /// # Parameters
+    /// - `product_id` — ID of the product.
+    /// - `claim_id` — ID of the claim to update.
+    /// - `new_status` — New [`assembly_warranty::ClaimStatus`] value.
+    /// - `caller` — Must be the product owner.
+    ///
+    /// # Errors
+    /// - [`Error::ProductNotFound`] — if `product_id` is not registered.
+    /// - [`Error::NotAuthorized`] — if caller is not the product owner.
+    ///
+    /// # Panics
+    /// - `"claim not found"` — if no claim with `claim_id` exists.
+    ///
+    /// # Emitted Events
+    /// Publishes `("warranty_claim_updated", product_id)` with the updated
+    /// [`assembly_warranty::WarrantyClaim`] struct as the body.
+    pub fn update_claim_status(
+        env: Env,
+        product_id: String,
+        claim_id: String,
+        new_status: assembly_warranty::ClaimStatus,
+        caller: Address,
+    ) -> Result<assembly_warranty::WarrantyClaim, Error> {
+        assembly_warranty::update_claim_status(&env, product_id, claim_id, new_status, caller)
+    }
+
+    /// Return all warranty claims for a product.
+    pub fn list_warranty_claims(
+        env: Env,
+        product_id: String,
+    ) -> Vec<assembly_warranty::WarrantyClaim> {
+        assembly_warranty::list_warranty_claims(&env, product_id)
     }
 }
 


### PR DESCRIPTION
closes #471 
closes #472 


- Extend Soroban contract with ProductAssembly contracttype and
  register_assembly, get_assembly, get_parents_of_component methods
- Add WarrantyInfo, WarrantyClaim, ClaimStatus contracttypes with
  register_warranty, void_warranty, file_warranty_claim, update_claim_status
- Add Assembly, Warranty, WarrantyClaims DataKey variants to persistent storage
- Add assembly_warranty.rs module and 16 Rust contract tests
- Add AssemblyPanel.tsx: component list with provenance links, owner form
- Add WarrantyPanel.tsx: Active/Expired/Voided badge, claims management
- Add REST routes: GET/POST /api/v1/products/[id]/assembly,
  /warranty, and /warranty/claims
- Extend Product type with assembly and warranty fields
- Integrate both panels into product detail page below Certifications
- Add 58 frontend tests across component and API layers

