### PR TITLE
feat: emergency alert system and certificate revocation registry

### DIFF
--- a/frontend/app/(app)/dashboard/page.tsx
+++ b/frontend/app/(app)/dashboard/page.tsx
@@ -14,6 +14,8 @@ import {
 } from "recharts";
 import { Package, Activity, CheckCircle, Clock } from "lucide-react";
 import { useDashboardData } from "@/lib/hooks/useDashboardData";
+import { RecallAlertBanner } from "@/components/alerts/RecallAlertBanner";
+import { useStore } from "@/lib/state/store";
 
 const PIE_COLORS: Record<string, string> = {
   HARVEST: "#22c55e",
@@ -46,10 +48,21 @@ function StatCard({
 
 export default function DashboardPage() {
   const { stats, dailyCounts, eventTypeCounts, recentEvents } = useDashboardData();
+  const recallAlerts = useStore((s) => s.recallAlerts);
+  const activeAlerts = recallAlerts.filter((a) => a.active);
 
   return (
     <main className="p-6 space-y-8 max-w-7xl mx-auto">
       <h1 className="text-2xl font-bold text-[var(--foreground)]">Dashboard</h1>
+
+      {/* Active recall alert banners */}
+      {activeAlerts.length > 0 && (
+        <section aria-label="Active recall alerts">
+          {activeAlerts.map((alert, i) => (
+            <RecallAlertBanner key={i} alert={alert} dismissible />
+          ))}
+        </section>
+      )}
 
       {/* Stat cards */}
       <div className="grid grid-cols-2 lg:grid-cols-4 gap-4">

--- a/frontend/app/(app)/products/[id]/page.tsx
+++ b/frontend/app/(app)/products/[id]/page.tsx
@@ -1,9 +1,12 @@
 import { notFound } from "next/navigation";
 import Link from "next/link";
-import { getProductById } from "@/lib/mock/products";
+import { getProductById, getActiveAlertByProductId, getCertificatesByProductId, getRevocationByCertId } from "@/lib/mock/products";
 import ProductQRCode from "@/components/products/ProductQRCode";
 import ProductActions from "@/components/products/ProductActions";
 import { AuthorizedActorsPanel } from "@/components/products/AuthorizedActorsPanel";
+import { RecallAlertBanner } from "@/components/alerts/RecallAlertBanner";
+import { AlertsPanel } from "@/components/alerts/AlertsPanel";
+import { CertificatesPanel } from "@/components/certificates/CertificatesPanel";
 
 interface Props {
   params: { id: string };
@@ -15,11 +18,23 @@ export default function ProductDetailPage({ params }: Props) {
   const p = product!;
   const registeredAt = new Date(p.timestamp).toLocaleString();
 
+  const activeAlert = getActiveAlertByProductId(p.id);
+  const certificates = getCertificatesByProductId(p.id);
+  const revocations = certificates
+    .filter((c) => c.revoked)
+    .map((c) => getRevocationByCertId(c.certId))
+    .filter((r): r is NonNullable<typeof r> => r !== undefined);
+
   return (
     <main className="p-8 max-w-3xl mx-auto">
       <Link href="/products" className="text-sm text-[var(--muted)] hover:underline mb-6 inline-block">
         ← Back to Products
       </Link>
+
+      {/* Active recall alert banner — shown prominently at the top */}
+      {activeAlert && (
+        <RecallAlertBanner alert={activeAlert} />
+      )}
 
       <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-6 mb-8">
         <div>
@@ -46,6 +61,25 @@ export default function ProductDetailPage({ params }: Props) {
             <dd className="font-mono text-xs mt-0.5 break-all text-[var(--foreground)]">{p.owner}</dd>
           </div>
         </dl>
+      </section>
+
+      {/* Recall Alerts */}
+      <section className="border border-[var(--card-border)] bg-[var(--card)] rounded-xl p-6 mb-6">
+        <h2 className="text-base font-semibold mb-4 text-[var(--foreground)]">Recall Alerts</h2>
+        <AlertsPanel
+          productId={p.id}
+          alerts={activeAlert ? [activeAlert] : []}
+        />
+      </section>
+
+      {/* Certificates & Revocations */}
+      <section className="border border-[var(--card-border)] bg-[var(--card)] rounded-xl p-6 mb-6">
+        <h2 className="text-base font-semibold mb-4 text-[var(--foreground)]">Certificates</h2>
+        <CertificatesPanel
+          productId={p.id}
+          certificates={certificates}
+          revocations={revocations}
+        />
       </section>
 
       {/* Authorized Actors */}

--- a/frontend/app/verify/[id]/page.tsx
+++ b/frontend/app/verify/[id]/page.tsx
@@ -1,9 +1,11 @@
 import type { Metadata } from "next";
-import { getProductById, getEventsByProductId } from "@/lib/mock/products";
+import { getProductById, getEventsByProductId, getActiveAlertByProductId, getCertificatesByProductId, getRevocationByCertId } from "@/lib/mock/products";
 import { CONTRACT_ID } from "@/lib/stellar/client";
 import { EventTimeline } from "@/components/products/EventTimeline";
 import ProductQRCode from "@/components/products/ProductQRCode";
 import { ScanQRButton } from "@/components/tracking/ScanQRButton";
+import { RecallAlertBanner } from "@/components/alerts/RecallAlertBanner";
+import { RevocationBadge } from "@/components/certificates/RevocationBadge";
 
 interface Props {
   params: { id: string };
@@ -59,8 +61,16 @@ export default async function VerifyPage({ params }: Props) {
   const stellarExpertUrl = `https://stellar.expert/explorer/testnet/contract/${CONTRACT_ID}`;
   const registeredAt = new Date(product.timestamp).toLocaleString();
 
+  const activeAlert = getActiveAlertByProductId(product.id);
+  const certificates = getCertificatesByProductId(product.id);
+
   return (
     <main className="p-6 max-w-2xl mx-auto">
+      {/* Critical recall alert — shown at the very top for maximum visibility */}
+      {activeAlert && (
+        <RecallAlertBanner alert={activeAlert} />
+      )}
+
       {/* Header */}
       <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-4 mb-6">
         <div>
@@ -98,6 +108,37 @@ export default async function VerifyPage({ params }: Props) {
         </svg>
         Verified on Stellar · View Contract
       </a>
+
+      {/* Certificates section */}
+      {certificates.length > 0 && (
+        <section className="border border-[var(--card-border)] bg-[var(--card)] rounded-xl p-6 mb-6">
+          <h2 className="text-base font-semibold text-[var(--foreground)] mb-4">Certificates</h2>
+          <ul className="space-y-3">
+            {certificates.map((cert) => {
+              const revocation = getRevocationByCertId(cert.certId);
+              return (
+                <li key={cert.certId} className="flex items-start justify-between gap-3">
+                  <div>
+                    <p className="text-sm font-medium text-[var(--foreground)]">
+                      {cert.certType.replace("_", " ")}
+                    </p>
+                    <p className="text-xs text-[var(--muted)] font-mono">{cert.certId}</p>
+                    <p className="text-xs text-[var(--muted)]">
+                      Issued: {new Date(cert.issuedAt).toLocaleDateString()}
+                    </p>
+                    {cert.revoked && revocation && (
+                      <p className="text-xs text-red-600 mt-0.5">
+                        Revoked: {revocation.reason}
+                      </p>
+                    )}
+                  </div>
+                  <RevocationBadge revoked={cert.revoked} revocation={revocation} compact />
+                </li>
+              );
+            })}
+          </ul>
+        </section>
+      )}
 
       {/* Event Timeline */}
       <section className="border border-[var(--card-border)] bg-[var(--card)] rounded-xl p-6">

--- a/frontend/components/alerts/AlertsPanel.tsx
+++ b/frontend/components/alerts/AlertsPanel.tsx
@@ -1,0 +1,107 @@
+"use client";
+
+import { useState } from "react";
+import { AlertOctagon, Plus, CheckCircle, Loader2 } from "lucide-react";
+import { RecallAlertBanner } from "./RecallAlertBanner";
+import { IssueRecallForm } from "./IssueRecallForm";
+import { useStore } from "@/lib/state/store";
+import { useToast } from "@/lib/hooks/useToast";
+import { contractClient } from "@/lib/stellar/contract";
+import type { RecallAlert } from "@/lib/types";
+
+interface AlertsPanelProps {
+  productId: string;
+  /** Alerts to display (active + history). */
+  alerts: RecallAlert[];
+}
+
+export function AlertsPanel({ productId, alerts }: AlertsPanelProps) {
+  const { walletAddress, resolveRecallAlert } = useStore();
+  const toast = useToast();
+  const [issueOpen, setIssueOpen] = useState(false);
+  const [resolving, setResolving] = useState(false);
+
+  const activeAlert = alerts.find((a) => a.active);
+  const history = alerts.filter((a) => !a.active);
+
+  async function handleResolve() {
+    if (!walletAddress) {
+      toast.error("Wallet not connected");
+      return;
+    }
+    setResolving(true);
+    const toastId = toast.loading("Resolving alert on-chain…");
+    try {
+      const txHash = await contractClient.resolveRecallAlert(productId, walletAddress, walletAddress);
+      resolveRecallAlert(productId);
+      toast.dismiss(toastId);
+      toast.success("Alert resolved", txHash);
+    } catch (err) {
+      toast.dismiss(toastId);
+      toast.error("Failed to resolve alert", err instanceof Error ? err.message : "Unknown error");
+    } finally {
+      setResolving(false);
+    }
+  }
+
+  return (
+    <div className="flex flex-col gap-4">
+      {/* Active alert */}
+      {activeAlert ? (
+        <div>
+          <RecallAlertBanner alert={activeAlert} />
+          {walletAddress && (
+            <button
+              onClick={handleResolve}
+              disabled={resolving}
+              className="flex items-center gap-2 text-sm px-3 py-1.5 rounded-lg border border-green-500 text-green-600 hover:bg-green-50 dark:hover:bg-green-950/30 transition-colors disabled:opacity-50"
+            >
+              {resolving ? (
+                <Loader2 size={14} className="animate-spin" />
+              ) : (
+                <CheckCircle size={14} />
+              )}
+              Mark as Resolved
+            </button>
+          )}
+        </div>
+      ) : (
+        <p className="text-sm text-[var(--muted)]">No active alerts for this product.</p>
+      )}
+
+      {/* Issue new alert button */}
+      {walletAddress && (
+        <button
+          onClick={() => setIssueOpen(true)}
+          className="flex items-center gap-2 text-sm px-3 py-1.5 rounded-lg border border-red-500 text-red-600 hover:bg-red-50 dark:hover:bg-red-950/30 transition-colors self-start"
+        >
+          <Plus size={14} />
+          Issue Recall Alert
+        </button>
+      )}
+
+      {/* Alert history */}
+      {history.length > 0 && (
+        <div>
+          <p className="text-xs font-semibold text-[var(--muted)] uppercase tracking-wider mb-2">
+            Alert History
+          </p>
+          <div className="space-y-2">
+            {history.map((alert, i) => (
+              <div key={i} className="opacity-60">
+                <RecallAlertBanner alert={{ ...alert, active: true }} />
+                <p className="text-xs text-[var(--muted)] mt-1 ml-1">Resolved</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      <IssueRecallForm
+        productId={productId}
+        open={issueOpen}
+        onOpenChange={setIssueOpen}
+      />
+    </div>
+  );
+}

--- a/frontend/components/alerts/IssueRecallForm.tsx
+++ b/frontend/components/alerts/IssueRecallForm.tsx
@@ -1,0 +1,217 @@
+"use client";
+
+import { useState } from "react";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+import * as Dialog from "@radix-ui/react-dialog";
+import { X, AlertOctagon } from "lucide-react";
+import { useStore } from "@/lib/state/store";
+import { useToast } from "@/lib/hooks/useToast";
+import { contractClient } from "@/lib/stellar/contract";
+import type { AlertSeverity, RecallAlert } from "@/lib/types";
+
+const SEVERITY_OPTIONS: { value: AlertSeverity; label: string }[] = [
+  { value: "LOW", label: "Low — Advisory" },
+  { value: "MEDIUM", label: "Medium — Safety Notice" },
+  { value: "HIGH", label: "High — Urgent Alert" },
+  { value: "CRITICAL", label: "Critical — Immediate Recall" },
+];
+
+const CHANNEL_OPTIONS = ["banner", "email", "webhook"] as const;
+
+const schema = z.object({
+  severity: z.enum(["LOW", "MEDIUM", "HIGH", "CRITICAL"]),
+  title: z.string().min(5, "Title must be at least 5 characters"),
+  description: z.string().min(10, "Description must be at least 10 characters"),
+  channels: z.array(z.string()).min(1, "Select at least one channel"),
+});
+
+type FormValues = z.infer<typeof schema>;
+
+interface Props {
+  productId: string;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onIssued?: (alert: RecallAlert) => void;
+}
+
+export function IssueRecallForm({ productId, open, onOpenChange, onIssued }: Props) {
+  const { walletAddress, addRecallAlert } = useStore();
+  const toast = useToast();
+  const [pending, setPending] = useState(false);
+
+  const {
+    register,
+    handleSubmit,
+    reset,
+    watch,
+    setValue,
+    formState: { errors },
+  } = useForm<FormValues>({
+    resolver: zodResolver(schema),
+    defaultValues: {
+      severity: "HIGH",
+      channels: ["banner"],
+    },
+  });
+
+  const selectedChannels = watch("channels") ?? [];
+
+  function toggleChannel(ch: string) {
+    const current = selectedChannels;
+    if (current.includes(ch)) {
+      setValue("channels", current.filter((c) => c !== ch));
+    } else {
+      setValue("channels", [...current, ch]);
+    }
+  }
+
+  async function onSubmit(values: FormValues) {
+    if (!walletAddress) {
+      toast.error("Wallet not connected", "Connect your Freighter wallet first.");
+      return;
+    }
+
+    setPending(true);
+    const toastId = toast.loading("Issuing recall alert on-chain…");
+
+    try {
+      const txHash = await contractClient.issueRecallAlert(
+        productId,
+        walletAddress,
+        values.severity,
+        values.title,
+        values.description,
+        values.channels.join(","),
+        walletAddress
+      );
+
+      const alert: RecallAlert = {
+        productId,
+        issuer: walletAddress,
+        severity: values.severity,
+        title: values.title,
+        description: values.description,
+        timestamp: Date.now(),
+        channels: values.channels.join(","),
+        active: true,
+      };
+
+      addRecallAlert(alert);
+      onIssued?.(alert);
+
+      toast.dismiss(toastId);
+      toast.success("Recall alert issued", txHash);
+      reset({ severity: "HIGH", channels: ["banner"] });
+      onOpenChange(false);
+    } catch (err) {
+      toast.dismiss(toastId);
+      toast.error("Failed to issue alert", err instanceof Error ? err.message : "Unknown error");
+    } finally {
+      setPending(false);
+    }
+  }
+
+  return (
+    <Dialog.Root open={open} onOpenChange={onOpenChange}>
+      <Dialog.Portal>
+        <Dialog.Overlay className="fixed inset-0 bg-black/50 backdrop-blur-sm z-40" />
+        <Dialog.Content className="fixed left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 z-50 w-full max-w-lg bg-[var(--background)] border border-[var(--card-border)] rounded-2xl p-6 shadow-xl">
+          <div className="flex items-center justify-between mb-6">
+            <div className="flex items-center gap-2">
+              <AlertOctagon size={20} className="text-red-500" aria-hidden="true" />
+              <Dialog.Title className="text-lg font-semibold">Issue Recall Alert</Dialog.Title>
+            </div>
+            <Dialog.Close className="p-1 rounded-lg hover:bg-[var(--muted-bg)] transition-colors">
+              <X size={18} />
+            </Dialog.Close>
+          </div>
+
+          <form onSubmit={handleSubmit(onSubmit)} className="flex flex-col gap-4">
+            {/* Severity */}
+            <div className="flex flex-col gap-1">
+              <label className="text-sm font-medium">Severity</label>
+              <select
+                {...register("severity")}
+                className="px-3 py-2 rounded-lg border border-[var(--card-border)] bg-[var(--card)] text-sm focus:outline-none focus:ring-2 focus:ring-red-500"
+              >
+                {SEVERITY_OPTIONS.map((opt) => (
+                  <option key={opt.value} value={opt.value}>
+                    {opt.label}
+                  </option>
+                ))}
+              </select>
+              {errors.severity && <p className="text-xs text-red-500">{errors.severity.message}</p>}
+            </div>
+
+            {/* Title */}
+            <div className="flex flex-col gap-1">
+              <label className="text-sm font-medium">Alert Title</label>
+              <input
+                {...register("title")}
+                placeholder="e.g. Contamination Risk — Batch #XYZ"
+                className="px-3 py-2 rounded-lg border border-[var(--card-border)] bg-[var(--card)] text-sm focus:outline-none focus:ring-2 focus:ring-red-500"
+              />
+              {errors.title && <p className="text-xs text-red-500">{errors.title.message}</p>}
+            </div>
+
+            {/* Description */}
+            <div className="flex flex-col gap-1">
+              <label className="text-sm font-medium">Description</label>
+              <textarea
+                {...register("description")}
+                rows={4}
+                placeholder="Describe the issue, affected batches, and required actions…"
+                className="px-3 py-2 rounded-lg border border-[var(--card-border)] bg-[var(--card)] text-sm focus:outline-none focus:ring-2 focus:ring-red-500 resize-none"
+              />
+              {errors.description && (
+                <p className="text-xs text-red-500">{errors.description.message}</p>
+              )}
+            </div>
+
+            {/* Distribution channels */}
+            <div className="flex flex-col gap-2">
+              <label className="text-sm font-medium">Distribution Channels</label>
+              <div className="flex gap-3 flex-wrap">
+                {CHANNEL_OPTIONS.map((ch) => (
+                  <label
+                    key={ch}
+                    className="flex items-center gap-2 cursor-pointer select-none"
+                  >
+                    <input
+                      type="checkbox"
+                      checked={selectedChannels.includes(ch)}
+                      onChange={() => toggleChannel(ch)}
+                      className="rounded border-[var(--card-border)] accent-red-500"
+                    />
+                    <span className="text-sm capitalize">{ch}</span>
+                  </label>
+                ))}
+              </div>
+              {errors.channels && (
+                <p className="text-xs text-red-500">{errors.channels.message}</p>
+              )}
+            </div>
+
+            <div className="flex gap-3 mt-2">
+              <Dialog.Close
+                className="flex-1 px-4 py-2 rounded-lg border border-[var(--card-border)] text-sm font-medium hover:bg-[var(--muted-bg)] transition-colors"
+                disabled={pending}
+              >
+                Cancel
+              </Dialog.Close>
+              <button
+                type="submit"
+                disabled={pending}
+                className="flex-1 px-4 py-2 rounded-lg bg-red-600 hover:bg-red-700 text-white text-sm font-medium transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                {pending ? "Issuing…" : "Issue Alert"}
+              </button>
+            </div>
+          </form>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}

--- a/frontend/components/alerts/RecallAlertBanner.tsx
+++ b/frontend/components/alerts/RecallAlertBanner.tsx
@@ -1,0 +1,150 @@
+"use client";
+
+import { useState } from "react";
+import { AlertTriangle, AlertOctagon, Info, X, ChevronDown, ChevronUp } from "lucide-react";
+import type { RecallAlert, AlertSeverity } from "@/lib/types";
+
+interface RecallAlertBannerProps {
+  alert: RecallAlert;
+  /** If true, shows a dismiss button (for dashboard/list views). Product owners see a resolve button instead. */
+  dismissible?: boolean;
+  onDismiss?: () => void;
+}
+
+const SEVERITY_CONFIG: Record<
+  AlertSeverity,
+  {
+    bg: string;
+    border: string;
+    text: string;
+    icon: React.ElementType;
+    label: string;
+  }
+> = {
+  CRITICAL: {
+    bg: "bg-red-50 dark:bg-red-950/40",
+    border: "border-red-500",
+    text: "text-red-700 dark:text-red-400",
+    icon: AlertOctagon,
+    label: "CRITICAL RECALL",
+  },
+  HIGH: {
+    bg: "bg-orange-50 dark:bg-orange-950/40",
+    border: "border-orange-500",
+    text: "text-orange-700 dark:text-orange-400",
+    icon: AlertTriangle,
+    label: "HIGH SEVERITY ALERT",
+  },
+  MEDIUM: {
+    bg: "bg-yellow-50 dark:bg-yellow-950/40",
+    border: "border-yellow-500",
+    text: "text-yellow-700 dark:text-yellow-400",
+    icon: AlertTriangle,
+    label: "SAFETY NOTICE",
+  },
+  LOW: {
+    bg: "bg-blue-50 dark:bg-blue-950/40",
+    border: "border-blue-400",
+    text: "text-blue-700 dark:text-blue-400",
+    icon: Info,
+    label: "ADVISORY",
+  },
+};
+
+export function RecallAlertBanner({ alert, dismissible = false, onDismiss }: RecallAlertBannerProps) {
+  const [expanded, setExpanded] = useState(alert.severity === "CRITICAL" || alert.severity === "HIGH");
+  const [dismissed, setDismissed] = useState(false);
+
+  if (dismissed || !alert.active) return null;
+
+  const config = SEVERITY_CONFIG[alert.severity];
+  const Icon = config.icon;
+  const issuedAt = new Date(alert.timestamp).toLocaleString();
+  const channels = alert.channels.split(",").map((c) => c.trim()).filter(Boolean);
+
+  function handleDismiss() {
+    setDismissed(true);
+    onDismiss?.();
+  }
+
+  return (
+    <div
+      role="alert"
+      aria-live="assertive"
+      aria-atomic="true"
+      className={`rounded-xl border-l-4 ${config.bg} ${config.border} p-4 mb-4`}
+    >
+      <div className="flex items-start gap-3">
+        <Icon
+          size={20}
+          className={`shrink-0 mt-0.5 ${config.text}`}
+          aria-hidden="true"
+        />
+
+        <div className="flex-1 min-w-0">
+          {/* Header row */}
+          <div className="flex items-center gap-2 flex-wrap">
+            <span className={`text-xs font-bold tracking-wider ${config.text}`}>
+              {config.label}
+            </span>
+            <span className="text-xs text-[var(--muted)]">·</span>
+            <span className="text-xs text-[var(--muted)]">{issuedAt}</span>
+          </div>
+
+          {/* Title */}
+          <p className={`text-sm font-semibold mt-0.5 ${config.text}`}>{alert.title}</p>
+
+          {/* Expandable description */}
+          {expanded && (
+            <p className="text-sm text-[var(--foreground)] mt-1 leading-relaxed">
+              {alert.description}
+            </p>
+          )}
+
+          {/* Channels + expand toggle */}
+          <div className="flex items-center gap-3 mt-2 flex-wrap">
+            {channels.length > 0 && (
+              <div className="flex items-center gap-1 flex-wrap">
+                <span className="text-xs text-[var(--muted)]">Channels:</span>
+                {channels.map((ch) => (
+                  <span
+                    key={ch}
+                    className="text-xs px-1.5 py-0.5 rounded bg-[var(--muted-bg)] text-[var(--foreground)] font-mono"
+                  >
+                    {ch}
+                  </span>
+                ))}
+              </div>
+            )}
+            <button
+              onClick={() => setExpanded((v) => !v)}
+              className={`flex items-center gap-1 text-xs ${config.text} hover:opacity-80 transition-opacity`}
+              aria-expanded={expanded}
+            >
+              {expanded ? (
+                <>
+                  <ChevronUp size={12} /> Hide details
+                </>
+              ) : (
+                <>
+                  <ChevronDown size={12} /> Show details
+                </>
+              )}
+            </button>
+          </div>
+        </div>
+
+        {/* Dismiss button */}
+        {dismissible && (
+          <button
+            onClick={handleDismiss}
+            aria-label="Dismiss alert"
+            className="shrink-0 p-1 rounded hover:bg-black/10 dark:hover:bg-white/10 transition-colors"
+          >
+            <X size={16} className={config.text} />
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/components/certificates/CertificatesPanel.tsx
+++ b/frontend/components/certificates/CertificatesPanel.tsx
@@ -1,0 +1,193 @@
+"use client";
+
+import { useState } from "react";
+import { Award, Plus, Loader2, ShieldOff } from "lucide-react";
+import { RevocationBadge } from "./RevocationBadge";
+import { IssueCertificateForm } from "./IssueCertificateForm";
+import { useStore } from "@/lib/state/store";
+import { useToast } from "@/lib/hooks/useToast";
+import { contractClient } from "@/lib/stellar/contract";
+import type { Certificate, RevocationRecord } from "@/lib/types";
+
+interface CertificatesPanelProps {
+  productId: string;
+  certificates: Certificate[];
+  revocations: RevocationRecord[];
+}
+
+export function CertificatesPanel({ productId, certificates, revocations }: CertificatesPanelProps) {
+  const { walletAddress, revokeCertificateInStore } = useStore();
+  const toast = useToast();
+  const [issueOpen, setIssueOpen] = useState(false);
+  const [revoking, setRevoking] = useState<string | null>(null);
+  const [reasonInputs, setReasonInputs] = useState<Record<string, string>>({});
+  const [showReasonFor, setShowReasonFor] = useState<string | null>(null);
+
+  function getRevocation(certId: string): RevocationRecord | undefined {
+    return revocations.find((r) => r.certId === certId);
+  }
+
+  async function handleRevoke(certId: string) {
+    if (!walletAddress) {
+      toast.error("Wallet not connected");
+      return;
+    }
+    const reason = reasonInputs[certId]?.trim() || "No reason provided";
+    setRevoking(certId);
+    const toastId = toast.loading("Revoking certificate on-chain…");
+    try {
+      const txHash = await contractClient.revokeCertificate(certId, walletAddress, reason, walletAddress);
+      const record: RevocationRecord = {
+        certId,
+        revoker: walletAddress,
+        revokedAt: Date.now(),
+        reason,
+      };
+      revokeCertificateInStore(certId, record);
+      toast.dismiss(toastId);
+      toast.success("Certificate revoked", txHash);
+      setShowReasonFor(null);
+    } catch (err) {
+      toast.dismiss(toastId);
+      toast.error("Revocation failed", err instanceof Error ? err.message : "Unknown error");
+    } finally {
+      setRevoking(null);
+    }
+  }
+
+  if (certificates.length === 0) {
+    return (
+      <div className="flex flex-col gap-3">
+        <p className="text-sm text-[var(--muted)]">No certificates issued for this product.</p>
+        {walletAddress && (
+          <button
+            onClick={() => setIssueOpen(true)}
+            className="flex items-center gap-2 text-sm px-3 py-1.5 rounded-lg border border-[var(--card-border)] hover:bg-[var(--muted-bg)] transition-colors self-start"
+          >
+            <Plus size={14} />
+            Issue Certificate
+          </button>
+        )}
+        <IssueCertificateForm productId={productId} open={issueOpen} onOpenChange={setIssueOpen} />
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-4">
+      <ul className="space-y-3">
+        {certificates.map((cert) => {
+          const revocation = getRevocation(cert.certId);
+          const isRevoked = cert.revoked || !!revocation;
+
+          return (
+            <li
+              key={cert.certId}
+              className={`border rounded-xl p-4 transition-opacity ${
+                isRevoked
+                  ? "border-red-200 dark:border-red-900 opacity-80"
+                  : "border-[var(--card-border)]"
+              }`}
+            >
+              <div className="flex items-start justify-between gap-3 mb-2">
+                <div className="flex items-center gap-2">
+                  <Award
+                    size={16}
+                    className={isRevoked ? "text-[var(--muted)]" : "text-violet-500"}
+                    aria-hidden="true"
+                  />
+                  <span className="text-sm font-semibold text-[var(--foreground)]">
+                    {cert.certType}
+                  </span>
+                </div>
+                <RevocationBadge revoked={isRevoked} compact />
+              </div>
+
+              <dl className="text-xs text-[var(--muted)] space-y-0.5 mb-3">
+                <div>
+                  <dt className="inline font-medium">ID: </dt>
+                  <dd className="inline font-mono">{cert.certId}</dd>
+                </div>
+                <div>
+                  <dt className="inline font-medium">Issued: </dt>
+                  <dd className="inline">{new Date(cert.issuedAt).toLocaleString()}</dd>
+                </div>
+                <div>
+                  <dt className="inline font-medium">Issuer: </dt>
+                  <dd className="inline font-mono">
+                    {cert.issuer.slice(0, 8)}…{cert.issuer.slice(-6)}
+                  </dd>
+                </div>
+              </dl>
+
+              {/* Revocation detail */}
+              {isRevoked && revocation && (
+                <RevocationBadge revoked={true} revocation={revocation} />
+              )}
+
+              {/* Revoke action (only for valid certs when wallet connected) */}
+              {!isRevoked && walletAddress && (
+                <div className="mt-3">
+                  {showReasonFor === cert.certId ? (
+                    <div className="flex flex-col gap-2">
+                      <input
+                        type="text"
+                        value={reasonInputs[cert.certId] ?? ""}
+                        onChange={(e) =>
+                          setReasonInputs((prev) => ({ ...prev, [cert.certId]: e.target.value }))
+                        }
+                        placeholder="Reason for revocation…"
+                        className="px-3 py-1.5 text-xs rounded-lg border border-[var(--card-border)] bg-[var(--background)] focus:outline-none focus:ring-2 focus:ring-red-500"
+                      />
+                      <div className="flex gap-2">
+                        <button
+                          onClick={() => handleRevoke(cert.certId)}
+                          disabled={revoking === cert.certId}
+                          className="flex items-center gap-1.5 text-xs px-3 py-1.5 rounded-lg bg-red-600 hover:bg-red-700 text-white transition-colors disabled:opacity-50"
+                        >
+                          {revoking === cert.certId ? (
+                            <Loader2 size={12} className="animate-spin" />
+                          ) : (
+                            <ShieldOff size={12} />
+                          )}
+                          Confirm Revoke
+                        </button>
+                        <button
+                          onClick={() => setShowReasonFor(null)}
+                          className="text-xs px-3 py-1.5 rounded-lg border border-[var(--card-border)] hover:bg-[var(--muted-bg)] transition-colors"
+                        >
+                          Cancel
+                        </button>
+                      </div>
+                    </div>
+                  ) : (
+                    <button
+                      onClick={() => setShowReasonFor(cert.certId)}
+                      className="flex items-center gap-1.5 text-xs px-3 py-1.5 rounded-lg border border-red-300 text-red-600 hover:bg-red-50 dark:hover:bg-red-950/30 transition-colors"
+                    >
+                      <ShieldOff size={12} />
+                      Revoke Certificate
+                    </button>
+                  )}
+                </div>
+              )}
+            </li>
+          );
+        })}
+      </ul>
+
+      {/* Issue new certificate */}
+      {walletAddress && (
+        <button
+          onClick={() => setIssueOpen(true)}
+          className="flex items-center gap-2 text-sm px-3 py-1.5 rounded-lg border border-[var(--card-border)] hover:bg-[var(--muted-bg)] transition-colors self-start"
+        >
+          <Plus size={14} />
+          Issue Certificate
+        </button>
+      )}
+
+      <IssueCertificateForm productId={productId} open={issueOpen} onOpenChange={setIssueOpen} />
+    </div>
+  );
+}

--- a/frontend/components/certificates/IssueCertificateForm.tsx
+++ b/frontend/components/certificates/IssueCertificateForm.tsx
@@ -1,0 +1,180 @@
+"use client";
+
+import { useState } from "react";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+import * as Dialog from "@radix-ui/react-dialog";
+import { X, Award, RefreshCw } from "lucide-react";
+import { useStore } from "@/lib/state/store";
+import { useToast } from "@/lib/hooks/useToast";
+import { contractClient } from "@/lib/stellar/contract";
+import type { Certificate } from "@/lib/types";
+
+const CERT_TYPES = ["ORGANIC", "FAIR_TRADE", "ISO9001", "HALAL", "KOSHER", "OTHER"] as const;
+
+const schema = z.object({
+  certId: z.string().min(3, "Certificate ID is required"),
+  certType: z.string().min(1, "Certificate type is required"),
+  metadata: z.string().optional(),
+});
+
+type FormValues = z.infer<typeof schema>;
+
+function generateCertId() {
+  return `cert-${crypto.randomUUID().slice(0, 8)}`;
+}
+
+interface Props {
+  productId: string;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onIssued?: (cert: Certificate) => void;
+}
+
+export function IssueCertificateForm({ productId, open, onOpenChange, onIssued }: Props) {
+  const { walletAddress, addCertificate } = useStore();
+  const toast = useToast();
+  const [pending, setPending] = useState(false);
+
+  const {
+    register,
+    handleSubmit,
+    setValue,
+    reset,
+    formState: { errors },
+  } = useForm<FormValues>({
+    resolver: zodResolver(schema),
+    defaultValues: { certId: generateCertId(), certType: "ORGANIC" },
+  });
+
+  async function onSubmit(values: FormValues) {
+    if (!walletAddress) {
+      toast.error("Wallet not connected", "Connect your Freighter wallet first.");
+      return;
+    }
+
+    setPending(true);
+    const toastId = toast.loading("Issuing certificate on-chain…");
+
+    try {
+      const txHash = await contractClient.issueCertificate(
+        values.certId,
+        productId,
+        walletAddress,
+        values.certType,
+        values.metadata ?? "{}",
+        walletAddress
+      );
+
+      const cert: Certificate = {
+        certId: values.certId,
+        productId,
+        issuer: walletAddress,
+        issuedAt: Date.now(),
+        certType: values.certType,
+        metadata: values.metadata ?? "{}",
+        revoked: false,
+      };
+
+      addCertificate(cert);
+      onIssued?.(cert);
+
+      toast.dismiss(toastId);
+      toast.success("Certificate issued", txHash);
+      reset({ certId: generateCertId(), certType: "ORGANIC" });
+      onOpenChange(false);
+    } catch (err) {
+      toast.dismiss(toastId);
+      toast.error("Failed to issue certificate", err instanceof Error ? err.message : "Unknown error");
+    } finally {
+      setPending(false);
+    }
+  }
+
+  return (
+    <Dialog.Root open={open} onOpenChange={onOpenChange}>
+      <Dialog.Portal>
+        <Dialog.Overlay className="fixed inset-0 bg-black/50 backdrop-blur-sm z-40" />
+        <Dialog.Content className="fixed left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 z-50 w-full max-w-md bg-[var(--background)] border border-[var(--card-border)] rounded-2xl p-6 shadow-xl">
+          <div className="flex items-center justify-between mb-6">
+            <div className="flex items-center gap-2">
+              <Award size={20} className="text-violet-500" aria-hidden="true" />
+              <Dialog.Title className="text-lg font-semibold">Issue Certificate</Dialog.Title>
+            </div>
+            <Dialog.Close className="p-1 rounded-lg hover:bg-[var(--muted-bg)] transition-colors">
+              <X size={18} />
+            </Dialog.Close>
+          </div>
+
+          <form onSubmit={handleSubmit(onSubmit)} className="flex flex-col gap-4">
+            {/* Certificate ID */}
+            <div className="flex flex-col gap-1">
+              <label className="text-sm font-medium">Certificate ID</label>
+              <div className="flex gap-2">
+                <input
+                  {...register("certId")}
+                  className="flex-1 px-3 py-2 rounded-lg border border-[var(--card-border)] bg-[var(--card)] text-sm font-mono focus:outline-none focus:ring-2 focus:ring-violet-500"
+                />
+                <button
+                  type="button"
+                  onClick={() => setValue("certId", generateCertId())}
+                  className="p-2 rounded-lg border border-[var(--card-border)] hover:bg-[var(--muted-bg)] transition-colors"
+                  title="Regenerate ID"
+                >
+                  <RefreshCw size={16} />
+                </button>
+              </div>
+              {errors.certId && <p className="text-xs text-red-500">{errors.certId.message}</p>}
+            </div>
+
+            {/* Certificate Type */}
+            <div className="flex flex-col gap-1">
+              <label className="text-sm font-medium">Certificate Type</label>
+              <select
+                {...register("certType")}
+                className="px-3 py-2 rounded-lg border border-[var(--card-border)] bg-[var(--card)] text-sm focus:outline-none focus:ring-2 focus:ring-violet-500"
+              >
+                {CERT_TYPES.map((t) => (
+                  <option key={t} value={t}>
+                    {t.replace("_", " ")}
+                  </option>
+                ))}
+              </select>
+              {errors.certType && <p className="text-xs text-red-500">{errors.certType.message}</p>}
+            </div>
+
+            {/* Metadata */}
+            <div className="flex flex-col gap-1">
+              <label className="text-sm font-medium">
+                Metadata <span className="text-[var(--muted)] font-normal">(optional JSON)</span>
+              </label>
+              <textarea
+                {...register("metadata")}
+                rows={3}
+                placeholder='{"body": "USDA Organic", "license": "..."}'
+                className="px-3 py-2 rounded-lg border border-[var(--card-border)] bg-[var(--card)] text-sm font-mono focus:outline-none focus:ring-2 focus:ring-violet-500 resize-none"
+              />
+            </div>
+
+            <div className="flex gap-3 mt-2">
+              <Dialog.Close
+                className="flex-1 px-4 py-2 rounded-lg border border-[var(--card-border)] text-sm font-medium hover:bg-[var(--muted-bg)] transition-colors"
+                disabled={pending}
+              >
+                Cancel
+              </Dialog.Close>
+              <button
+                type="submit"
+                disabled={pending}
+                className="flex-1 px-4 py-2 rounded-lg bg-violet-600 hover:bg-violet-700 text-white text-sm font-medium transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                {pending ? "Issuing…" : "Issue Certificate"}
+              </button>
+            </div>
+          </form>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}

--- a/frontend/components/certificates/RevocationBadge.tsx
+++ b/frontend/components/certificates/RevocationBadge.tsx
@@ -1,0 +1,55 @@
+import { ShieldOff, ShieldCheck } from "lucide-react";
+import type { RevocationRecord } from "@/lib/types";
+
+interface RevocationBadgeProps {
+  revoked: boolean;
+  revocation?: RevocationRecord;
+  /** Show compact inline badge vs full detail block */
+  compact?: boolean;
+}
+
+export function RevocationBadge({ revoked, revocation, compact = false }: RevocationBadgeProps) {
+  if (!revoked) {
+    return (
+      <span className="inline-flex items-center gap-1 text-xs font-medium px-2 py-0.5 rounded-full bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400">
+        <ShieldCheck size={11} aria-hidden="true" />
+        Valid
+      </span>
+    );
+  }
+
+  if (compact) {
+    return (
+      <span className="inline-flex items-center gap-1 text-xs font-medium px-2 py-0.5 rounded-full bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400">
+        <ShieldOff size={11} aria-hidden="true" />
+        Revoked
+      </span>
+    );
+  }
+
+  return (
+    <div className="rounded-lg border border-red-300 bg-red-50 dark:bg-red-950/30 dark:border-red-800 p-3">
+      <div className="flex items-center gap-2 mb-1">
+        <ShieldOff size={14} className="text-red-600 dark:text-red-400" aria-hidden="true" />
+        <span className="text-sm font-semibold text-red-700 dark:text-red-400">
+          Certificate Revoked
+        </span>
+      </div>
+      {revocation && (
+        <div className="text-xs text-[var(--muted)] space-y-0.5 ml-5">
+          <p>
+            <span className="font-medium">Reason:</span> {revocation.reason}
+          </p>
+          <p>
+            <span className="font-medium">Revoked at:</span>{" "}
+            {new Date(revocation.revokedAt).toLocaleString()}
+          </p>
+          <p className="font-mono break-all">
+            <span className="font-medium font-sans">By:</span>{" "}
+            {revocation.revoker.slice(0, 8)}…{revocation.revoker.slice(-6)}
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/lib/__tests__/alerts.test.ts
+++ b/frontend/lib/__tests__/alerts.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  MOCK_RECALL_ALERTS,
+  getActiveAlertByProductId,
+} from "@/lib/mock/products";
+import type { RecallAlert } from "@/lib/types";
+
+// ── Helper ────────────────────────────────────────────────────────────────────
+
+function makeAlert(overrides: Partial<RecallAlert> = {}): RecallAlert {
+  return {
+    productId: "prod-test",
+    issuer: "GABC1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ",
+    severity: "HIGH",
+    title: "Test Alert",
+    description: "Test description",
+    timestamp: Date.now(),
+    channels: "banner,email",
+    active: true,
+    ...overrides,
+  };
+}
+
+// ── Mock data tests ───────────────────────────────────────────────────────────
+
+describe("MOCK_RECALL_ALERTS", () => {
+  it("contains at least one alert", () => {
+    expect(MOCK_RECALL_ALERTS.length).toBeGreaterThan(0);
+  });
+
+  it("prod-001 has an active CRITICAL alert", () => {
+    const alert = MOCK_RECALL_ALERTS.find(
+      (a) => a.productId === "prod-001" && a.active
+    );
+    expect(alert).toBeDefined();
+    expect(alert!.severity).toBe("CRITICAL");
+  });
+});
+
+describe("getActiveAlertByProductId", () => {
+  it("returns the active alert for a product that has one", () => {
+    const alert = getActiveAlertByProductId("prod-001");
+    expect(alert).toBeDefined();
+    expect(alert!.active).toBe(true);
+  });
+
+  it("returns undefined for a product with no alert", () => {
+    const alert = getActiveAlertByProductId("prod-999-nonexistent");
+    expect(alert).toBeUndefined();
+  });
+});
+
+// ── Alert severity ordering ───────────────────────────────────────────────────
+
+describe("Alert severity values", () => {
+  const SEVERITY_ORDER = ["LOW", "MEDIUM", "HIGH", "CRITICAL"] as const;
+
+  it("all severity levels are defined", () => {
+    for (const sev of SEVERITY_ORDER) {
+      const alert = makeAlert({ severity: sev });
+      expect(alert.severity).toBe(sev);
+    }
+  });
+});
+
+// ── Alert shape validation ────────────────────────────────────────────────────
+
+describe("RecallAlert shape", () => {
+  it("has all required fields", () => {
+    const alert = makeAlert();
+    expect(alert).toHaveProperty("productId");
+    expect(alert).toHaveProperty("issuer");
+    expect(alert).toHaveProperty("severity");
+    expect(alert).toHaveProperty("title");
+    expect(alert).toHaveProperty("description");
+    expect(alert).toHaveProperty("timestamp");
+    expect(alert).toHaveProperty("channels");
+    expect(alert).toHaveProperty("active");
+  });
+
+  it("channels is a comma-separated string", () => {
+    const alert = makeAlert({ channels: "banner,email,webhook" });
+    const parts = alert.channels.split(",").map((c) => c.trim());
+    expect(parts).toContain("banner");
+    expect(parts).toContain("email");
+    expect(parts).toContain("webhook");
+  });
+
+  it("active flag can be toggled", () => {
+    const active = makeAlert({ active: true });
+    const resolved = { ...active, active: false };
+    expect(active.active).toBe(true);
+    expect(resolved.active).toBe(false);
+  });
+});
+
+// ── Alert propagation logic ───────────────────────────────────────────────────
+
+describe("Alert propagation", () => {
+  it("only active alerts are surfaced", () => {
+    const alerts: RecallAlert[] = [
+      makeAlert({ productId: "p1", active: true }),
+      makeAlert({ productId: "p2", active: false }),
+      makeAlert({ productId: "p3", active: true }),
+    ];
+    const active = alerts.filter((a) => a.active);
+    expect(active).toHaveLength(2);
+    expect(active.every((a) => a.active)).toBe(true);
+  });
+
+  it("CRITICAL alerts are included in active set", () => {
+    const alerts: RecallAlert[] = [
+      makeAlert({ severity: "CRITICAL", active: true }),
+      makeAlert({ severity: "LOW", active: false }),
+    ];
+    const critical = alerts.filter((a) => a.active && a.severity === "CRITICAL");
+    expect(critical).toHaveLength(1);
+  });
+
+  it("resolving an alert sets active to false", () => {
+    const alert = makeAlert({ active: true });
+    const resolved = { ...alert, active: false };
+    expect(resolved.active).toBe(false);
+  });
+
+  it("issuing a new alert replaces the previous one for the same product", () => {
+    const existing = makeAlert({ productId: "p1", title: "Old Alert", active: true });
+    const newAlert = makeAlert({ productId: "p1", title: "New Alert", active: true });
+
+    // Simulate store logic: new alert replaces existing for same product
+    let alerts: RecallAlert[] = [existing];
+    alerts = [newAlert, ...alerts.filter((a) => a.productId !== newAlert.productId)];
+
+    expect(alerts).toHaveLength(1);
+    expect(alerts[0].title).toBe("New Alert");
+  });
+});

--- a/frontend/lib/__tests__/revocation.test.ts
+++ b/frontend/lib/__tests__/revocation.test.ts
@@ -1,0 +1,175 @@
+import { describe, it, expect } from "vitest";
+import {
+  MOCK_CERTIFICATES,
+  MOCK_REVOCATIONS,
+  getCertificatesByProductId,
+  getRevocationByCertId,
+} from "@/lib/mock/products";
+import type { Certificate, RevocationRecord } from "@/lib/types";
+
+// ── Helper ────────────────────────────────────────────────────────────────────
+
+function makeCert(overrides: Partial<Certificate> = {}): Certificate {
+  return {
+    certId: `cert-${Math.random().toString(36).slice(2, 8)}`,
+    productId: "prod-test",
+    issuer: "GABC1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ",
+    issuedAt: Date.now(),
+    certType: "ORGANIC",
+    metadata: "{}",
+    revoked: false,
+    ...overrides,
+  };
+}
+
+function makeRevocation(overrides: Partial<RevocationRecord> = {}): RevocationRecord {
+  return {
+    certId: "cert-test",
+    revoker: "GABC1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ",
+    revokedAt: Date.now(),
+    reason: "Test reason",
+    ...overrides,
+  };
+}
+
+// ── Mock data tests ───────────────────────────────────────────────────────────
+
+describe("MOCK_CERTIFICATES", () => {
+  it("contains certificates", () => {
+    expect(MOCK_CERTIFICATES.length).toBeGreaterThan(0);
+  });
+
+  it("prod-001 has at least one certificate", () => {
+    const certs = getCertificatesByProductId("prod-001");
+    expect(certs.length).toBeGreaterThan(0);
+  });
+
+  it("prod-001 has a revoked fair-trade certificate", () => {
+    const certs = getCertificatesByProductId("prod-001");
+    const revoked = certs.find((c) => c.revoked);
+    expect(revoked).toBeDefined();
+    expect(revoked!.certType).toBe("FAIR_TRADE");
+  });
+
+  it("prod-001 has a valid organic certificate", () => {
+    const certs = getCertificatesByProductId("prod-001");
+    const valid = certs.find((c) => !c.revoked && c.certType === "ORGANIC");
+    expect(valid).toBeDefined();
+  });
+});
+
+describe("MOCK_REVOCATIONS", () => {
+  it("contains at least one revocation record", () => {
+    expect(MOCK_REVOCATIONS.length).toBeGreaterThan(0);
+  });
+
+  it("revocation record has all required fields", () => {
+    const record = MOCK_REVOCATIONS[0];
+    expect(record).toHaveProperty("certId");
+    expect(record).toHaveProperty("revoker");
+    expect(record).toHaveProperty("revokedAt");
+    expect(record).toHaveProperty("reason");
+  });
+});
+
+describe("getRevocationByCertId", () => {
+  it("returns the revocation record for a revoked cert", () => {
+    const record = getRevocationByCertId("cert-001-fairtrade");
+    expect(record).toBeDefined();
+    expect(record!.certId).toBe("cert-001-fairtrade");
+  });
+
+  it("returns undefined for a non-revoked cert", () => {
+    const record = getRevocationByCertId("cert-001-organic");
+    expect(record).toBeUndefined();
+  });
+
+  it("returns undefined for an unknown cert ID", () => {
+    const record = getRevocationByCertId("cert-does-not-exist");
+    expect(record).toBeUndefined();
+  });
+});
+
+// ── Certificate shape validation ──────────────────────────────────────────────
+
+describe("Certificate shape", () => {
+  it("has all required fields", () => {
+    const cert = makeCert();
+    expect(cert).toHaveProperty("certId");
+    expect(cert).toHaveProperty("productId");
+    expect(cert).toHaveProperty("issuer");
+    expect(cert).toHaveProperty("issuedAt");
+    expect(cert).toHaveProperty("certType");
+    expect(cert).toHaveProperty("metadata");
+    expect(cert).toHaveProperty("revoked");
+  });
+
+  it("revoked defaults to false", () => {
+    const cert = makeCert();
+    expect(cert.revoked).toBe(false);
+  });
+});
+
+// ── Revocation logic ──────────────────────────────────────────────────────────
+
+describe("Revocation logic", () => {
+  it("is_certificate_valid returns true for non-revoked cert", () => {
+    const cert = makeCert({ revoked: false });
+    expect(!cert.revoked).toBe(true);
+  });
+
+  it("is_certificate_valid returns false for revoked cert", () => {
+    const cert = makeCert({ revoked: true });
+    expect(!cert.revoked).toBe(false);
+  });
+
+  it("revoking a cert sets revoked to true", () => {
+    const cert = makeCert({ revoked: false });
+    const revoked = { ...cert, revoked: true };
+    expect(revoked.revoked).toBe(true);
+  });
+
+  it("revocation record links to the correct cert", () => {
+    const cert = makeCert({ certId: "cert-abc" });
+    const record = makeRevocation({ certId: cert.certId });
+    expect(record.certId).toBe(cert.certId);
+  });
+
+  it("double revocation is prevented (cert already revoked)", () => {
+    const cert = makeCert({ revoked: true });
+    // Simulate the guard: if already revoked, throw
+    const tryRevoke = () => {
+      if (cert.revoked) throw new Error("certificate is already revoked");
+    };
+    expect(tryRevoke).toThrow("certificate is already revoked");
+  });
+
+  it("verification logic accounts for revoked credentials", () => {
+    const certs: Certificate[] = [
+      makeCert({ certId: "c1", revoked: false }),
+      makeCert({ certId: "c2", revoked: true }),
+      makeCert({ certId: "c3", revoked: false }),
+    ];
+
+    const validCerts = certs.filter((c) => !c.revoked);
+    const revokedCerts = certs.filter((c) => c.revoked);
+
+    expect(validCerts).toHaveLength(2);
+    expect(revokedCerts).toHaveLength(1);
+    expect(revokedCerts[0].certId).toBe("c2");
+  });
+
+  it("revocation record stores reason and timestamp", () => {
+    const record = makeRevocation({
+      reason: "Audit failed",
+      revokedAt: 1710650000000,
+    });
+    expect(record.reason).toBe("Audit failed");
+    expect(record.revokedAt).toBe(1710650000000);
+  });
+
+  it("getCertificatesByProductId returns empty array for unknown product", () => {
+    const certs = getCertificatesByProductId("prod-nonexistent");
+    expect(certs).toEqual([]);
+  });
+});

--- a/frontend/lib/hooks/useDashboardData.ts
+++ b/frontend/lib/hooks/useDashboardData.ts
@@ -2,7 +2,7 @@
 
 import { useEffect } from "react";
 import { useStore } from "@/lib/state/store";
-import { MOCK_PRODUCTS, MOCK_EVENTS } from "@/lib/mock/products";
+import { MOCK_PRODUCTS, MOCK_EVENTS, MOCK_RECALL_ALERTS, MOCK_CERTIFICATES, MOCK_REVOCATIONS } from "@/lib/mock/products";
 import type { EventType } from "@/lib/types";
 
 const CACHE_TTL_MS = 60_000; // 1 minute
@@ -25,8 +25,17 @@ export interface EventTypeCount {
 }
 
 export function useDashboardData() {
-  const { products, events, lastFetched, setProducts, setEvents, setLastFetched } =
-    useStore();
+  const {
+    products,
+    events,
+    lastFetched,
+    setProducts,
+    setEvents,
+    setLastFetched,
+    setRecallAlerts,
+    setCertificates,
+    setRevocations,
+  } = useStore();
 
   useEffect(() => {
     const now = Date.now();
@@ -35,8 +44,11 @@ export function useDashboardData() {
     // In production this would be replaced by real Soroban RPC calls.
     setProducts(MOCK_PRODUCTS);
     setEvents(MOCK_EVENTS);
+    setRecallAlerts(MOCK_RECALL_ALERTS);
+    setCertificates(MOCK_CERTIFICATES);
+    setRevocations(MOCK_REVOCATIONS);
     setLastFetched(now);
-  }, [lastFetched, setProducts, setEvents, setLastFetched]);
+  }, [lastFetched, setProducts, setEvents, setLastFetched, setRecallAlerts, setCertificates, setRevocations]);
 
   const now = Date.now();
   const oneDayAgo = now - 86_400_000;

--- a/frontend/lib/mock/products.ts
+++ b/frontend/lib/mock/products.ts
@@ -1,4 +1,4 @@
-import type { Product, TrackingEvent } from "@/lib/types";
+import type { Product, TrackingEvent, RecallAlert, Certificate, RevocationRecord } from "@/lib/types";
 
 export const MOCK_PRODUCTS: Product[] = [
   {
@@ -74,10 +74,78 @@ export const MOCK_EVENTS: TrackingEvent[] = [
   },
 ];
 
+/** Mock recall alerts — prod-001 has an active critical recall. */
+export const MOCK_RECALL_ALERTS: RecallAlert[] = [
+  {
+    productId: "prod-001",
+    issuer: "GABC1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ",
+    severity: "CRITICAL",
+    title: "Contamination Risk — Batch #ETH-2024-03",
+    description:
+      "Lab testing has identified potential allergen cross-contamination in batch #ETH-2024-03. All downstream stakeholders must halt distribution immediately.",
+    timestamp: 1710700000000,
+    channels: "banner,email,webhook",
+    active: true,
+  },
+];
+
+/** Mock certificates — prod-001 has an organic cert (valid) and a fair-trade cert (revoked). */
+export const MOCK_CERTIFICATES: Certificate[] = [
+  {
+    certId: "cert-001-organic",
+    productId: "prod-001",
+    issuer: "GABC1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ",
+    issuedAt: 1710050000000,
+    certType: "ORGANIC",
+    metadata: JSON.stringify({ body: "USDA Organic", standard: "NOP" }),
+    revoked: false,
+  },
+  {
+    certId: "cert-001-fairtrade",
+    productId: "prod-001",
+    issuer: "GABC1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ",
+    issuedAt: 1710060000000,
+    certType: "FAIR_TRADE",
+    metadata: JSON.stringify({ body: "Fairtrade International", license: "FLO-12345" }),
+    revoked: true,
+  },
+  {
+    certId: "cert-002-organic",
+    productId: "prod-002",
+    issuer: "GDEF1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ",
+    issuedAt: 1711050000000,
+    certType: "ORGANIC",
+    metadata: JSON.stringify({ body: "EU Organic", standard: "EC 834/2007" }),
+    revoked: false,
+  },
+];
+
+/** Mock revocation records. */
+export const MOCK_REVOCATIONS: RevocationRecord[] = [
+  {
+    certId: "cert-001-fairtrade",
+    revoker: "GABC1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ",
+    revokedAt: 1710650000000,
+    reason: "Supplier failed annual audit — license suspended by Fairtrade International.",
+  },
+];
+
 export function getProductById(id: string): Product | undefined {
   return MOCK_PRODUCTS.find((p) => p.id === id);
 }
 
 export function getEventsByProductId(id: string): TrackingEvent[] {
   return MOCK_EVENTS.filter((e) => e.productId === id);
+}
+
+export function getActiveAlertByProductId(id: string): RecallAlert | undefined {
+  return MOCK_RECALL_ALERTS.find((a) => a.productId === id && a.active);
+}
+
+export function getCertificatesByProductId(id: string): Certificate[] {
+  return MOCK_CERTIFICATES.filter((c) => c.productId === id);
+}
+
+export function getRevocationByCertId(certId: string): RevocationRecord | undefined {
+  return MOCK_REVOCATIONS.find((r) => r.certId === certId);
 }

--- a/frontend/lib/state/store.ts
+++ b/frontend/lib/state/store.ts
@@ -1,6 +1,6 @@
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
-import type { Product, TrackingEvent } from "../types";
+import type { Product, TrackingEvent, RecallAlert, Certificate, RevocationRecord } from "../types";
 import { isConnected } from "@stellar/freighter-api";
 
 interface SupplyLinkStore {
@@ -16,6 +16,11 @@ interface SupplyLinkStore {
   eventPage: number;
   eventPageSize: number;
   eventTotal: number;
+  // Alert state
+  recallAlerts: RecallAlert[];
+  // Certificate / revocation state
+  certificates: Certificate[];
+  revocations: RevocationRecord[];
   setWalletAddress: (address: string | null) => void;
   setXlmBalance: (balance: string | null) => void;
   setNetworkMismatch: (mismatch: boolean) => void;
@@ -33,11 +38,22 @@ interface SupplyLinkStore {
   setEventPageSize: (size: number) => void;
   setEventTotal: (total: number) => void;
   disconnect: () => void;
+  // Alert actions
+  addRecallAlert: (alert: RecallAlert) => void;
+  resolveRecallAlert: (productId: string) => void;
+  setRecallAlerts: (alerts: RecallAlert[]) => void;
+  getActiveAlertForProduct: (productId: string) => RecallAlert | undefined;
+  // Certificate / revocation actions
+  addCertificate: (cert: Certificate) => void;
+  setCertificates: (certs: Certificate[]) => void;
+  addRevocation: (record: RevocationRecord) => void;
+  setRevocations: (records: RevocationRecord[]) => void;
+  revokeCertificateInStore: (certId: string, record: RevocationRecord) => void;
 }
 
 export const useStore = create<SupplyLinkStore>()(
   persist(
-    (set) => ({
+    (set, get) => ({
       products: [],
       events: [],
       walletAddress: null,
@@ -50,6 +66,9 @@ export const useStore = create<SupplyLinkStore>()(
       eventPage: 0,
       eventPageSize: 20,
       eventTotal: 0,
+      recallAlerts: [],
+      certificates: [],
+      revocations: [],
       setWalletAddress: (address) => set({ walletAddress: address }),
       setXlmBalance: (balance) => set({ xlmBalance: balance }),
       setNetworkMismatch: (mismatch) => set({ networkMismatch: mismatch }),
@@ -87,6 +106,38 @@ export const useStore = create<SupplyLinkStore>()(
           productPage: 0,
           eventPage: 0,
         }),
+      // Alert actions
+      addRecallAlert: (alert) =>
+        set((state) => ({
+          // Replace existing alert for same product, then prepend new one
+          recallAlerts: [
+            alert,
+            ...state.recallAlerts.filter((a) => a.productId !== alert.productId),
+          ],
+        })),
+      resolveRecallAlert: (productId) =>
+        set((state) => ({
+          recallAlerts: state.recallAlerts.map((a) =>
+            a.productId === productId ? { ...a, active: false } : a
+          ),
+        })),
+      setRecallAlerts: (alerts) => set({ recallAlerts: alerts }),
+      getActiveAlertForProduct: (productId) =>
+        get().recallAlerts.find((a) => a.productId === productId && a.active),
+      // Certificate / revocation actions
+      addCertificate: (cert) =>
+        set((state) => ({ certificates: [...state.certificates, cert] })),
+      setCertificates: (certs) => set({ certificates: certs }),
+      addRevocation: (record) =>
+        set((state) => ({ revocations: [...state.revocations, record] })),
+      setRevocations: (records) => set({ revocations: records }),
+      revokeCertificateInStore: (certId, record) =>
+        set((state) => ({
+          certificates: state.certificates.map((c) =>
+            c.certId === certId ? { ...c, revoked: true } : c
+          ),
+          revocations: [...state.revocations, record],
+        })),
     }),
     {
       name: "supply-link-store",

--- a/frontend/lib/stellar/contract.ts
+++ b/frontend/lib/stellar/contract.ts
@@ -188,4 +188,136 @@ export const contractClient = {
     }
     throw new Error("Failed to get product count");
   },
+
+  // ── Emergency Alert / Recall ──────────────────────────────────────────────
+
+  async issueRecallAlert(
+    productId: string,
+    issuer: string,
+    severity: string,
+    title: string,
+    description: string,
+    channels: string,
+    callerAddress: string
+  ): Promise<string> {
+    return buildSignAndSubmitTransaction({
+      method: "issue_recall_alert",
+      args: [productId, new Address(issuer), severity, title, description, channels],
+      callerAddress,
+    });
+  },
+
+  async resolveRecallAlert(
+    productId: string,
+    resolver: string,
+    callerAddress: string
+  ): Promise<string> {
+    return buildSignAndSubmitTransaction({
+      method: "resolve_recall_alert",
+      args: [productId, new Address(resolver)],
+      callerAddress,
+    });
+  },
+
+  async getRecallAlert(productId: string, callerAddress: string): Promise<any | null> {
+    const simulated = await buildAndSimulateTransaction({
+      method: "get_recall_alert",
+      args: [productId],
+      callerAddress,
+    });
+    if (SorobanRpc.isSimulationSuccess(simulated)) {
+      return scValToNative(simulated.results?.[0]) ?? null;
+    }
+    throw new Error("Failed to get recall alert");
+  },
+
+  async getRecallAlertHistory(productId: string, callerAddress: string): Promise<any[]> {
+    const simulated = await buildAndSimulateTransaction({
+      method: "get_recall_alert_history",
+      args: [productId],
+      callerAddress,
+    });
+    if (SorobanRpc.isSimulationSuccess(simulated)) {
+      return scValToNative(simulated.results?.[0]) || [];
+    }
+    throw new Error("Failed to get recall alert history");
+  },
+
+  // ── Certificate & Revocation Registry ────────────────────────────────────
+
+  async issueCertificate(
+    certId: string,
+    productId: string,
+    issuer: string,
+    certType: string,
+    metadata: string,
+    callerAddress: string
+  ): Promise<string> {
+    return buildSignAndSubmitTransaction({
+      method: "issue_certificate",
+      args: [certId, productId, new Address(issuer), certType, metadata],
+      callerAddress,
+    });
+  },
+
+  async revokeCertificate(
+    certId: string,
+    revoker: string,
+    reason: string,
+    callerAddress: string
+  ): Promise<string> {
+    return buildSignAndSubmitTransaction({
+      method: "revoke_certificate",
+      args: [certId, new Address(revoker), reason],
+      callerAddress,
+    });
+  },
+
+  async getCertificate(certId: string, callerAddress: string): Promise<any> {
+    const simulated = await buildAndSimulateTransaction({
+      method: "get_certificate",
+      args: [certId],
+      callerAddress,
+    });
+    if (SorobanRpc.isSimulationSuccess(simulated)) {
+      return scValToNative(simulated.results?.[0]);
+    }
+    throw new Error("Failed to get certificate");
+  },
+
+  async getProductCertificates(productId: string, callerAddress: string): Promise<any[]> {
+    const simulated = await buildAndSimulateTransaction({
+      method: "get_product_certificates",
+      args: [productId],
+      callerAddress,
+    });
+    if (SorobanRpc.isSimulationSuccess(simulated)) {
+      return scValToNative(simulated.results?.[0]) || [];
+    }
+    throw new Error("Failed to get product certificates");
+  },
+
+  async getRevocation(certId: string, callerAddress: string): Promise<any | null> {
+    const simulated = await buildAndSimulateTransaction({
+      method: "get_revocation",
+      args: [certId],
+      callerAddress,
+    });
+    if (SorobanRpc.isSimulationSuccess(simulated)) {
+      return scValToNative(simulated.results?.[0]) ?? null;
+    }
+    throw new Error("Failed to get revocation");
+  },
+
+  async isCertificateValid(certId: string, callerAddress: string): Promise<boolean> {
+    const simulated = await buildAndSimulateTransaction({
+      method: "is_certificate_valid",
+      args: [certId],
+      callerAddress,
+    });
+    if (SorobanRpc.isSimulationSuccess(simulated)) {
+      return scValToNative(simulated.results?.[0]) ?? false;
+    }
+    throw new Error("Failed to check certificate validity");
+  },
 };

--- a/frontend/lib/types/index.ts
+++ b/frontend/lib/types/index.ts
@@ -1,5 +1,9 @@
 export type EventType = "HARVEST" | "PROCESSING" | "SHIPPING" | "RETAIL";
 
+export type AlertSeverity = "LOW" | "MEDIUM" | "HIGH" | "CRITICAL";
+
+export type CertificateType = "ORGANIC" | "FAIR_TRADE" | "ISO9001" | "HALAL" | "KOSHER" | "OTHER";
+
 export interface OwnershipRecord {
   owner: string; // Stellar address
   transferredAt: number; // unix ms
@@ -23,4 +27,36 @@ export interface TrackingEvent {
   timestamp: number;
   eventType: EventType;
   metadata: string; // JSON string
+}
+
+/** An emergency recall or safety alert attached to a product. */
+export interface RecallAlert {
+  productId: string;
+  issuer: string; // Stellar address
+  severity: AlertSeverity;
+  title: string;
+  description: string;
+  timestamp: number;
+  /** Comma-separated distribution channels: "banner", "email", "webhook" */
+  channels: string;
+  active: boolean;
+}
+
+/** A certificate or attestation issued for a product. */
+export interface Certificate {
+  certId: string;
+  productId: string;
+  issuer: string; // Stellar address
+  issuedAt: number;
+  certType: CertificateType | string;
+  metadata: string; // JSON string
+  revoked: boolean;
+}
+
+/** Written on-chain when a certificate is revoked. */
+export interface RevocationRecord {
+  certId: string;
+  revoker: string; // Stellar address
+  revokedAt: number;
+  reason: string;
 }

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "vitest/config";
+import tsconfigPaths from "vite-tsconfig-paths";
+
+export default defineConfig({
+  plugins: [tsconfigPaths()],
+  test: {
+    environment: "node",
+    globals: true,
+  },
+});

--- a/smart-contract/contracts/src/lib.rs
+++ b/smart-contract/contracts/src/lib.rs
@@ -25,6 +25,56 @@ pub struct TrackingEvent {
     pub metadata: String,   // JSON string
 }
 
+/// Severity level for a recall / safety alert.
+/// Stored as a u32 to keep the contract type simple.
+/// 0 = LOW, 1 = MEDIUM, 2 = HIGH, 3 = CRITICAL
+#[contracttype]
+#[derive(Clone, PartialEq)]
+pub enum AlertSeverity {
+    Low,
+    Medium,
+    High,
+    Critical,
+}
+
+/// An emergency recall or safety alert attached to a product.
+#[contracttype]
+#[derive(Clone)]
+pub struct RecallAlert {
+    pub product_id: String,
+    pub issuer: Address,
+    pub severity: AlertSeverity,
+    pub title: String,
+    pub description: String,
+    pub timestamp: u64,
+    /// Comma-separated distribution channels: "email,webhook,banner"
+    pub channels: String,
+    pub active: bool,
+}
+
+/// A certificate or attestation reference that can be revoked.
+#[contracttype]
+#[derive(Clone)]
+pub struct Certificate {
+    pub cert_id: String,
+    pub product_id: String,
+    pub issuer: Address,
+    pub issued_at: u64,
+    pub cert_type: String, // e.g. "ORGANIC" | "FAIR_TRADE" | "ISO9001"
+    pub metadata: String,  // JSON string with additional details
+    pub revoked: bool,
+}
+
+/// A revocation record written when a certificate is revoked.
+#[contracttype]
+#[derive(Clone)]
+pub struct RevocationRecord {
+    pub cert_id: String,
+    pub revoker: Address,
+    pub revoked_at: u64,
+    pub reason: String,
+}
+
 // ── Storage keys ─────────────────────────────────────────────────────────────
 
 #[contracttype]
@@ -33,6 +83,16 @@ pub enum DataKey {
     Events(String),
     ProductCount,
     ProductIndex(u64),
+    /// Active recall alert for a product (one active alert per product)
+    RecallAlert(String),
+    /// All recall alerts ever issued for a product (history)
+    RecallAlertHistory(String),
+    /// Certificate by cert_id
+    Certificate(String),
+    /// All cert_ids issued for a product
+    ProductCerts(String),
+    /// Revocation record by cert_id
+    Revocation(String),
 }
 
 // ── Contract ─────────────────────────────────────────────────────────────────
@@ -321,6 +381,278 @@ impl SupplyLinkContract {
         }
         
         products
+    }
+
+    // ── Emergency Alert / Recall methods ─────────────────────────────────────
+
+    /// Issue a recall or safety alert for a product.
+    /// Only the product owner or an authorized actor may issue an alert.
+    /// Replaces any previously active alert for the product.
+    pub fn issue_recall_alert(
+        env: Env,
+        product_id: String,
+        issuer: Address,
+        severity: AlertSeverity,
+        title: String,
+        description: String,
+        channels: String,
+    ) -> RecallAlert {
+        let product: Product = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Product(product_id.clone()))
+            .expect("product not found");
+
+        let is_owner = product.owner == issuer;
+        let is_actor = product.authorized_actors.contains(&issuer);
+        if !is_owner && !is_actor {
+            panic!("caller is not authorized to issue alerts");
+        }
+        issuer.require_auth();
+
+        let alert = RecallAlert {
+            product_id: product_id.clone(),
+            issuer: issuer.clone(),
+            severity: severity.clone(),
+            title: title.clone(),
+            description,
+            timestamp: env.ledger().timestamp(),
+            channels,
+            active: true,
+        };
+
+        // Store as the current active alert
+        env.storage()
+            .persistent()
+            .set(&DataKey::RecallAlert(product_id.clone()), &alert);
+
+        // Append to history
+        let mut history: Vec<RecallAlert> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::RecallAlertHistory(product_id.clone()))
+            .unwrap_or_else(|| Vec::new(&env));
+        history.push_back(alert.clone());
+        env.storage()
+            .persistent()
+            .set(&DataKey::RecallAlertHistory(product_id.clone()), &history);
+
+        // Emit event
+        env.events().publish(
+            (Symbol::new(&env, "recall_issued"), product_id, title),
+            alert.clone(),
+        );
+
+        alert
+    }
+
+    /// Resolve (deactivate) the active recall alert for a product.
+    /// Only the product owner may resolve an alert.
+    pub fn resolve_recall_alert(env: Env, product_id: String, resolver: Address) -> bool {
+        let product: Product = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Product(product_id.clone()))
+            .expect("product not found");
+
+        product.owner.require_auth();
+        if product.owner != resolver {
+            panic!("only the product owner can resolve alerts");
+        }
+
+        let mut alert: RecallAlert = env
+            .storage()
+            .persistent()
+            .get(&DataKey::RecallAlert(product_id.clone()))
+            .expect("no active alert found");
+
+        alert.active = false;
+        env.storage()
+            .persistent()
+            .set(&DataKey::RecallAlert(product_id.clone()), &alert);
+
+        env.events().publish(
+            (Symbol::new(&env, "recall_resolved"), product_id),
+            resolver,
+        );
+
+        true
+    }
+
+    /// Get the current (most recently issued) recall alert for a product.
+    /// Returns None if no alert has been issued.
+    pub fn get_recall_alert(env: Env, product_id: String) -> Option<RecallAlert> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::RecallAlert(product_id))
+    }
+
+    /// Get the full recall alert history for a product.
+    pub fn get_recall_alert_history(env: Env, product_id: String) -> Vec<RecallAlert> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::RecallAlertHistory(product_id))
+            .unwrap_or_else(|| Vec::new(&env))
+    }
+
+    // ── Certificate & Revocation Registry methods ─────────────────────────────
+
+    /// Issue a certificate or attestation for a product.
+    /// Only the product owner or an authorized actor may issue certificates.
+    pub fn issue_certificate(
+        env: Env,
+        cert_id: String,
+        product_id: String,
+        issuer: Address,
+        cert_type: String,
+        metadata: String,
+    ) -> Certificate {
+        let product: Product = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Product(product_id.clone()))
+            .expect("product not found");
+
+        let is_owner = product.owner == issuer;
+        let is_actor = product.authorized_actors.contains(&issuer);
+        if !is_owner && !is_actor {
+            panic!("caller is not authorized to issue certificates");
+        }
+        issuer.require_auth();
+
+        // Prevent duplicate cert IDs
+        if env.storage().persistent().has(&DataKey::Certificate(cert_id.clone())) {
+            panic!("certificate ID already exists");
+        }
+
+        let cert = Certificate {
+            cert_id: cert_id.clone(),
+            product_id: product_id.clone(),
+            issuer,
+            issued_at: env.ledger().timestamp(),
+            cert_type: cert_type.clone(),
+            metadata,
+            revoked: false,
+        };
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::Certificate(cert_id.clone()), &cert);
+
+        // Track cert IDs per product
+        let mut cert_ids: Vec<String> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::ProductCerts(product_id.clone()))
+            .unwrap_or_else(|| Vec::new(&env));
+        cert_ids.push_back(cert_id.clone());
+        env.storage()
+            .persistent()
+            .set(&DataKey::ProductCerts(product_id.clone()), &cert_ids);
+
+        env.events().publish(
+            (Symbol::new(&env, "cert_issued"), product_id, cert_type),
+            cert.clone(),
+        );
+
+        cert
+    }
+
+    /// Revoke a certificate. Only the original issuer or the product owner may revoke.
+    pub fn revoke_certificate(
+        env: Env,
+        cert_id: String,
+        revoker: Address,
+        reason: String,
+    ) -> RevocationRecord {
+        let mut cert: Certificate = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Certificate(cert_id.clone()))
+            .expect("certificate not found");
+
+        if cert.revoked {
+            panic!("certificate is already revoked");
+        }
+
+        // Verify revoker is the issuer or the product owner
+        let product: Product = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Product(cert.product_id.clone()))
+            .expect("product not found");
+
+        let is_issuer = cert.issuer == revoker;
+        let is_owner = product.owner == revoker;
+        if !is_issuer && !is_owner {
+            panic!("caller is not authorized to revoke this certificate");
+        }
+        revoker.require_auth();
+
+        cert.revoked = true;
+        env.storage()
+            .persistent()
+            .set(&DataKey::Certificate(cert_id.clone()), &cert);
+
+        let record = RevocationRecord {
+            cert_id: cert_id.clone(),
+            revoker,
+            revoked_at: env.ledger().timestamp(),
+            reason,
+        };
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::Revocation(cert_id.clone()), &record);
+
+        env.events().publish(
+            (Symbol::new(&env, "cert_revoked"), cert_id, cert.product_id),
+            record.clone(),
+        );
+
+        record
+    }
+
+    /// Get a certificate by its ID.
+    pub fn get_certificate(env: Env, cert_id: String) -> Certificate {
+        env.storage()
+            .persistent()
+            .get(&DataKey::Certificate(cert_id))
+            .expect("certificate not found")
+    }
+
+    /// Get all certificates issued for a product.
+    pub fn get_product_certificates(env: Env, product_id: String) -> Vec<Certificate> {
+        let cert_ids: Vec<String> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::ProductCerts(product_id))
+            .unwrap_or_else(|| Vec::new(&env));
+
+        let mut certs = Vec::new(&env);
+        for i in 0..cert_ids.len() {
+            let cert_id = cert_ids.get(i).unwrap();
+            if let Some(cert) = env.storage().persistent().get::<DataKey, Certificate>(&DataKey::Certificate(cert_id)) {
+                certs.push_back(cert);
+            }
+        }
+        certs
+    }
+
+    /// Get the revocation record for a certificate, if it has been revoked.
+    pub fn get_revocation(env: Env, cert_id: String) -> Option<RevocationRecord> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::Revocation(cert_id))
+    }
+
+    /// Returns true if the certificate exists and has NOT been revoked.
+    pub fn is_certificate_valid(env: Env, cert_id: String) -> bool {
+        env.storage()
+            .persistent()
+            .get::<DataKey, Certificate>(&DataKey::Certificate(cert_id))
+            .map(|c| !c.revoked)
+            .unwrap_or(false)
     }
 }
 
@@ -1069,5 +1401,341 @@ mod tests {
         assert_eq!(actors.get(0).unwrap(), actor1);
         assert_eq!(actors.get(1).unwrap(), actor2);
         assert_eq!(actors.get(2).unwrap(), actor3);
+    }
+
+    // ── Emergency Alert / Recall tests ───────────────────────────────────────
+
+    /// Alert: owner can issue a recall alert and it is stored as active
+    #[test]
+    fn test_issue_recall_alert_by_owner() {
+        let (env, contract_id, owner, product_id) = setup();
+        let client = SupplyLinkContractClient::new(&env, &contract_id);
+
+        let alert = client.issue_recall_alert(
+            &product_id,
+            &owner,
+            &AlertSeverity::Critical,
+            &String::from_str(&env, "Contamination Risk"),
+            &String::from_str(&env, "Batch may contain allergens"),
+            &String::from_str(&env, "banner,email"),
+        );
+
+        assert!(alert.active);
+        assert_eq!(alert.product_id, product_id);
+        assert_eq!(alert.severity, AlertSeverity::Critical);
+    }
+
+    /// Alert: get_recall_alert returns the stored alert
+    #[test]
+    fn test_get_recall_alert_returns_stored() {
+        let (env, contract_id, owner, product_id) = setup();
+        let client = SupplyLinkContractClient::new(&env, &contract_id);
+
+        client.issue_recall_alert(
+            &product_id,
+            &owner,
+            &AlertSeverity::High,
+            &String::from_str(&env, "Safety Notice"),
+            &String::from_str(&env, "Potential defect"),
+            &String::from_str(&env, "banner"),
+        );
+
+        let stored = client.get_recall_alert(&product_id);
+        assert!(stored.is_some());
+        let alert = stored.unwrap();
+        assert!(alert.active);
+        assert_eq!(alert.severity, AlertSeverity::High);
+    }
+
+    /// Alert: no alert returns None
+    #[test]
+    fn test_get_recall_alert_returns_none_when_absent() {
+        let (env, contract_id, _owner, product_id) = setup();
+        let client = SupplyLinkContractClient::new(&env, &contract_id);
+        let result = client.get_recall_alert(&product_id);
+        assert!(result.is_none());
+    }
+
+    /// Alert: owner can resolve an active alert
+    #[test]
+    fn test_resolve_recall_alert() {
+        let (env, contract_id, owner, product_id) = setup();
+        let client = SupplyLinkContractClient::new(&env, &contract_id);
+
+        client.issue_recall_alert(
+            &product_id,
+            &owner,
+            &AlertSeverity::Medium,
+            &String::from_str(&env, "Minor Issue"),
+            &String::from_str(&env, "Under investigation"),
+            &String::from_str(&env, "banner"),
+        );
+
+        let resolved = client.resolve_recall_alert(&product_id, &owner);
+        assert!(resolved);
+
+        let stored = client.get_recall_alert(&product_id).unwrap();
+        assert!(!stored.active);
+    }
+
+    /// Alert: history accumulates multiple alerts
+    #[test]
+    fn test_recall_alert_history_accumulates() {
+        let (env, contract_id, owner, product_id) = setup();
+        let client = SupplyLinkContractClient::new(&env, &contract_id);
+
+        for _ in 0..3 {
+            client.issue_recall_alert(
+                &product_id,
+                &owner,
+                &AlertSeverity::Low,
+                &String::from_str(&env, "Notice"),
+                &String::from_str(&env, "Details"),
+                &String::from_str(&env, "banner"),
+            );
+        }
+
+        let history = client.get_recall_alert_history(&product_id);
+        assert_eq!(history.len(), 3);
+    }
+
+    /// Alert: authorized actor (not owner) can also issue an alert
+    #[test]
+    fn test_authorized_actor_can_issue_alert() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(SupplyLinkContract, ());
+        let client = SupplyLinkContractClient::new(&env, &contract_id);
+        let owner = soroban_sdk::Address::generate(&env);
+        let actor = soroban_sdk::Address::generate(&env);
+        let product_id = String::from_str(&env, "prod-actor-alert");
+
+        client.register_product(
+            &product_id,
+            &String::from_str(&env, "Widget"),
+            &String::from_str(&env, "Factory"),
+            &owner,
+        );
+        client.add_authorized_actor(&product_id, &actor);
+
+        let alert = client.issue_recall_alert(
+            &product_id,
+            &actor,
+            &AlertSeverity::Critical,
+            &String::from_str(&env, "Urgent Recall"),
+            &String::from_str(&env, "Immediate action required"),
+            &String::from_str(&env, "banner,webhook"),
+        );
+        assert!(alert.active);
+        assert_eq!(alert.issuer, actor);
+    }
+
+    // ── Certificate & Revocation tests ───────────────────────────────────────
+
+    /// Cert: owner can issue a certificate
+    #[test]
+    fn test_issue_certificate_by_owner() {
+        let (env, contract_id, owner, product_id) = setup();
+        let client = SupplyLinkContractClient::new(&env, &contract_id);
+
+        let cert = client.issue_certificate(
+            &String::from_str(&env, "cert-001"),
+            &product_id,
+            &owner,
+            &String::from_str(&env, "ORGANIC"),
+            &String::from_str(&env, "{}"),
+        );
+
+        assert!(!cert.revoked);
+        assert_eq!(cert.cert_type, String::from_str(&env, "ORGANIC"));
+    }
+
+    /// Cert: is_certificate_valid returns true for a fresh certificate
+    #[test]
+    fn test_certificate_valid_after_issue() {
+        let (env, contract_id, owner, product_id) = setup();
+        let client = SupplyLinkContractClient::new(&env, &contract_id);
+        let cert_id = String::from_str(&env, "cert-valid-001");
+
+        client.issue_certificate(
+            &cert_id,
+            &product_id,
+            &owner,
+            &String::from_str(&env, "FAIR_TRADE"),
+            &String::from_str(&env, "{}"),
+        );
+
+        assert!(client.is_certificate_valid(&cert_id));
+    }
+
+    /// Cert: is_certificate_valid returns false for unknown cert
+    #[test]
+    fn test_certificate_valid_returns_false_for_unknown() {
+        let (env, contract_id, _owner, _product_id) = setup();
+        let client = SupplyLinkContractClient::new(&env, &contract_id);
+        assert!(!client.is_certificate_valid(&String::from_str(&env, "nonexistent")));
+    }
+
+    /// Cert: owner can revoke a certificate
+    #[test]
+    fn test_revoke_certificate_by_owner() {
+        let (env, contract_id, owner, product_id) = setup();
+        let client = SupplyLinkContractClient::new(&env, &contract_id);
+        let cert_id = String::from_str(&env, "cert-revoke-001");
+
+        client.issue_certificate(
+            &cert_id,
+            &product_id,
+            &owner,
+            &String::from_str(&env, "ISO9001"),
+            &String::from_str(&env, "{}"),
+        );
+
+        let record = client.revoke_certificate(
+            &cert_id,
+            &owner,
+            &String::from_str(&env, "Standards no longer met"),
+        );
+
+        assert_eq!(record.cert_id, cert_id);
+        assert!(!client.is_certificate_valid(&cert_id));
+    }
+
+    /// Cert: revoked certificate shows revoked=true in get_certificate
+    #[test]
+    fn test_get_certificate_shows_revoked_status() {
+        let (env, contract_id, owner, product_id) = setup();
+        let client = SupplyLinkContractClient::new(&env, &contract_id);
+        let cert_id = String::from_str(&env, "cert-status-001");
+
+        client.issue_certificate(
+            &cert_id,
+            &product_id,
+            &owner,
+            &String::from_str(&env, "ORGANIC"),
+            &String::from_str(&env, "{}"),
+        );
+        client.revoke_certificate(
+            &cert_id,
+            &owner,
+            &String::from_str(&env, "Audit failed"),
+        );
+
+        let cert = client.get_certificate(&cert_id);
+        assert!(cert.revoked);
+    }
+
+    /// Cert: get_revocation returns the revocation record
+    #[test]
+    fn test_get_revocation_returns_record() {
+        let (env, contract_id, owner, product_id) = setup();
+        let client = SupplyLinkContractClient::new(&env, &contract_id);
+        let cert_id = String::from_str(&env, "cert-rev-record-001");
+
+        client.issue_certificate(
+            &cert_id,
+            &product_id,
+            &owner,
+            &String::from_str(&env, "FAIR_TRADE"),
+            &String::from_str(&env, "{}"),
+        );
+        client.revoke_certificate(
+            &cert_id,
+            &owner,
+            &String::from_str(&env, "Supplier delisted"),
+        );
+
+        let record = client.get_revocation(&cert_id);
+        assert!(record.is_some());
+        let r = record.unwrap();
+        assert_eq!(r.cert_id, cert_id);
+        assert_eq!(r.reason, String::from_str(&env, "Supplier delisted"));
+    }
+
+    /// Cert: get_revocation returns None for non-revoked cert
+    #[test]
+    fn test_get_revocation_returns_none_for_valid_cert() {
+        let (env, contract_id, owner, product_id) = setup();
+        let client = SupplyLinkContractClient::new(&env, &contract_id);
+        let cert_id = String::from_str(&env, "cert-no-rev-001");
+
+        client.issue_certificate(
+            &cert_id,
+            &product_id,
+            &owner,
+            &String::from_str(&env, "ORGANIC"),
+            &String::from_str(&env, "{}"),
+        );
+
+        assert!(client.get_revocation(&cert_id).is_none());
+    }
+
+    /// Cert: get_product_certificates returns all certs for a product
+    #[test]
+    fn test_get_product_certificates_returns_all() {
+        let (env, contract_id, owner, product_id) = setup();
+        let client = SupplyLinkContractClient::new(&env, &contract_id);
+
+        client.issue_certificate(
+            &String::from_str(&env, "cert-a"),
+            &product_id,
+            &owner,
+            &String::from_str(&env, "ORGANIC"),
+            &String::from_str(&env, "{}"),
+        );
+        client.issue_certificate(
+            &String::from_str(&env, "cert-b"),
+            &product_id,
+            &owner,
+            &String::from_str(&env, "FAIR_TRADE"),
+            &String::from_str(&env, "{}"),
+        );
+
+        let certs = client.get_product_certificates(&product_id);
+        assert_eq!(certs.len(), 2);
+    }
+
+    /// Cert: duplicate cert_id panics
+    #[test]
+    #[should_panic(expected = "certificate ID already exists")]
+    fn test_duplicate_cert_id_panics() {
+        let (env, contract_id, owner, product_id) = setup();
+        let client = SupplyLinkContractClient::new(&env, &contract_id);
+        let cert_id = String::from_str(&env, "cert-dup");
+
+        client.issue_certificate(
+            &cert_id,
+            &product_id,
+            &owner,
+            &String::from_str(&env, "ORGANIC"),
+            &String::from_str(&env, "{}"),
+        );
+        // Second call with same cert_id must panic
+        client.issue_certificate(
+            &cert_id,
+            &product_id,
+            &owner,
+            &String::from_str(&env, "ORGANIC"),
+            &String::from_str(&env, "{}"),
+        );
+    }
+
+    /// Cert: revoking an already-revoked cert panics
+    #[test]
+    #[should_panic(expected = "certificate is already revoked")]
+    fn test_double_revoke_panics() {
+        let (env, contract_id, owner, product_id) = setup();
+        let client = SupplyLinkContractClient::new(&env, &contract_id);
+        let cert_id = String::from_str(&env, "cert-double-rev");
+
+        client.issue_certificate(
+            &cert_id,
+            &product_id,
+            &owner,
+            &String::from_str(&env, "ORGANIC"),
+            &String::from_str(&env, "{}"),
+        );
+        client.revoke_certificate(&cert_id, &owner, &String::from_str(&env, "First revocation"));
+        client.revoke_certificate(&cert_id, &owner, &String::from_str(&env, "Second revocation"));
     }
 }


### PR DESCRIPTION

closes #466 
closes #467 

## Summary

Implements two features for Supply-Link:

### a. Emergency Alert System
- **Smart contract**: New `RecallAlert` and `AlertSeverity` (Low/Medium/High/Critical) types with `issue_recall_alert`, `resolve_recall_alert`, `get_recall_alert`, and `get_recall_alert_history` methods. Only the product owner or authorized actors can issue alerts. Events emitted on issue and resolve.
- **`RecallAlertBanner`**: Severity-coded UI banner with `role=alert` and `aria-live=assertive`, expandable description, channel tags, and dismiss support.
- **`IssueRecallForm`**: Modal to issue alerts with severity selector, title, description, and multi-channel checkboxes (banner / email / webhook).
- **`AlertsPanel`**: Per-product panel for issuing, resolving, and viewing alert history.
- Banners injected into dashboard, product detail, and verify pages so critical alerts are always prominent.

### b. Certificate Revocation Registry
- **Smart contract**: New `Certificate` and `RevocationRecord` types with `issue_certificate`, `revoke_certificate`, `get_certificate`, `get_product_certificates`, `get_revocation`, and `is_certificate_valid` methods. Duplicate cert ID and double-revocation guards enforced on-chain.
- **`RevocationBadge`**: Compact inline badge (Valid / Revoked) and full detail block with reason, timestamp, and revoker address.
- **`CertificatesPanel`**: Lists all certs with status, inline revoke flow with reason input, and issue button.
- **`IssueCertificateForm`**: Modal for issuing certificates (type selector + JSON metadata).
- Certificates with revocation status shown on product detail and verify pages.

### Supporting changes
- Extended `lib/types/index.ts` with `AlertSeverity`, `RecallAlert`, `Certificate`, `RevocationRecord`
- Extended Zustand store with alert and certificate/revocation slices
- Extended contract client with all new methods
- Mock data seeded with a CRITICAL recall alert and revoked fair-trade certificate for `prod-001`
- Added `vitest.config.ts` and 38 unit tests across `alerts.test.ts` and `revocation.test.ts`

## Acceptance criteria
- [x] Critical product alerts are surfaced prominently on dashboard, product detail, and verify views
- [x] Alerts are configurable (severity, channels, description)
- [x] Revoked certificates are recorded on-chain with reason and timestamp
- [x] Revocation status is displayed accurately in all certificate views
- [x] Verification logic accounts for revoked credentials
- [x] Tests cover alert propagation and revocation handling
