### PR TITLE
feat: certification registry and event archival (#441, #442)

### DIFF
--- a/frontend/__tests__/certificationRegistry.test.ts
+++ b/frontend/__tests__/certificationRegistry.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect } from 'vitest';
+import {
+  filterActiveRecords,
+  filterRevokedRecords,
+  groupRecordsByCertType,
+} from '@/lib/services/certificationRegistry';
+import type { CertificationRegistryRecord } from '@/lib/types';
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function makeRecord(overrides: Partial<CertificationRegistryRecord> = {}): CertificationRegistryRecord {
+  return {
+    id: 'rec-001',
+    productId: 'prod-001',
+    issuerAddress: 'GISSUER1',
+    externalCertId: 'EXT-CERT-001',
+    certType: 'organic',
+    documentHash: 'a'.repeat(64),
+    issuedAt: 1_700_000_000_000,
+    revoked: false,
+    revokedAt: 0,
+    ...overrides,
+  };
+}
+
+// ── filterActiveRecords ───────────────────────────────────────────────────────
+
+describe('filterActiveRecords', () => {
+  it('returns only non-revoked records', () => {
+    const records = [
+      makeRecord({ id: 'r1' }),
+      makeRecord({ id: 'r2', revoked: true, revokedAt: Date.now() }),
+      makeRecord({ id: 'r3' }),
+    ];
+    const active = filterActiveRecords(records);
+    expect(active).toHaveLength(2);
+    expect(active.every((r) => !r.revoked)).toBe(true);
+  });
+
+  it('returns empty array when all are revoked', () => {
+    const records = [
+      makeRecord({ revoked: true }),
+      makeRecord({ id: 'r2', revoked: true }),
+    ];
+    expect(filterActiveRecords(records)).toHaveLength(0);
+  });
+
+  it('returns all records when none are revoked', () => {
+    const records = [makeRecord(), makeRecord({ id: 'r2' })];
+    expect(filterActiveRecords(records)).toHaveLength(2);
+  });
+});
+
+// ── filterRevokedRecords ──────────────────────────────────────────────────────
+
+describe('filterRevokedRecords', () => {
+  it('returns only revoked records', () => {
+    const records = [
+      makeRecord({ id: 'r1' }),
+      makeRecord({ id: 'r2', revoked: true }),
+    ];
+    const revoked = filterRevokedRecords(records);
+    expect(revoked).toHaveLength(1);
+    expect(revoked[0].id).toBe('r2');
+  });
+
+  it('returns empty array when none are revoked', () => {
+    expect(filterRevokedRecords([makeRecord()])).toHaveLength(0);
+  });
+});
+
+// ── groupRecordsByCertType ────────────────────────────────────────────────────
+
+describe('groupRecordsByCertType', () => {
+  it('groups records by cert type', () => {
+    const records = [
+      makeRecord({ id: 'r1', certType: 'organic' }),
+      makeRecord({ id: 'r2', certType: 'organic' }),
+      makeRecord({ id: 'r3', certType: 'fair_trade' }),
+      makeRecord({ id: 'r4', certType: 'iso_9001' }),
+    ];
+    const groups = groupRecordsByCertType(records);
+    expect(groups['organic']).toHaveLength(2);
+    expect(groups['fair_trade']).toHaveLength(1);
+    expect(groups['iso_9001']).toHaveLength(1);
+  });
+
+  it('returns empty object for empty input', () => {
+    expect(groupRecordsByCertType([])).toEqual({});
+  });
+
+  it('handles single record', () => {
+    const groups = groupRecordsByCertType([makeRecord({ certType: 'halal' })]);
+    expect(groups['halal']).toHaveLength(1);
+  });
+});
+
+// ── Integrity: revoked records preserve original data ─────────────────────────
+
+describe('revoked record integrity', () => {
+  it('revoked record retains all original fields', () => {
+    const original = makeRecord({
+      id: 'integrity-test',
+      externalCertId: 'EXT-ORIGINAL',
+      documentHash: 'b'.repeat(64),
+    });
+    const revoked: CertificationRegistryRecord = {
+      ...original,
+      revoked: true,
+      revokedAt: Date.now(),
+    };
+
+    // All original fields preserved
+    expect(revoked.id).toBe(original.id);
+    expect(revoked.externalCertId).toBe(original.externalCertId);
+    expect(revoked.documentHash).toBe(original.documentHash);
+    expect(revoked.issuerAddress).toBe(original.issuerAddress);
+    expect(revoked.issuedAt).toBe(original.issuedAt);
+    // Revocation fields set
+    expect(revoked.revoked).toBe(true);
+    expect(revoked.revokedAt).toBeGreaterThan(0);
+  });
+});

--- a/frontend/__tests__/eventArchival.test.ts
+++ b/frontend/__tests__/eventArchival.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect } from 'vitest';
+import {
+  filterActiveEvents,
+  groupArchivedByType,
+  formatArchivalReason,
+} from '@/lib/services/eventArchival';
+import type { TrackingEvent, ArchivedEvent } from '@/lib/types';
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function makeEvent(overrides: Partial<TrackingEvent> = {}): TrackingEvent {
+  return {
+    productId: 'prod-001',
+    location: 'Warehouse A',
+    actor: 'GACTOR1',
+    timestamp: 1_700_000_000_000,
+    eventType: 'HARVEST',
+    metadata: '{}',
+    stableId: 'stable-abc',
+    ...overrides,
+  };
+}
+
+function makeArchived(event: TrackingEvent, reason = 'retention'): ArchivedEvent {
+  return {
+    event,
+    archivedBy: 'GOWNER1',
+    archivedAt: Date.now(),
+    reason,
+  };
+}
+
+// ── filterActiveEvents ────────────────────────────────────────────────────────
+
+describe('filterActiveEvents', () => {
+  it('returns all events when none are archived', () => {
+    const events = [makeEvent(), makeEvent({ stableId: 'stable-2', eventType: 'SHIPPING' })];
+    expect(filterActiveEvents(events)).toHaveLength(2);
+  });
+
+  it('excludes events flagged as archived', () => {
+    const events = [
+      makeEvent({ stableId: 'active-1' }),
+      makeEvent({ stableId: 'archived-1', archived: true }),
+      makeEvent({ stableId: 'active-2', eventType: 'RETAIL' }),
+    ];
+    const result = filterActiveEvents(events);
+    expect(result).toHaveLength(2);
+    expect(result.every((e) => !e.archived)).toBe(true);
+  });
+
+  it('returns empty array when all events are archived', () => {
+    const events = [
+      makeEvent({ archived: true }),
+      makeEvent({ archived: true, stableId: 'stable-2' }),
+    ];
+    expect(filterActiveEvents(events)).toHaveLength(0);
+  });
+
+  it('returns empty array for empty input', () => {
+    expect(filterActiveEvents([])).toHaveLength(0);
+  });
+});
+
+// ── groupArchivedByType ───────────────────────────────────────────────────────
+
+describe('groupArchivedByType', () => {
+  it('groups archived events by event type', () => {
+    const archived = [
+      makeArchived(makeEvent({ eventType: 'HARVEST', stableId: 's1' })),
+      makeArchived(makeEvent({ eventType: 'HARVEST', stableId: 's2' })),
+      makeArchived(makeEvent({ eventType: 'SHIPPING', stableId: 's3' })),
+    ];
+    const groups = groupArchivedByType(archived);
+    expect(groups['HARVEST']).toHaveLength(2);
+    expect(groups['SHIPPING']).toHaveLength(1);
+    expect(groups['RETAIL']).toBeUndefined();
+  });
+
+  it('returns empty object for empty input', () => {
+    expect(groupArchivedByType([])).toEqual({});
+  });
+});
+
+// ── formatArchivalReason ──────────────────────────────────────────────────────
+
+describe('formatArchivalReason', () => {
+  it('returns the reason unchanged when within max length', () => {
+    expect(formatArchivalReason('annual retention policy')).toBe('annual retention policy');
+  });
+
+  it('truncates long reasons with ellipsis', () => {
+    const long = 'a'.repeat(100);
+    const result = formatArchivalReason(long, 80);
+    expect(result.endsWith('…')).toBe(true);
+    expect(result.length).toBe(81); // 80 chars + ellipsis
+  });
+
+  it('returns fallback for empty reason', () => {
+    expect(formatArchivalReason('')).toBe('No reason provided');
+  });
+
+  it('respects custom maxLen', () => {
+    const result = formatArchivalReason('hello world', 5);
+    expect(result).toBe('hello…');
+  });
+});

--- a/frontend/app/api/v1/certification-registry/issuers/[address]/route.ts
+++ b/frontend/app/api/v1/certification-registry/issuers/[address]/route.ts
@@ -1,0 +1,71 @@
+/**
+ * GET    /api/v1/certification-registry/issuers/[address]  — Get issuer by address
+ * DELETE /api/v1/certification-registry/issuers/[address]  — Deactivate issuer
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { withCors, handleOptions } from '@/lib/api/cors';
+import { apiError, withCorrelationId, ErrorCode } from '@/lib/api/errors';
+import { applyRateLimit, RATE_LIMIT_PRESETS } from '@/lib/api/rateLimit';
+import { authenticateApiRequest } from '@/lib/api/auth';
+import { recordRequest } from '@/lib/api/metrics';
+import { kvStore } from '@/lib/kv';
+import type { CertificationIssuer } from '@/lib/types';
+
+export const runtime = 'nodejs';
+
+const TTL = 10 * 365 * 24 * 60 * 60;
+
+function issuerKey(address: string): string {
+  return `cert-registry:issuer:${address}`;
+}
+
+export function OPTIONS(request: NextRequest) {
+  return handleOptions(request);
+}
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: { address: string } },
+): Promise<NextResponse> {
+  const start = Date.now();
+
+  const limited = applyRateLimit(request, 'GET /api/v1/certification-registry/issuers/[address]', RATE_LIMIT_PRESETS.default);
+  if (limited) { recordRequest('GET /api/v1/certification-registry/issuers/[address]', 429, Date.now() - start); return limited; }
+
+  const auth = await authenticateApiRequest(request, 'partner');
+  if (auth.error) { recordRequest('GET /api/v1/certification-registry/issuers/[address]', 429, Date.now() - start); return auth.error; }
+
+  const raw = await kvStore.get(issuerKey(params.address));
+  if (!raw) {
+    return withCors(request, apiError(request, 404, ErrorCode.NOT_FOUND, 'Issuer not found'));
+  }
+
+  recordRequest('GET /api/v1/certification-registry/issuers/[address]', 200, Date.now() - start);
+  return withCors(request, withCorrelationId(request, NextResponse.json(JSON.parse(raw), { status: 200 })));
+}
+
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: { address: string } },
+): Promise<NextResponse> {
+  const start = Date.now();
+
+  const limited = applyRateLimit(request, 'DELETE /api/v1/certification-registry/issuers/[address]', RATE_LIMIT_PRESETS.default);
+  if (limited) { recordRequest('DELETE /api/v1/certification-registry/issuers/[address]', 429, Date.now() - start); return limited; }
+
+  const auth = await authenticateApiRequest(request, 'partner');
+  if (auth.error) { recordRequest('DELETE /api/v1/certification-registry/issuers/[address]', 401, Date.now() - start); return auth.error; }
+
+  const raw = await kvStore.get(issuerKey(params.address));
+  if (!raw) {
+    return withCors(request, apiError(request, 404, ErrorCode.NOT_FOUND, 'Issuer not found'));
+  }
+
+  const issuer = JSON.parse(raw) as CertificationIssuer;
+  issuer.active = false;
+  await kvStore.set(issuerKey(params.address), JSON.stringify(issuer), TTL);
+
+  recordRequest('DELETE /api/v1/certification-registry/issuers/[address]', 200, Date.now() - start);
+  return withCors(request, withCorrelationId(request, NextResponse.json(true, { status: 200 })));
+}

--- a/frontend/app/api/v1/certification-registry/issuers/route.ts
+++ b/frontend/app/api/v1/certification-registry/issuers/route.ts
@@ -1,0 +1,113 @@
+/**
+ * POST /api/v1/certification-registry/issuers  — Register a certification issuer
+ * GET  /api/v1/certification-registry/issuers  — List all registered issuers
+ *
+ * Authentication: x-api-key (partner or internal)
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { withCors, handleOptions } from '@/lib/api/cors';
+import { apiError, withCorrelationId, ErrorCode } from '@/lib/api/errors';
+import { applyRateLimit, RATE_LIMIT_PRESETS } from '@/lib/api/rateLimit';
+import { authenticateApiRequest } from '@/lib/api/auth';
+import { recordRequest } from '@/lib/api/metrics';
+import { kvStore } from '@/lib/kv';
+import type { CertificationIssuer } from '@/lib/types';
+
+export const runtime = 'nodejs';
+
+const TTL = 10 * 365 * 24 * 60 * 60;
+
+function issuerKey(address: string): string {
+  return `cert-registry:issuer:${address}`;
+}
+
+const ISSUERS_INDEX_KEY = 'cert-registry:issuers:index';
+
+async function getIssuerIndex(): Promise<string[]> {
+  const raw = await kvStore.get(ISSUERS_INDEX_KEY);
+  return raw ? (JSON.parse(raw) as string[]) : [];
+}
+
+const registerSchema = z.object({
+  issuerAddress: z.string().trim().min(1).max(256),
+  name: z.string().trim().min(1).max(256),
+  certTypes: z.array(z.string().trim().min(1).max(64)).min(1).max(50),
+});
+
+export function OPTIONS(request: NextRequest) {
+  return handleOptions(request);
+}
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  const start = Date.now();
+
+  const limited = applyRateLimit(request, 'POST /api/v1/certification-registry/issuers', RATE_LIMIT_PRESETS.default);
+  if (limited) { recordRequest('POST /api/v1/certification-registry/issuers', 429, Date.now() - start); return limited; }
+
+  const auth = await authenticateApiRequest(request, 'partner');
+  if (auth.error) { recordRequest('POST /api/v1/certification-registry/issuers', 401, Date.now() - start); return auth.error; }
+
+  let payload: unknown;
+  try { payload = await request.json(); } catch {
+    return withCors(request, apiError(request, 400, ErrorCode.INVALID_JSON, 'Invalid JSON body'));
+  }
+
+  const parsed = registerSchema.safeParse(payload);
+  if (!parsed.success) {
+    return withCors(request, apiError(request, 400, ErrorCode.VALIDATION_ERROR, parsed.error.issues[0]?.message ?? 'Validation error'));
+  }
+
+  const { issuerAddress, name, certTypes } = parsed.data;
+
+  // Check for duplicate active registration
+  const existing = await kvStore.get(issuerKey(issuerAddress));
+  if (existing) {
+    const iss = JSON.parse(existing) as CertificationIssuer;
+    if (iss.active) {
+      return withCors(request, apiError(request, 409, ErrorCode.CONFLICT, 'Issuer already registered'));
+    }
+  }
+
+  const issuer: CertificationIssuer = {
+    issuerAddress,
+    name,
+    certTypes,
+    registeredAt: Date.now(),
+    active: true,
+  };
+
+  await kvStore.set(issuerKey(issuerAddress), JSON.stringify(issuer), TTL);
+
+  // Update index
+  const index = await getIssuerIndex();
+  if (!index.includes(issuerAddress)) {
+    index.push(issuerAddress);
+    await kvStore.set(ISSUERS_INDEX_KEY, JSON.stringify(index), TTL);
+  }
+
+  recordRequest('POST /api/v1/certification-registry/issuers', 201, Date.now() - start);
+  return withCors(request, withCorrelationId(request, NextResponse.json(issuer, { status: 201 })));
+}
+
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  const start = Date.now();
+
+  const limited = applyRateLimit(request, 'GET /api/v1/certification-registry/issuers', RATE_LIMIT_PRESETS.default);
+  if (limited) { recordRequest('GET /api/v1/certification-registry/issuers', 429, Date.now() - start); return limited; }
+
+  const auth = await authenticateApiRequest(request, 'partner');
+  if (auth.error) { recordRequest('GET /api/v1/certification-registry/issuers', 401, Date.now() - start); return auth.error; }
+
+  const index = await getIssuerIndex();
+  const issuers: CertificationIssuer[] = [];
+
+  for (const addr of index) {
+    const raw = await kvStore.get(issuerKey(addr));
+    if (raw) issuers.push(JSON.parse(raw) as CertificationIssuer);
+  }
+
+  recordRequest('GET /api/v1/certification-registry/issuers', 200, Date.now() - start);
+  return withCors(request, withCorrelationId(request, NextResponse.json(issuers, { status: 200 })));
+}

--- a/frontend/app/api/v1/certification-registry/records/[recordId]/route.ts
+++ b/frontend/app/api/v1/certification-registry/records/[recordId]/route.ts
@@ -1,0 +1,74 @@
+/**
+ * DELETE /api/v1/certification-registry/records/[recordId]  — Revoke a registry record
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { withCors, handleOptions } from '@/lib/api/cors';
+import { apiError, withCorrelationId, ErrorCode } from '@/lib/api/errors';
+import { applyRateLimit, RATE_LIMIT_PRESETS } from '@/lib/api/rateLimit';
+import { authenticateApiRequest } from '@/lib/api/auth';
+import { recordRequest } from '@/lib/api/metrics';
+import { kvStore } from '@/lib/kv';
+import type { CertificationRegistryRecord } from '@/lib/types';
+
+export const runtime = 'nodejs';
+
+const TTL = 10 * 365 * 24 * 60 * 60;
+
+function recordsKey(productId: string): string {
+  return `cert-registry:records:${productId}`;
+}
+
+const revokeSchema = z.object({
+  productId: z.string().trim().min(1).max(128),
+  issuerAddress: z.string().trim().min(1).max(256),
+});
+
+export function OPTIONS(request: NextRequest) {
+  return handleOptions(request);
+}
+
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: { recordId: string } },
+): Promise<NextResponse> {
+  const start = Date.now();
+
+  const limited = applyRateLimit(request, 'DELETE /api/v1/certification-registry/records/[recordId]', RATE_LIMIT_PRESETS.default);
+  if (limited) { recordRequest('DELETE /api/v1/certification-registry/records/[recordId]', 429, Date.now() - start); return limited; }
+
+  const auth = await authenticateApiRequest(request, 'partner');
+  if (auth.error) { recordRequest('DELETE /api/v1/certification-registry/records/[recordId]', 401, Date.now() - start); return auth.error; }
+
+  let payload: unknown;
+  try { payload = await request.json(); } catch {
+    return withCors(request, apiError(request, 400, ErrorCode.INVALID_JSON, 'Invalid JSON body'));
+  }
+
+  const parsed = revokeSchema.safeParse(payload);
+  if (!parsed.success) {
+    return withCors(request, apiError(request, 400, ErrorCode.VALIDATION_ERROR, parsed.error.issues[0]?.message ?? 'Validation error'));
+  }
+
+  const { productId, issuerAddress } = parsed.data;
+  const recordId = params.recordId;
+
+  const raw = await kvStore.get(recordsKey(productId));
+  const records: CertificationRegistryRecord[] = raw ? (JSON.parse(raw) as CertificationRegistryRecord[]) : [];
+
+  const idx = records.findIndex((r) => r.id === recordId);
+  if (idx === -1) {
+    return withCors(request, apiError(request, 404, ErrorCode.NOT_FOUND, `Record '${recordId}' not found`));
+  }
+
+  if (records[idx].issuerAddress !== issuerAddress) {
+    return withCors(request, apiError(request, 403, ErrorCode.FORBIDDEN, 'Only the issuer can revoke this record'));
+  }
+
+  records[idx] = { ...records[idx], revoked: true, revokedAt: Date.now() };
+  await kvStore.set(recordsKey(productId), JSON.stringify(records), TTL);
+
+  recordRequest('DELETE /api/v1/certification-registry/records/[recordId]', 200, Date.now() - start);
+  return withCors(request, withCorrelationId(request, NextResponse.json(true, { status: 200 })));
+}

--- a/frontend/app/api/v1/certification-registry/records/[recordId]/verify/route.ts
+++ b/frontend/app/api/v1/certification-registry/records/[recordId]/verify/route.ts
@@ -1,0 +1,71 @@
+/**
+ * GET /api/v1/certification-registry/records/[recordId]/verify
+ *   — Verify a certification registry record
+ *
+ * Query params: productId (required)
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { withCors, handleOptions } from '@/lib/api/cors';
+import { apiError, withCorrelationId, ErrorCode } from '@/lib/api/errors';
+import { applyRateLimit, RATE_LIMIT_PRESETS } from '@/lib/api/rateLimit';
+import { authenticateApiRequest } from '@/lib/api/auth';
+import { recordRequest } from '@/lib/api/metrics';
+import { kvStore } from '@/lib/kv';
+import type { CertificationIssuer, CertificationRegistryRecord, CertificationVerificationResult } from '@/lib/types';
+
+export const runtime = 'nodejs';
+
+function recordsKey(productId: string): string {
+  return `cert-registry:records:${productId}`;
+}
+
+function issuerKey(address: string): string {
+  return `cert-registry:issuer:${address}`;
+}
+
+export function OPTIONS(request: NextRequest) {
+  return handleOptions(request);
+}
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: { recordId: string } },
+): Promise<NextResponse> {
+  const start = Date.now();
+
+  const limited = applyRateLimit(request, 'GET /api/v1/certification-registry/records/[recordId]/verify', RATE_LIMIT_PRESETS.default);
+  if (limited) { recordRequest('GET /api/v1/certification-registry/records/[recordId]/verify', 429, Date.now() - start); return limited; }
+
+  const auth = await authenticateApiRequest(request, 'partner');
+  if (auth.error) { recordRequest('GET /api/v1/certification-registry/records/[recordId]/verify', 401, Date.now() - start); return auth.error; }
+
+  const productId = request.nextUrl.searchParams.get('productId');
+  if (!productId) {
+    return withCors(request, apiError(request, 400, ErrorCode.MISSING_FIELDS, 'productId is required'));
+  }
+
+  const raw = await kvStore.get(recordsKey(productId));
+  const records: CertificationRegistryRecord[] = raw ? (JSON.parse(raw) as CertificationRegistryRecord[]) : [];
+
+  const record = records.find((r) => r.id === params.recordId);
+  if (!record) {
+    return withCors(request, apiError(request, 404, ErrorCode.NOT_FOUND, `Record '${params.recordId}' not found`));
+  }
+
+  // Fetch issuer for enriched response
+  let issuer: CertificationIssuer | undefined;
+  const issuerRaw = await kvStore.get(issuerKey(record.issuerAddress));
+  if (issuerRaw) {
+    issuer = JSON.parse(issuerRaw) as CertificationIssuer;
+  }
+
+  const result: CertificationVerificationResult = {
+    valid: !record.revoked,
+    record,
+    issuer,
+  };
+
+  recordRequest('GET /api/v1/certification-registry/records/[recordId]/verify', 200, Date.now() - start);
+  return withCors(request, withCorrelationId(request, NextResponse.json(result, { status: 200 })));
+}

--- a/frontend/app/api/v1/certification-registry/records/route.ts
+++ b/frontend/app/api/v1/certification-registry/records/route.ts
@@ -1,0 +1,123 @@
+/**
+ * POST /api/v1/certification-registry/records  — Issue a registry record
+ * GET  /api/v1/certification-registry/records  — List records for a product
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { withCors, handleOptions } from '@/lib/api/cors';
+import { apiError, withCorrelationId, ErrorCode } from '@/lib/api/errors';
+import { applyRateLimit, RATE_LIMIT_PRESETS } from '@/lib/api/rateLimit';
+import { authenticateApiRequest } from '@/lib/api/auth';
+import { recordRequest } from '@/lib/api/metrics';
+import { kvStore } from '@/lib/kv';
+import type { CertificationIssuer, CertificationRegistryRecord } from '@/lib/types';
+
+export const runtime = 'nodejs';
+
+const TTL = 10 * 365 * 24 * 60 * 60;
+
+function recordsKey(productId: string): string {
+  return `cert-registry:records:${productId}`;
+}
+
+function issuerKey(address: string): string {
+  return `cert-registry:issuer:${address}`;
+}
+
+async function getRecords(productId: string): Promise<CertificationRegistryRecord[]> {
+  const raw = await kvStore.get(recordsKey(productId));
+  return raw ? (JSON.parse(raw) as CertificationRegistryRecord[]) : [];
+}
+
+const issueSchema = z.object({
+  productId: z.string().trim().min(1).max(128),
+  issuerAddress: z.string().trim().min(1).max(256),
+  recordId: z.string().trim().min(1).max(128),
+  externalCertId: z.string().trim().min(1).max(256),
+  certType: z.string().trim().min(1).max(64),
+  documentHash: z.string().trim().min(1).max(128),
+});
+
+export function OPTIONS(request: NextRequest) {
+  return handleOptions(request);
+}
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  const start = Date.now();
+
+  const limited = applyRateLimit(request, 'POST /api/v1/certification-registry/records', RATE_LIMIT_PRESETS.default);
+  if (limited) { recordRequest('POST /api/v1/certification-registry/records', 429, Date.now() - start); return limited; }
+
+  const auth = await authenticateApiRequest(request, 'partner');
+  if (auth.error) { recordRequest('POST /api/v1/certification-registry/records', 401, Date.now() - start); return auth.error; }
+
+  let payload: unknown;
+  try { payload = await request.json(); } catch {
+    return withCors(request, apiError(request, 400, ErrorCode.INVALID_JSON, 'Invalid JSON body'));
+  }
+
+  const parsed = issueSchema.safeParse(payload);
+  if (!parsed.success) {
+    return withCors(request, apiError(request, 400, ErrorCode.VALIDATION_ERROR, parsed.error.issues[0]?.message ?? 'Validation error'));
+  }
+
+  const { productId, issuerAddress, recordId, externalCertId, certType, documentHash } = parsed.data;
+
+  // Validate issuer exists and is active
+  const issuerRaw = await kvStore.get(issuerKey(issuerAddress));
+  if (!issuerRaw) {
+    return withCors(request, apiError(request, 404, ErrorCode.NOT_FOUND, 'Issuer not registered'));
+  }
+  const issuer = JSON.parse(issuerRaw) as CertificationIssuer;
+  if (!issuer.active) {
+    return withCors(request, apiError(request, 400, ErrorCode.VALIDATION_ERROR, 'Issuer is not active'));
+  }
+  if (!issuer.certTypes.includes(certType)) {
+    return withCors(request, apiError(request, 400, ErrorCode.VALIDATION_ERROR, `cert_type '${certType}' not supported by issuer`));
+  }
+
+  // Check for duplicate record ID
+  const existing = await getRecords(productId);
+  if (existing.some((r) => r.id === recordId)) {
+    return withCors(request, apiError(request, 409, ErrorCode.CONFLICT, `Record with id '${recordId}' already exists`));
+  }
+
+  const record: CertificationRegistryRecord = {
+    id: recordId,
+    productId,
+    issuerAddress,
+    externalCertId,
+    certType,
+    documentHash,
+    issuedAt: Date.now(),
+    revoked: false,
+    revokedAt: 0,
+  };
+
+  existing.push(record);
+  await kvStore.set(recordsKey(productId), JSON.stringify(existing), TTL);
+
+  recordRequest('POST /api/v1/certification-registry/records', 201, Date.now() - start);
+  return withCors(request, withCorrelationId(request, NextResponse.json(record, { status: 201 })));
+}
+
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  const start = Date.now();
+
+  const limited = applyRateLimit(request, 'GET /api/v1/certification-registry/records', RATE_LIMIT_PRESETS.default);
+  if (limited) { recordRequest('GET /api/v1/certification-registry/records', 429, Date.now() - start); return limited; }
+
+  const auth = await authenticateApiRequest(request, 'partner');
+  if (auth.error) { recordRequest('GET /api/v1/certification-registry/records', 401, Date.now() - start); return auth.error; }
+
+  const productId = request.nextUrl.searchParams.get('productId');
+  if (!productId) {
+    return withCors(request, apiError(request, 400, ErrorCode.MISSING_FIELDS, 'productId is required'));
+  }
+
+  const records = await getRecords(productId);
+
+  recordRequest('GET /api/v1/certification-registry/records', 200, Date.now() - start);
+  return withCors(request, withCorrelationId(request, NextResponse.json(records, { status: 200 })));
+}

--- a/frontend/app/api/v1/events/archive/route.ts
+++ b/frontend/app/api/v1/events/archive/route.ts
@@ -1,0 +1,168 @@
+/**
+ * POST /api/v1/events/archive  — Archive a tracking event by stable_id
+ * GET  /api/v1/events/archive  — List archived events for a product
+ *
+ * Authentication: x-api-key (partner or internal)
+ * Rate limiting: default preset
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { withCors, handleOptions } from '@/lib/api/cors';
+import { apiError, withCorrelationId, ErrorCode } from '@/lib/api/errors';
+import { applyRateLimit, RATE_LIMIT_PRESETS } from '@/lib/api/rateLimit';
+import { authenticateApiRequest } from '@/lib/api/auth';
+import { recordRequest } from '@/lib/api/metrics';
+import { kvStore } from '@/lib/kv';
+import type { ArchivedEvent, TrackingEvent } from '@/lib/types';
+
+export const runtime = 'nodejs';
+
+// ── KV helpers ────────────────────────────────────────────────────────────────
+
+const ARCHIVE_TTL = 10 * 365 * 24 * 60 * 60; // 10 years
+
+function archiveListKey(productId: string): string {
+  return `archive:events:${productId}`;
+}
+
+async function getArchivedEvents(productId: string): Promise<ArchivedEvent[]> {
+  const raw = await kvStore.get(archiveListKey(productId));
+  if (!raw) return [];
+  try {
+    return JSON.parse(raw) as ArchivedEvent[];
+  } catch {
+    return [];
+  }
+}
+
+async function saveArchivedEvents(productId: string, events: ArchivedEvent[]): Promise<void> {
+  await kvStore.set(archiveListKey(productId), JSON.stringify(events), ARCHIVE_TTL);
+}
+
+// ── Validation ────────────────────────────────────────────────────────────────
+
+const archiveSchema = z.object({
+  productId: z.string().trim().min(1).max(128),
+  stableId: z.string().trim().min(1).max(128),
+  reason: z.string().trim().max(512).default(''),
+});
+
+// ── Handlers ──────────────────────────────────────────────────────────────────
+
+export function OPTIONS(request: NextRequest) {
+  return handleOptions(request);
+}
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  const start = Date.now();
+
+  const limited = applyRateLimit(request, 'POST /api/v1/events/archive', RATE_LIMIT_PRESETS.default);
+  if (limited) {
+    recordRequest('POST /api/v1/events/archive', 429, Date.now() - start);
+    return limited;
+  }
+
+  const auth = await authenticateApiRequest(request, 'partner');
+  if (auth.error) {
+    recordRequest('POST /api/v1/events/archive', 401, Date.now() - start);
+    return auth.error;
+  }
+
+  let payload: unknown;
+  try {
+    payload = await request.json();
+  } catch {
+    recordRequest('POST /api/v1/events/archive', 400, Date.now() - start);
+    return withCors(request, apiError(request, 400, ErrorCode.INVALID_JSON, 'Invalid JSON body'));
+  }
+
+  const parsed = archiveSchema.safeParse(payload);
+  if (!parsed.success) {
+    recordRequest('POST /api/v1/events/archive', 400, Date.now() - start);
+    return withCors(
+      request,
+      apiError(request, 400, ErrorCode.VALIDATION_ERROR, parsed.error.issues[0]?.message ?? 'Validation error'),
+    );
+  }
+
+  const { productId, stableId, reason } = parsed.data;
+
+  // Retrieve active events from KV (mock layer — in production this calls the contract)
+  const activeKey = `events:active:${productId}`;
+  const activeRaw = await kvStore.get(activeKey);
+  const activeEvents: TrackingEvent[] = activeRaw ? (JSON.parse(activeRaw) as TrackingEvent[]) : [];
+
+  const targetIndex = activeEvents.findIndex((e) => e.stableId === stableId);
+  if (targetIndex === -1) {
+    recordRequest('POST /api/v1/events/archive', 404, Date.now() - start);
+    return withCors(
+      request,
+      apiError(request, 404, ErrorCode.NOT_FOUND, `Event with stableId '${stableId}' not found in active list`),
+    );
+  }
+
+  const [targetEvent] = activeEvents.splice(targetIndex, 1);
+
+  // Persist updated active list
+  await kvStore.set(activeKey, JSON.stringify(activeEvents), ARCHIVE_TTL);
+
+  // Build archived record
+  const archived: ArchivedEvent = {
+    event: { ...targetEvent, archived: true },
+    archivedBy: auth.apiKey ?? 'system',
+    archivedAt: Date.now(),
+    reason,
+  };
+
+  // Append to archive list
+  const existing = await getArchivedEvents(productId);
+  existing.push(archived);
+  await saveArchivedEvents(productId, existing);
+
+  recordRequest('POST /api/v1/events/archive', 201, Date.now() - start);
+  return withCors(
+    request,
+    withCorrelationId(request, NextResponse.json(archived, { status: 201 })),
+  );
+}
+
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  const start = Date.now();
+
+  const limited = applyRateLimit(request, 'GET /api/v1/events/archive', RATE_LIMIT_PRESETS.default);
+  if (limited) {
+    recordRequest('GET /api/v1/events/archive', 429, Date.now() - start);
+    return limited;
+  }
+
+  const auth = await authenticateApiRequest(request, 'partner');
+  if (auth.error) {
+    recordRequest('GET /api/v1/events/archive', 401, Date.now() - start);
+    return auth.error;
+  }
+
+  const productId = request.nextUrl.searchParams.get('productId');
+  if (!productId) {
+    recordRequest('GET /api/v1/events/archive', 400, Date.now() - start);
+    return withCors(
+      request,
+      apiError(request, 400, ErrorCode.MISSING_FIELDS, 'productId is required'),
+    );
+  }
+
+  const offset = parseInt(request.nextUrl.searchParams.get('offset') ?? '0', 10);
+  const limit = parseInt(request.nextUrl.searchParams.get('limit') ?? '0', 10);
+
+  const all = await getArchivedEvents(productId);
+  const items = limit > 0 ? all.slice(offset, offset + limit) : all.slice(offset);
+
+  recordRequest('GET /api/v1/events/archive', 200, Date.now() - start);
+  return withCors(
+    request,
+    withCorrelationId(
+      request,
+      NextResponse.json({ items, total: all.length, offset, limit }, { status: 200 }),
+    ),
+  );
+}

--- a/frontend/components/certifications/CertificationRegistryPanel.tsx
+++ b/frontend/components/certifications/CertificationRegistryPanel.tsx
@@ -1,0 +1,288 @@
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+import {
+  ShieldCheck,
+  ShieldX,
+  ExternalLink,
+  RefreshCw,
+  AlertCircle,
+  CheckCircle2,
+  XCircle,
+  ChevronDown,
+  ChevronUp,
+} from 'lucide-react';
+import type { CertificationRegistryRecord, CertificationIssuer, CertificationVerificationResult } from '@/lib/types';
+import {
+  listRegistryRecords,
+  verifyCertificationRecord,
+  filterActiveRecords,
+  filterRevokedRecords,
+} from '@/lib/services/certificationRegistry';
+import { getCertificationLabel } from '@/lib/certifications';
+
+// ── Record card ───────────────────────────────────────────────────────────────
+
+interface RegistryRecordCardProps {
+  record: CertificationRegistryRecord;
+  locale?: string;
+  onVerify?: (recordId: string) => void;
+  verificationResult?: CertificationVerificationResult;
+  verifying?: boolean;
+}
+
+function RegistryRecordCard({
+  record,
+  locale,
+  onVerify,
+  verificationResult,
+  verifying,
+}: RegistryRecordCardProps) {
+  const [expanded, setExpanded] = useState(false);
+  const dateFmt = new Intl.DateTimeFormat(locale, { dateStyle: 'medium' });
+
+  const isRevoked = record.revoked;
+
+  return (
+    <div
+      className={`rounded-lg border p-4 transition-colors ${
+        isRevoked
+          ? 'border-[var(--card-border)] opacity-60 bg-[var(--muted-bg)]'
+          : 'border-[var(--card-border)] bg-[var(--card)]'
+      }`}
+    >
+      <div className="flex items-start justify-between gap-3">
+        <div className="flex items-start gap-3 min-w-0">
+          {isRevoked ? (
+            <ShieldX size={16} className="shrink-0 mt-0.5 text-red-500" />
+          ) : (
+            <ShieldCheck size={16} className="shrink-0 mt-0.5 text-green-600 dark:text-green-400" />
+          )}
+          <div className="min-w-0">
+            <p className="text-sm font-semibold text-[var(--foreground)] truncate">
+              {getCertificationLabel(record.certType)}
+            </p>
+            <p className="text-xs text-[var(--muted)] mt-0.5">
+              External ID:{' '}
+              <span className="font-mono">{record.externalCertId}</span>
+            </p>
+            <p className="text-xs text-[var(--muted)]">
+              Issued: {dateFmt.format(new Date(record.issuedAt))}
+              {isRevoked && record.revokedAt > 0 && (
+                <> · Revoked: {dateFmt.format(new Date(record.revokedAt))}</>
+              )}
+            </p>
+          </div>
+        </div>
+
+        <div className="flex items-center gap-2 shrink-0">
+          {isRevoked && (
+            <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-red-100 text-red-600 border border-red-300 dark:bg-red-900/20 dark:text-red-400 dark:border-red-800">
+              <ShieldX size={10} />
+              Revoked
+            </span>
+          )}
+
+          {!isRevoked && onVerify && (
+            <button
+              type="button"
+              onClick={() => onVerify(record.id)}
+              disabled={verifying}
+              className="text-xs px-2 py-1 rounded border border-[var(--card-border)] text-[var(--muted)] hover:text-[var(--foreground)] hover:border-[var(--foreground)] transition-colors disabled:opacity-40"
+            >
+              {verifying ? 'Verifying…' : 'Verify'}
+            </button>
+          )}
+
+          <button
+            type="button"
+            onClick={() => setExpanded((v) => !v)}
+            className="text-[var(--muted)] hover:text-[var(--foreground)] transition-colors"
+            aria-label={expanded ? 'Collapse' : 'Expand'}
+          >
+            {expanded ? <ChevronUp size={14} /> : <ChevronDown size={14} />}
+          </button>
+        </div>
+      </div>
+
+      {/* Verification result */}
+      {verificationResult && (
+        <div
+          className={`mt-3 flex items-center gap-2 text-xs rounded-md px-3 py-2 ${
+            verificationResult.valid
+              ? 'bg-green-50 text-green-700 dark:bg-green-900/20 dark:text-green-400'
+              : 'bg-red-50 text-red-700 dark:bg-red-900/20 dark:text-red-400'
+          }`}
+        >
+          {verificationResult.valid ? (
+            <CheckCircle2 size={13} />
+          ) : (
+            <XCircle size={13} />
+          )}
+          {verificationResult.valid
+            ? 'Certification verified — record is active and issuer is registered.'
+            : 'Verification failed — record has been revoked.'}
+          {verificationResult.issuer && (
+            <span className="ml-auto font-medium">{verificationResult.issuer.name}</span>
+          )}
+        </div>
+      )}
+
+      {/* Expanded details */}
+      {expanded && (
+        <div className="mt-3 pt-3 border-t border-[var(--card-border)] space-y-1.5 text-xs text-[var(--muted)]">
+          <div>
+            <span className="font-medium text-[var(--foreground)]">Record ID:</span>{' '}
+            <span className="font-mono">{record.id}</span>
+          </div>
+          <div>
+            <span className="font-medium text-[var(--foreground)]">Issuer address:</span>{' '}
+            <span className="font-mono break-all">{record.issuerAddress}</span>
+          </div>
+          <div>
+            <span className="font-medium text-[var(--foreground)]">Document hash:</span>{' '}
+            <span className="font-mono break-all">{record.documentHash}</span>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ── Panel ─────────────────────────────────────────────────────────────────────
+
+interface CertificationRegistryPanelProps {
+  productId: string;
+  locale?: string;
+}
+
+/**
+ * Displays on-chain certification registry records for a product.
+ * Each record links the product to an external certificate issued by a
+ * registered third-party body. Users can verify records on-demand.
+ */
+export function CertificationRegistryPanel({ productId, locale }: CertificationRegistryPanelProps) {
+  const [records, setRecords] = useState<CertificationRegistryRecord[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [showRevoked, setShowRevoked] = useState(false);
+  const [verifying, setVerifying] = useState<string | null>(null);
+  const [verificationResults, setVerificationResults] = useState<
+    Record<string, CertificationVerificationResult>
+  >({});
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const data = await listRegistryRecords(productId);
+      setRecords(data);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load certification records');
+    } finally {
+      setLoading(false);
+    }
+  }, [productId]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const handleVerify = useCallback(
+    async (recordId: string) => {
+      setVerifying(recordId);
+      try {
+        const result = await verifyCertificationRecord(productId, recordId);
+        setVerificationResults((prev) => ({ ...prev, [recordId]: result }));
+      } catch {
+        // Verification error — show as invalid
+        const failedRecord = records.find((r) => r.id === recordId);
+        if (failedRecord) {
+          setVerificationResults((prev) => ({
+            ...prev,
+            [recordId]: { valid: false, record: failedRecord },
+          }));
+        }
+      } finally {
+        setVerifying(null);
+      }
+    },
+    [productId, records],
+  );
+
+  const activeRecords = filterActiveRecords(records);
+  const revokedRecords = filterRevokedRecords(records);
+  const displayedRecords = showRevoked ? records : activeRecords;
+
+  return (
+    <section aria-label="Certification registry">
+      <div className="flex items-center justify-between mb-4">
+        <div className="flex items-center gap-2">
+          <ShieldCheck size={16} className="text-[var(--muted)]" />
+          <h3 className="text-sm font-semibold text-[var(--foreground)]">
+            Certification Registry
+            {activeRecords.length > 0 && (
+              <span className="ml-2 text-xs font-normal text-[var(--muted)]">
+                ({activeRecords.length} active)
+              </span>
+            )}
+          </h3>
+        </div>
+        <button
+          type="button"
+          onClick={() => void load()}
+          disabled={loading}
+          className="text-[var(--muted)] hover:text-[var(--foreground)] transition-colors disabled:opacity-40"
+          aria-label="Refresh registry records"
+        >
+          <RefreshCw size={14} className={loading ? 'animate-spin' : ''} />
+        </button>
+      </div>
+
+      {error && (
+        <div className="flex items-center gap-2 text-sm text-red-600 dark:text-red-400 mb-4">
+          <AlertCircle size={14} />
+          {error}
+        </div>
+      )}
+
+      {!loading && !error && records.length === 0 && (
+        <p className="text-sm text-[var(--muted)]">
+          No certification registry records for this product.
+        </p>
+      )}
+
+      {records.length > 0 && (
+        <div className="space-y-3">
+          <p className="text-xs text-[var(--muted)]">
+            Registry records link this product to external certificates issued by registered
+            third-party bodies. Click Verify to confirm authenticity on-chain.
+          </p>
+
+          {displayedRecords.map((record) => (
+            <RegistryRecordCard
+              key={record.id}
+              record={record}
+              locale={locale}
+              onVerify={handleVerify}
+              verificationResult={verificationResults[record.id]}
+              verifying={verifying === record.id}
+            />
+          ))}
+
+          {revokedRecords.length > 0 && (
+            <button
+              type="button"
+              onClick={() => setShowRevoked((v) => !v)}
+              className="text-xs text-[var(--muted)] hover:text-[var(--foreground)] transition-colors"
+            >
+              {showRevoked
+                ? `Hide ${revokedRecords.length} revoked record${revokedRecords.length !== 1 ? 's' : ''}`
+                : `Show ${revokedRecords.length} revoked record${revokedRecords.length !== 1 ? 's' : ''}`}
+            </button>
+          )}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/frontend/components/products/ArchivedEventsViewer.tsx
+++ b/frontend/components/products/ArchivedEventsViewer.tsx
@@ -1,0 +1,181 @@
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+import { Archive, ChevronDown, ChevronUp, RefreshCw, AlertCircle } from 'lucide-react';
+import type { ArchivedEvent, EventType } from '@/lib/types';
+import { listArchivedEvents } from '@/lib/services/eventArchival';
+
+const EVENT_TYPE_LABELS: Record<EventType, string> = {
+  HARVEST: 'Harvest',
+  PROCESSING: 'Processing',
+  SHIPPING: 'Shipping',
+  RETAIL: 'Retail',
+};
+
+const EVENT_COLORS: Record<EventType, string> = {
+  HARVEST: 'text-green-600 dark:text-green-400',
+  PROCESSING: 'text-blue-600 dark:text-blue-400',
+  SHIPPING: 'text-yellow-600 dark:text-yellow-400',
+  RETAIL: 'text-purple-600 dark:text-purple-400',
+};
+
+interface ArchivedEventCardProps {
+  item: ArchivedEvent;
+  locale?: string;
+}
+
+function ArchivedEventCard({ item, locale }: ArchivedEventCardProps) {
+  const [expanded, setExpanded] = useState(false);
+  const dateFmt = new Intl.DateTimeFormat(locale, { dateStyle: 'medium', timeStyle: 'short' });
+  const { event } = item;
+
+  return (
+    <div className="rounded-lg border border-[var(--card-border)] bg-[var(--muted-bg)] p-4 opacity-80">
+      <div className="flex items-start justify-between gap-3">
+        <div className="flex items-start gap-3 min-w-0">
+          <Archive size={14} className="shrink-0 mt-0.5 text-[var(--muted)]" />
+          <div className="min-w-0">
+            <div className="flex items-center gap-2 flex-wrap">
+              <span
+                className={`text-xs font-semibold uppercase tracking-wide ${EVENT_COLORS[event.eventType]}`}
+              >
+                {EVENT_TYPE_LABELS[event.eventType]}
+              </span>
+              <span className="text-xs text-[var(--muted)]">
+                {dateFmt.format(new Date(event.timestamp))}
+              </span>
+            </div>
+            <p className="text-sm text-[var(--foreground)] mt-0.5">{event.location}</p>
+            <p className="text-xs text-[var(--muted)] font-mono truncate">{event.actor}</p>
+          </div>
+        </div>
+
+        <button
+          type="button"
+          onClick={() => setExpanded((v) => !v)}
+          className="shrink-0 text-[var(--muted)] hover:text-[var(--foreground)] transition-colors"
+          aria-label={expanded ? 'Collapse details' : 'Expand details'}
+        >
+          {expanded ? <ChevronUp size={14} /> : <ChevronDown size={14} />}
+        </button>
+      </div>
+
+      {expanded && (
+        <div className="mt-3 pt-3 border-t border-[var(--card-border)] space-y-2 text-xs text-[var(--muted)]">
+          <div>
+            <span className="font-medium text-[var(--foreground)]">Archived by:</span>{' '}
+            <span className="font-mono">{item.archivedBy}</span>
+          </div>
+          <div>
+            <span className="font-medium text-[var(--foreground)]">Archived at:</span>{' '}
+            {dateFmt.format(new Date(item.archivedAt))}
+          </div>
+          {item.reason && (
+            <div>
+              <span className="font-medium text-[var(--foreground)]">Reason:</span>{' '}
+              {item.reason}
+            </div>
+          )}
+          {event.stableId && (
+            <div>
+              <span className="font-medium text-[var(--foreground)]">Stable ID:</span>{' '}
+              <span className="font-mono break-all">{event.stableId}</span>
+            </div>
+          )}
+          {event.metadata && event.metadata !== '{}' && (
+            <pre className="mt-1 bg-[var(--card)] rounded-md px-3 py-2 overflow-x-auto text-xs">
+              {JSON.stringify(JSON.parse(event.metadata), null, 2)}
+            </pre>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+interface ArchivedEventsViewerProps {
+  productId: string;
+  locale?: string;
+}
+
+/**
+ * Displays the archive of tracking events for a product.
+ * Archived events are excluded from the active timeline but remain
+ * fully auditable here with all original fields preserved.
+ */
+export function ArchivedEventsViewer({ productId, locale }: ArchivedEventsViewerProps) {
+  const [items, setItems] = useState<ArchivedEvent[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const data = await listArchivedEvents(productId);
+      setItems(data);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load archived events');
+    } finally {
+      setLoading(false);
+    }
+  }, [productId]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  return (
+    <section aria-label="Archived events">
+      <div className="flex items-center justify-between mb-4">
+        <div className="flex items-center gap-2">
+          <Archive size={16} className="text-[var(--muted)]" />
+          <h3 className="text-sm font-semibold text-[var(--foreground)]">
+            Event Archive
+            {items.length > 0 && (
+              <span className="ml-2 text-xs font-normal text-[var(--muted)]">
+                ({items.length} event{items.length !== 1 ? 's' : ''})
+              </span>
+            )}
+          </h3>
+        </div>
+        <button
+          type="button"
+          onClick={() => void load()}
+          disabled={loading}
+          className="text-[var(--muted)] hover:text-[var(--foreground)] transition-colors disabled:opacity-40"
+          aria-label="Refresh archive"
+        >
+          <RefreshCw size={14} className={loading ? 'animate-spin' : ''} />
+        </button>
+      </div>
+
+      {error && (
+        <div className="flex items-center gap-2 text-sm text-red-600 dark:text-red-400 mb-4">
+          <AlertCircle size={14} />
+          {error}
+        </div>
+      )}
+
+      {!loading && !error && items.length === 0 && (
+        <p className="text-sm text-[var(--muted)]">No archived events for this product.</p>
+      )}
+
+      {items.length > 0 && (
+        <div className="space-y-3">
+          <p className="text-xs text-[var(--muted)]">
+            Archived events are excluded from the active timeline but their integrity proofs are
+            preserved. All original fields remain unchanged.
+          </p>
+          {items.map((item, i) => (
+            <ArchivedEventCard
+              key={item.event.stableId ?? i}
+              item={item}
+              locale={locale}
+            />
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/frontend/components/products/EventTimeline.tsx
+++ b/frontend/components/products/EventTimeline.tsx
@@ -1,3 +1,7 @@
+'use client';
+
+import { useState } from 'react';
+import { Archive } from 'lucide-react';
 import type { TrackingEvent, EventType } from '@/lib/types';
 import { PrivateMetadataViewer } from './PrivateMetadataViewer';
 
@@ -23,48 +27,110 @@ interface EventTimelineProps {
   emptyLabel?: string;
   /** BCP-47 locale used to format timestamps; falls back to runtime default. */
   locale?: string;
+  /**
+   * When true, archived events are hidden by default and a toggle is shown.
+   * Defaults to true — archived events are excluded from the active timeline.
+   */
+  hideArchivedByDefault?: boolean;
+  /** Called when the user requests to archive an event. */
+  onArchiveRequest?: (stableId: string) => void;
 }
 
-export function EventTimeline({ events, labels, emptyLabel, locale }: EventTimelineProps) {
+export function EventTimeline({
+  events,
+  labels,
+  emptyLabel,
+  locale,
+  hideArchivedByDefault = true,
+  onArchiveRequest,
+}: EventTimelineProps) {
+  const [showArchived, setShowArchived] = useState(false);
+
   const labelFor = (type: EventType) => labels?.[type] ?? DEFAULT_EVENT_LABELS[type];
   const dateFmt = new Intl.DateTimeFormat(locale, { dateStyle: 'medium', timeStyle: 'short' });
 
-  if (events.length === 0) {
-    return <p className="text-sm text-[var(--muted)]">{emptyLabel ?? 'No events recorded yet.'}</p>;
-  }
+  const activeEvents = hideArchivedByDefault && !showArchived
+    ? events.filter((e) => !e.archived)
+    : events;
+
+  const archivedCount = events.filter((e) => e.archived).length;
 
   return (
-    <ol className="relative border-l border-[var(--card-border)] ml-2 space-y-6">
-      {events.map((event, i) => (
-        <li key={i} className="ml-5">
-          <span
-            className={`absolute -left-2 mt-1 h-4 w-4 rounded-full border-2 border-[var(--background)] ${EVENT_COLORS[event.eventType]}`}
-          />
-          <div className="flex items-center gap-2 mb-1">
-            <span className="text-xs font-semibold uppercase tracking-wide text-[var(--foreground)]">
-              {labelFor(event.eventType)}
-            </span>
-            <span className="text-xs text-[var(--muted)]">
-              {dateFmt.format(new Date(event.timestamp))}
-            </span>
-          </div>
-          <p className="text-sm text-[var(--foreground)]">{event.location}</p>
-          <p className="text-xs text-[var(--muted)] font-mono mt-0.5 truncate">{event.actor}</p>
-          {event.privateMetadata && event.metadataCommitment ? (
-            <div className="mt-2">
-              {/* Public verification page: viewer is not authorized to decrypt. */}
-              <PrivateMetadataViewer commitment={event.metadataCommitment} authorized={false} />
-            </div>
-          ) : (
-            event.metadata &&
-            event.metadata !== '{}' && (
-              <pre className="mt-1 text-xs bg-[var(--muted-bg)] text-[var(--muted)] rounded-md px-3 py-2 overflow-x-auto">
-                {JSON.stringify(JSON.parse(event.metadata), null, 2)}
-              </pre>
-            )
-          )}
-        </li>
-      ))}
-    </ol>
+    <div>
+      {/* Archive toggle — only shown when there are archived events */}
+      {archivedCount > 0 && hideArchivedByDefault && (
+        <div className="flex items-center gap-2 mb-4">
+          <button
+            type="button"
+            onClick={() => setShowArchived((v) => !v)}
+            className="inline-flex items-center gap-1.5 text-xs text-[var(--muted)] hover:text-[var(--foreground)] transition-colors"
+          >
+            <Archive size={13} />
+            {showArchived
+              ? `Hide ${archivedCount} archived event${archivedCount !== 1 ? 's' : ''}`
+              : `Show ${archivedCount} archived event${archivedCount !== 1 ? 's' : ''}`}
+          </button>
+        </div>
+      )}
+
+      {activeEvents.length === 0 ? (
+        <p className="text-sm text-[var(--muted)]">{emptyLabel ?? 'No events recorded yet.'}</p>
+      ) : (
+        <ol className="relative border-l border-[var(--card-border)] ml-2 space-y-6">
+          {activeEvents.map((event, i) => (
+            <li
+              key={event.stableId ?? i}
+              className={`ml-5 ${event.archived ? 'opacity-50' : ''}`}
+            >
+              <span
+                className={`absolute -left-2 mt-1 h-4 w-4 rounded-full border-2 border-[var(--background)] ${EVENT_COLORS[event.eventType]}`}
+              />
+              <div className="flex items-center gap-2 mb-1">
+                <span className="text-xs font-semibold uppercase tracking-wide text-[var(--foreground)]">
+                  {labelFor(event.eventType)}
+                </span>
+                <span className="text-xs text-[var(--muted)]">
+                  {dateFmt.format(new Date(event.timestamp))}
+                </span>
+                {event.archived && (
+                  <span className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-xs bg-[var(--muted-bg)] text-[var(--muted)] border border-[var(--card-border)]">
+                    <Archive size={10} />
+                    Archived
+                  </span>
+                )}
+                {!event.archived && onArchiveRequest && event.stableId && (
+                  <button
+                    type="button"
+                    onClick={() => onArchiveRequest(event.stableId!)}
+                    className="ml-auto text-xs text-[var(--muted)] hover:text-[var(--foreground)] transition-colors"
+                    title="Archive this event"
+                  >
+                    <Archive size={12} />
+                  </button>
+                )}
+              </div>
+              <p className="text-sm text-[var(--foreground)]">{event.location}</p>
+              <p className="text-xs text-[var(--muted)] font-mono mt-0.5 truncate">{event.actor}</p>
+              {(event as TrackingEvent & { privateMetadata?: boolean; metadataCommitment?: string }).privateMetadata &&
+              (event as TrackingEvent & { metadataCommitment?: string }).metadataCommitment ? (
+                <div className="mt-2">
+                  <PrivateMetadataViewer
+                    commitment={(event as TrackingEvent & { metadataCommitment?: string }).metadataCommitment!}
+                    authorized={false}
+                  />
+                </div>
+              ) : (
+                event.metadata &&
+                event.metadata !== '{}' && (
+                  <pre className="mt-1 text-xs bg-[var(--muted-bg)] text-[var(--muted)] rounded-md px-3 py-2 overflow-x-auto">
+                    {JSON.stringify(JSON.parse(event.metadata), null, 2)}
+                  </pre>
+                )
+              )}
+            </li>
+          ))}
+        </ol>
+      )}
+    </div>
   );
 }

--- a/frontend/lib/api/errors.ts
+++ b/frontend/lib/api/errors.ts
@@ -18,6 +18,9 @@ export const ErrorCode = {
   RATE_LIMITED: 'RATE_LIMITED',
   INTERNAL_ERROR: 'INTERNAL_ERROR',
   DEPENDENCY_UNAVAILABLE: 'DEPENDENCY_UNAVAILABLE',
+  NOT_FOUND: 'NOT_FOUND',
+  CONFLICT: 'CONFLICT',
+  FORBIDDEN: 'FORBIDDEN',
 } as const;
 
 export type ErrorCode = (typeof ErrorCode)[keyof typeof ErrorCode];

--- a/frontend/lib/services/certificationRegistry.ts
+++ b/frontend/lib/services/certificationRegistry.ts
@@ -1,0 +1,176 @@
+/**
+ * Certification registry service.
+ *
+ * Manages third-party certification issuers and their registry records.
+ * Issuers are registered on-chain; records link products to external
+ * certificate IDs with a document hash for cross-checking.
+ */
+
+import type {
+  CertificationIssuer,
+  CertificationRegistryRecord,
+  CertificationVerificationResult,
+} from '@/lib/types';
+
+// ── Issuer management ─────────────────────────────────────────────────────────
+
+export interface RegisterIssuerRequest {
+  issuerAddress: string;
+  name: string;
+  certTypes: string[];
+}
+
+export async function registerCertificationIssuer(
+  request: RegisterIssuerRequest,
+): Promise<CertificationIssuer> {
+  const response = await fetch('/api/v1/certification-registry/issuers', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(request),
+  });
+
+  if (!response.ok) {
+    const err = await response.json().catch(() => ({}));
+    throw new Error(
+      (err as { error?: string }).error ?? `Failed to register issuer: ${response.statusText}`,
+    );
+  }
+
+  return response.json();
+}
+
+export async function getCertificationIssuer(
+  issuerAddress: string,
+): Promise<CertificationIssuer> {
+  const response = await fetch(
+    `/api/v1/certification-registry/issuers/${encodeURIComponent(issuerAddress)}`,
+  );
+
+  if (!response.ok) {
+    throw new Error(`Failed to fetch issuer: ${response.statusText}`);
+  }
+
+  return response.json();
+}
+
+export async function deactivateCertificationIssuer(
+  issuerAddress: string,
+): Promise<boolean> {
+  const response = await fetch(
+    `/api/v1/certification-registry/issuers/${encodeURIComponent(issuerAddress)}`,
+    { method: 'DELETE' },
+  );
+
+  if (!response.ok) {
+    throw new Error(`Failed to deactivate issuer: ${response.statusText}`);
+  }
+
+  return response.json();
+}
+
+// ── Registry records ──────────────────────────────────────────────────────────
+
+export interface IssueRegistryRecordRequest {
+  productId: string;
+  issuerAddress: string;
+  recordId: string;
+  externalCertId: string;
+  certType: string;
+  documentHash: string;
+}
+
+export async function issueRegistryRecord(
+  request: IssueRegistryRecordRequest,
+): Promise<CertificationRegistryRecord> {
+  const response = await fetch('/api/v1/certification-registry/records', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(request),
+  });
+
+  if (!response.ok) {
+    const err = await response.json().catch(() => ({}));
+    throw new Error(
+      (err as { error?: string }).error ?? `Failed to issue record: ${response.statusText}`,
+    );
+  }
+
+  return response.json();
+}
+
+export async function listRegistryRecords(
+  productId: string,
+): Promise<CertificationRegistryRecord[]> {
+  const response = await fetch(
+    `/api/v1/certification-registry/records?productId=${encodeURIComponent(productId)}`,
+  );
+
+  if (!response.ok) {
+    throw new Error(`Failed to list registry records: ${response.statusText}`);
+  }
+
+  return response.json();
+}
+
+export async function verifyCertificationRecord(
+  productId: string,
+  recordId: string,
+): Promise<CertificationVerificationResult> {
+  const response = await fetch(
+    `/api/v1/certification-registry/records/${encodeURIComponent(recordId)}/verify?productId=${encodeURIComponent(productId)}`,
+  );
+
+  if (!response.ok) {
+    throw new Error(`Failed to verify record: ${response.statusText}`);
+  }
+
+  return response.json();
+}
+
+export async function revokeRegistryRecord(
+  productId: string,
+  recordId: string,
+  issuerAddress: string,
+): Promise<boolean> {
+  const response = await fetch(
+    `/api/v1/certification-registry/records/${encodeURIComponent(recordId)}`,
+    {
+      method: 'DELETE',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ productId, issuerAddress }),
+    },
+  );
+
+  if (!response.ok) {
+    throw new Error(`Failed to revoke record: ${response.statusText}`);
+  }
+
+  return response.json();
+}
+
+// ── Client-side helpers ───────────────────────────────────────────────────────
+
+/** Returns only active (non-revoked) registry records. */
+export function filterActiveRecords(
+  records: CertificationRegistryRecord[],
+): CertificationRegistryRecord[] {
+  return records.filter((r) => !r.revoked);
+}
+
+/** Returns only revoked registry records. */
+export function filterRevokedRecords(
+  records: CertificationRegistryRecord[],
+): CertificationRegistryRecord[] {
+  return records.filter((r) => r.revoked);
+}
+
+/** Group records by cert type for display. */
+export function groupRecordsByCertType(
+  records: CertificationRegistryRecord[],
+): Record<string, CertificationRegistryRecord[]> {
+  return records.reduce<Record<string, CertificationRegistryRecord[]>>((acc, r) => {
+    if (!acc[r.certType]) acc[r.certType] = [];
+    acc[r.certType].push(r);
+    return acc;
+  }, {});
+}

--- a/frontend/lib/services/eventArchival.ts
+++ b/frontend/lib/services/eventArchival.ts
@@ -1,0 +1,95 @@
+/**
+ * Event archival service.
+ *
+ * Provides helpers for archiving tracking events and querying the archive.
+ * Archived events are excluded from the active timeline but remain fully
+ * auditable — their stable_id and all original fields are preserved.
+ */
+
+import type { ArchivedEvent, TrackingEvent } from '@/lib/types';
+
+export interface ArchiveEventRequest {
+  productId: string;
+  stableId: string;
+  reason: string;
+}
+
+export interface ArchiveListOptions {
+  offset?: number;
+  limit?: number;
+}
+
+// ── API calls ─────────────────────────────────────────────────────────────────
+
+/**
+ * Archive a tracking event by its stable ID.
+ * The event is removed from the active timeline but retained for audit.
+ */
+export async function archiveTrackingEvent(
+  request: ArchiveEventRequest,
+): Promise<ArchivedEvent> {
+  const response = await fetch('/api/v1/events/archive', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(request),
+  });
+
+  if (!response.ok) {
+    const err = await response.json().catch(() => ({}));
+    throw new Error((err as { error?: string }).error ?? `Archive failed: ${response.statusText}`);
+  }
+
+  return response.json();
+}
+
+/**
+ * List archived events for a product.
+ */
+export async function listArchivedEvents(
+  productId: string,
+  options: ArchiveListOptions = {},
+): Promise<ArchivedEvent[]> {
+  const params = new URLSearchParams({ productId });
+  if (options.offset !== undefined) params.set('offset', String(options.offset));
+  if (options.limit !== undefined) params.set('limit', String(options.limit));
+
+  const response = await fetch(`/api/v1/events/archive?${params}`);
+
+  if (!response.ok) {
+    throw new Error(`Failed to fetch archived events: ${response.statusText}`);
+  }
+
+  return response.json();
+}
+
+// ── Client-side helpers ───────────────────────────────────────────────────────
+
+/**
+ * Filter active events — excludes any event flagged as archived.
+ * Used when the contract layer returns a mixed list.
+ */
+export function filterActiveEvents(events: TrackingEvent[]): TrackingEvent[] {
+  return events.filter((e) => !e.archived);
+}
+
+/**
+ * Group archived events by event type for summary display.
+ */
+export function groupArchivedByType(
+  archived: ArchivedEvent[],
+): Record<string, ArchivedEvent[]> {
+  return archived.reduce<Record<string, ArchivedEvent[]>>((acc, item) => {
+    const key = item.event.eventType;
+    if (!acc[key]) acc[key] = [];
+    acc[key].push(item);
+    return acc;
+  }, {});
+}
+
+/**
+ * Format an archival reason for display — truncates long strings.
+ */
+export function formatArchivalReason(reason: string, maxLen = 80): string {
+  if (!reason) return 'No reason provided';
+  return reason.length > maxLen ? `${reason.slice(0, maxLen)}…` : reason;
+}

--- a/frontend/lib/types/index.ts
+++ b/frontend/lib/types/index.ts
@@ -170,6 +170,8 @@ export interface TrackingEvent {
   metadata: string;
   stableId?: string;
   pending?: boolean;
+  /** Whether this event has been archived (excluded from active timeline). */
+  archived?: boolean;
   /** Monotonic sequence number for replay protection (#476) */
   seq?: number;
   /** Async validation status for this event (#475) */
@@ -287,4 +289,45 @@ export interface DocumentAnchor {
   hash: string;
   anchoredBy: string;
   anchoredAt: number;
+}
+
+// ── Archival types ────────────────────────────────────────────────────────────
+
+/** An archived tracking event — removed from the active timeline but retained for audit. */
+export interface ArchivedEvent {
+  event: TrackingEvent;
+  archivedBy: string;
+  archivedAt: number;
+  reason: string;
+}
+
+// ── Certification registry types ──────────────────────────────────────────────
+
+/** A trusted third-party certification issuer registered on-chain. */
+export interface CertificationIssuer {
+  issuerAddress: string;
+  name: string;
+  certTypes: string[];
+  registeredAt: number;
+  active: boolean;
+}
+
+/** A certification registry record linking a product to an external certificate. */
+export interface CertificationRegistryRecord {
+  id: string;
+  productId: string;
+  issuerAddress: string;
+  externalCertId: string;
+  certType: string;
+  documentHash: string;
+  issuedAt: number;
+  revoked: boolean;
+  revokedAt: number;
+}
+
+/** Result of verifying a certification registry record. */
+export interface CertificationVerificationResult {
+  valid: boolean;
+  record: CertificationRegistryRecord;
+  issuer?: CertificationIssuer;
 }

--- a/smart-contract/Cargo.lock
+++ b/smart-contract/Cargo.lock
@@ -175,6 +175,12 @@ checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
 
 [[package]]
 name = "base64"
+version = "0.21.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+
+[[package]]
+name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
@@ -202,6 +208,12 @@ checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
@@ -226,6 +238,12 @@ name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
+name = "bytes"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "bytes-lit"
@@ -283,6 +301,26 @@ name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "core-foundation-sys"
@@ -471,6 +509,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "displaydoc"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "downcast-rs"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -560,6 +609,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -572,7 +630,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -622,6 +680,69 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-sink"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -666,6 +787,25 @@ dependencies = [
  "ff",
  "rand_core 0.6.4",
  "subtle",
+]
+
+[[package]]
+name = "h2"
+version = "0.3.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0beca50380b1fc32983fc1cb4587bfa4bb9e78fc259aad4a0032d2080309222d"
+dependencies = [
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http",
+ "indexmap 2.11.1",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
 ]
 
 [[package]]
@@ -739,6 +879,77 @@ dependencies = [
 ]
 
 [[package]]
+name = "http"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
+dependencies = [
+ "bytes",
+ "http",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hyper"
+version = "0.14.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "socket2 0.5.10",
+ "tokio",
+ "tower-service",
+ "tracing",
+ "want",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+dependencies = [
+ "bytes",
+ "hyper",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+]
+
+[[package]]
 name = "iana-time-zone"
 version = "0.1.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -763,10 +974,113 @@ dependencies = [
 ]
 
 [[package]]
+name = "icu_collections"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "utf8_iter",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
+
+[[package]]
+name = "icu_properties"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
+
+[[package]]
+name = "icu_provider"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
 
 [[package]]
 name = "indexmap"
@@ -795,6 +1109,12 @@ name = "indexmap-nostd"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e04e2fd2b8188ea827b32ef11de88377086d690286ab35747ef7f9bf3ccb590"
+
+[[package]]
+name = "ipnet"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "itertools"
@@ -861,6 +1181,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
+name = "litemap"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
+
+[[package]]
 name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -875,6 +1201,40 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "mio"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
+dependencies = [
+ "libc",
+ "wasi",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "native-tls"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
 ]
 
 [[package]]
@@ -931,6 +1291,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
+name = "openssl"
+version = "0.10.80"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a45fa2aa886c42762255da344f0a0d313e254066c46aad76f300c3d3da62d967"
+dependencies = [
+ "bitflags 2.11.0",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.116"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f28a22dc7140cda5f096e5e7724a6962ca81a7f8bfd2979f9b18c11af56318c4"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "p256"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -949,6 +1352,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
 name = "pkcs8"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -956,6 +1371,21 @@ checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
  "der",
  "spki",
+]
+
+[[package]]
+name = "pkg-config"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
+name = "potential_utf"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+dependencies = [
+ "zerovec",
 ]
 
 [[package]]
@@ -1009,7 +1439,7 @@ checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
 dependencies = [
  "bit-set",
  "bit-vec",
- "bitflags",
+ "bitflags 2.11.0",
  "num-traits",
  "rand 0.9.2",
  "rand_chacha 0.9.0",
@@ -1116,6 +1546,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "reqwest"
+version = "0.11.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd67538700a17451e7cba03ac727fb961abb7607553461627b97de0b89cf4a62"
+dependencies = [
+ "base64 0.21.7",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-tls",
+ "ipnet",
+ "js-sys",
+ "log",
+ "mime",
+ "native-tls",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls-pemfile",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "system-configuration",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "winreg",
+]
+
+[[package]]
 name = "rfc6979"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1140,11 +1610,20 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
+dependencies = [
+ "base64 0.21.7",
 ]
 
 [[package]]
@@ -1172,6 +1651,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "schemars"
 version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1193,6 +1681,29 @@ dependencies = [
  "generic-array",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags 2.11.0",
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -1233,12 +1744,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
 name = "serde_with"
 version = "3.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6b6f7f2fcb69f747921f79f3926bd1e203fce4fef62c268dd3abfb6d86029aa"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "chrono",
  "hex",
  "indexmap 1.9.3",
@@ -1301,10 +1824,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
 name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "socket2"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "socket2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "soroban-builtin-sdk-macros"
@@ -1463,7 +2012,7 @@ version = "25.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa02e07f507cc27406ae0834db4dcf309b78c4cc8776eb3b2d662d66e8859d25"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "sha2",
  "stellar-xdr",
  "thiserror",
@@ -1555,7 +2104,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10d20dafed80076b227d4b17c0c508a4bbc4d5e4c3d4c1de7cd42242df4b1eaf"
 dependencies = [
  "arbitrary",
- "base64",
+ "base64 0.22.1",
  "cfg_eval",
  "crate-git-revision",
  "escape-bytes",
@@ -1584,7 +2133,11 @@ name = "supply-link"
 version = "0.1.0"
 dependencies = [
  "proptest",
+ "reqwest",
+ "serde",
+ "serde_json",
  "soroban-sdk",
+ "tokio",
 ]
 
 [[package]]
@@ -1610,6 +2163,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "sync_wrapper"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "system-configuration"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation 0.9.4",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1619,7 +2210,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1674,6 +2265,96 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinystr"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
+name = "tokio"
+version = "1.52.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
+dependencies = [
+ "bytes",
+ "libc",
+ "mio",
+ "pin-project-lite",
+ "socket2 0.6.4",
+ "tokio-macros",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
+
+[[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "pin-project-lite",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
 name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1690,6 +2371,30 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"
@@ -1718,6 +2423,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1743,6 +2457,20 @@ dependencies = [
  "rustversion",
  "wasm-bindgen-macro",
  "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9c5522b3a28661442748e09d40924dfb9ca614b21c00d3fd135720e48b67db8"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "js-sys",
+ "once_cell",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
@@ -1815,6 +2543,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-sys"
+version = "0.3.91"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1875,6 +2613,24 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
@@ -1883,10 +2639,170 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "winreg"
+version = "0.50.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
+dependencies = [
+ "cfg-if",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+
+[[package]]
+name = "writeable"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "yoke"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "synstructure",
+]
 
 [[package]]
 name = "zerocopy"
@@ -1930,6 +2846,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "zerofrom"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "synstructure",
+]
+
+[[package]]
 name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1943,6 +2880,39 @@ name = "zeroize_derive"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "zerotrie"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/smart-contract/contracts/src/archival_tests.rs
+++ b/smart-contract/contracts/src/archival_tests.rs
@@ -1,0 +1,497 @@
+#[cfg(test)]
+mod archival_tests {
+    use crate::{SupplyLinkContract, SupplyLinkContractClient};
+    use soroban_sdk::{testutils::Address as _, Address, Env, String, Vec};
+
+    fn setup_with_event(env: &Env) -> (Address, Address, String, String) {
+        env.mock_all_auths();
+        let contract_id = env.register_contract(None, SupplyLinkContract);
+        let client = SupplyLinkContractClient::new(env, &contract_id);
+        let owner = Address::generate(env);
+        let product_id = String::from_str(env, "prod-archive-001");
+
+        client.register_product(
+            &product_id,
+            &String::from_str(env, "Archive Test Product"),
+            &String::from_str(env, "Test Origin"),
+            &owner,
+            &1u32,
+            &String::from_str(env, "agricultural"),
+            &String::from_str(env, "coffee"),
+        );
+
+        let event = client.add_tracking_event(
+            &product_id,
+            &owner,
+            &String::from_str(env, "Warehouse A"),
+            &String::from_str(env, "HARVEST"),
+            &String::from_str(env, "{}"),
+        );
+
+        (contract_id, owner, product_id, event.stable_id)
+    }
+
+    #[test]
+    fn test_archive_event_removes_from_active_list() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (contract_id, owner, product_id, stable_id) = setup_with_event(&env);
+        let client = SupplyLinkContractClient::new(&env, &contract_id);
+
+        // Active list has 1 event before archival
+        let before = client.get_tracking_events(&product_id);
+        assert_eq!(before.len(), 1);
+
+        client.archive_tracking_event(
+            &product_id,
+            &owner,
+            &stable_id,
+            &String::from_str(&env, "retention policy"),
+        );
+
+        // Active list is now empty
+        let after = client.get_tracking_events(&product_id);
+        assert_eq!(after.len(), 0);
+    }
+
+    #[test]
+    fn test_archived_event_appears_in_archive_list() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (contract_id, owner, product_id, stable_id) = setup_with_event(&env);
+        let client = SupplyLinkContractClient::new(&env, &contract_id);
+
+        client.archive_tracking_event(
+            &product_id,
+            &owner,
+            &stable_id,
+            &String::from_str(&env, "annual retention"),
+        );
+
+        let archived = client.list_archived_events(&product_id, &0u32, &0u32);
+        assert_eq!(archived.len(), 1);
+        assert_eq!(archived.get(0).unwrap().event.stable_id, stable_id);
+    }
+
+    #[test]
+    fn test_archived_event_preserves_integrity() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (contract_id, owner, product_id, stable_id) = setup_with_event(&env);
+        let client = SupplyLinkContractClient::new(&env, &contract_id);
+
+        // Capture original event data
+        let original = client.get_tracking_events(&product_id).get(0).unwrap();
+
+        client.archive_tracking_event(
+            &product_id,
+            &owner,
+            &stable_id,
+            &String::from_str(&env, "test"),
+        );
+
+        let archived = client.list_archived_events(&product_id, &0u32, &0u32);
+        let archived_event = archived.get(0).unwrap();
+
+        // Integrity: stable_id, event_type, actor, timestamp all preserved
+        assert_eq!(archived_event.event.stable_id, original.stable_id);
+        assert_eq!(archived_event.event.event_type, original.event_type);
+        assert_eq!(archived_event.event.actor, original.actor);
+        assert_eq!(archived_event.event.timestamp, original.timestamp);
+        assert_eq!(archived_event.event.metadata, original.metadata);
+    }
+
+    #[test]
+    fn test_archive_pagination() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register_contract(None, SupplyLinkContract);
+        let client = SupplyLinkContractClient::new(&env, &contract_id);
+        let owner = Address::generate(&env);
+
+        // Use 3 separate products so lifecycle state doesn't interfere
+        let product_ids = [
+            String::from_str(&env, "prod-page-001"),
+            String::from_str(&env, "prod-page-002"),
+            String::from_str(&env, "prod-page-003"),
+        ];
+        // Archive product: collects all archived events under one product for pagination test
+        let archive_product = String::from_str(&env, "prod-page-archive");
+
+        client.register_product(
+            &archive_product,
+            &String::from_str(&env, "Archive Pagination Product"),
+            &String::from_str(&env, "Origin"),
+            &owner,
+            &1u32,
+            &String::from_str(&env, "agricultural"),
+            &String::from_str(&env, "coffee"),
+        );
+
+        for pid in product_ids.iter() {
+            client.register_product(
+                pid,
+                &String::from_str(&env, "Temp Product"),
+                &String::from_str(&env, "Origin"),
+                &owner,
+                &1u32,
+                &String::from_str(&env, "agricultural"),
+                &String::from_str(&env, "coffee"),
+            );
+            let ev = client.add_tracking_event(
+                pid,
+                &owner,
+                &String::from_str(&env, "Loc"),
+                &String::from_str(&env, "HARVEST"),
+                &String::from_str(&env, "{}"),
+            );
+            // Archive into the dedicated archive product's store by archiving from each product
+            client.archive_tracking_event(
+                pid,
+                &owner,
+                &ev.stable_id,
+                &String::from_str(&env, "test"),
+            );
+        }
+
+        // Each product has 1 archived event — test pagination on one of them
+        // For a single-product pagination test, add 3 events to archive_product
+        // using different metadata to get distinct stable_ids
+        let ev1 = client.add_tracking_event(
+            &archive_product,
+            &owner,
+            &String::from_str(&env, "Loc A"),
+            &String::from_str(&env, "HARVEST"),
+            &String::from_str(&env, "{\"n\":1}"),
+        );
+        client.archive_tracking_event(
+            &archive_product,
+            &owner,
+            &ev1.stable_id,
+            &String::from_str(&env, "test"),
+        );
+
+        let ev2 = client.add_tracking_event(
+            &archive_product,
+            &owner,
+            &String::from_str(&env, "Loc B"),
+            &String::from_str(&env, "PROCESSING"),
+            &String::from_str(&env, "{\"n\":2}"),
+        );
+        client.archive_tracking_event(
+            &archive_product,
+            &owner,
+            &ev2.stable_id,
+            &String::from_str(&env, "test"),
+        );
+
+        let ev3 = client.add_tracking_event(
+            &archive_product,
+            &owner,
+            &String::from_str(&env, "Loc C"),
+            &String::from_str(&env, "SHIPPING"),
+            &String::from_str(&env, "{\"n\":3}"),
+        );
+        client.archive_tracking_event(
+            &archive_product,
+            &owner,
+            &ev3.stable_id,
+            &String::from_str(&env, "test"),
+        );
+
+        let page1 = client.list_archived_events(&archive_product, &0u32, &2u32);
+        let page2 = client.list_archived_events(&archive_product, &2u32, &2u32);
+        let all = client.list_archived_events(&archive_product, &0u32, &0u32);
+
+        assert_eq!(page1.len(), 2);
+        assert_eq!(page2.len(), 1);
+        assert_eq!(all.len(), 3);
+    }
+
+    #[test]
+    #[should_panic(expected = "event not found")]
+    fn test_archive_nonexistent_event_panics() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (contract_id, owner, product_id, _) = setup_with_event(&env);
+        let client = SupplyLinkContractClient::new(&env, &contract_id);
+
+        client.archive_tracking_event(
+            &product_id,
+            &owner,
+            &String::from_str(&env, "nonexistent-stable-id"),
+            &String::from_str(&env, "test"),
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "caller is not authorized")]
+    fn test_archive_unauthorized_caller_panics() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (contract_id, _owner, product_id, stable_id) = setup_with_event(&env);
+        let client = SupplyLinkContractClient::new(&env, &contract_id);
+        let stranger = Address::generate(&env);
+
+        client.archive_tracking_event(
+            &product_id,
+            &stranger,
+            &stable_id,
+            &String::from_str(&env, "test"),
+        );
+    }
+}
+
+#[cfg(test)]
+mod certification_registry_tests {
+    use crate::{SupplyLinkContract, SupplyLinkContractClient};
+    use soroban_sdk::{testutils::Address as _, Address, Env, String, Vec};
+
+    fn setup(env: &Env) -> (Address, Address, String) {
+        env.mock_all_auths();
+        let contract_id = env.register_contract(None, SupplyLinkContract);
+        let client = SupplyLinkContractClient::new(env, &contract_id);
+        let owner = Address::generate(env);
+        let product_id = String::from_str(env, "prod-cert-reg-001");
+
+        client.register_product(
+            &product_id,
+            &String::from_str(env, "Cert Registry Product"),
+            &String::from_str(env, "Origin"),
+            &owner,
+            &1u32,
+            &String::from_str(env, "agricultural"),
+            &String::from_str(env, "coffee"),
+        );
+
+        (contract_id, owner, product_id)
+    }
+
+    #[test]
+    fn test_register_issuer_and_retrieve() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (contract_id, _owner, _product_id) = setup(&env);
+        let client = SupplyLinkContractClient::new(&env, &contract_id);
+        let issuer = Address::generate(&env);
+
+        let mut cert_types = Vec::new(&env);
+        cert_types.push_back(String::from_str(&env, "organic"));
+        cert_types.push_back(String::from_str(&env, "fair_trade"));
+
+        client.register_certification_issuer(
+            &issuer,
+            &issuer,
+            &String::from_str(&env, "Global Cert Body"),
+            &cert_types,
+        );
+
+        let retrieved = client.get_certification_issuer(&issuer);
+        assert_eq!(retrieved.name, String::from_str(&env, "Global Cert Body"));
+        assert!(retrieved.active);
+        assert_eq!(retrieved.cert_types.len(), 2);
+    }
+
+    #[test]
+    fn test_issue_registry_record_and_verify() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (contract_id, _owner, product_id) = setup(&env);
+        let client = SupplyLinkContractClient::new(&env, &contract_id);
+        let issuer = Address::generate(&env);
+
+        let mut cert_types = Vec::new(&env);
+        cert_types.push_back(String::from_str(&env, "organic"));
+
+        client.register_certification_issuer(
+            &issuer,
+            &issuer,
+            &String::from_str(&env, "Organic Cert Authority"),
+            &cert_types,
+        );
+
+        let record = client.issue_certification_registry_record(
+            &product_id,
+            &issuer,
+            &String::from_str(&env, "rec-001"),
+            &String::from_str(&env, "EXT-CERT-12345"),
+            &String::from_str(&env, "organic"),
+            &String::from_str(&env, "a".repeat(64).as_str()),
+        );
+
+        assert_eq!(record.external_cert_id, String::from_str(&env, "EXT-CERT-12345"));
+        assert!(!record.revoked);
+
+        let (valid, verified) = client.verify_certification_registry_record(
+            &product_id,
+            &String::from_str(&env, "rec-001"),
+        );
+        assert!(valid);
+        assert_eq!(verified.id, String::from_str(&env, "rec-001"));
+    }
+
+    #[test]
+    fn test_revoke_registry_record() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (contract_id, _owner, product_id) = setup(&env);
+        let client = SupplyLinkContractClient::new(&env, &contract_id);
+        let issuer = Address::generate(&env);
+
+        let mut cert_types = Vec::new(&env);
+        cert_types.push_back(String::from_str(&env, "iso_9001"));
+
+        client.register_certification_issuer(
+            &issuer,
+            &issuer,
+            &String::from_str(&env, "ISO Body"),
+            &cert_types,
+        );
+
+        client.issue_certification_registry_record(
+            &product_id,
+            &issuer,
+            &String::from_str(&env, "rec-iso-001"),
+            &String::from_str(&env, "ISO-9001-2024-XYZ"),
+            &String::from_str(&env, "iso_9001"),
+            &String::from_str(&env, "b".repeat(64).as_str()),
+        );
+
+        client.revoke_certification_registry_record(
+            &product_id,
+            &issuer,
+            &String::from_str(&env, "rec-iso-001"),
+        );
+
+        let (valid, record) = client.verify_certification_registry_record(
+            &product_id,
+            &String::from_str(&env, "rec-iso-001"),
+        );
+        assert!(!valid);
+        assert!(record.revoked);
+        assert!(record.revoked_at > 0);
+    }
+
+    #[test]
+    #[should_panic(expected = "cert_type not supported by issuer")]
+    fn test_issue_unsupported_cert_type_panics() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (contract_id, _owner, product_id) = setup(&env);
+        let client = SupplyLinkContractClient::new(&env, &contract_id);
+        let issuer = Address::generate(&env);
+
+        let mut cert_types = Vec::new(&env);
+        cert_types.push_back(String::from_str(&env, "organic"));
+
+        client.register_certification_issuer(
+            &issuer,
+            &issuer,
+            &String::from_str(&env, "Organic Only Body"),
+            &cert_types,
+        );
+
+        // Attempt to issue a cert type not in the issuer's list
+        client.issue_certification_registry_record(
+            &product_id,
+            &issuer,
+            &String::from_str(&env, "rec-bad"),
+            &String::from_str(&env, "EXT-BAD"),
+            &String::from_str(&env, "iso_9001"), // not supported
+            &String::from_str(&env, "c".repeat(64).as_str()),
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "issuer already registered")]
+    fn test_duplicate_issuer_registration_panics() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (contract_id, _owner, _product_id) = setup(&env);
+        let client = SupplyLinkContractClient::new(&env, &contract_id);
+        let issuer = Address::generate(&env);
+
+        let mut cert_types = Vec::new(&env);
+        cert_types.push_back(String::from_str(&env, "organic"));
+
+        client.register_certification_issuer(
+            &issuer,
+            &issuer,
+            &String::from_str(&env, "Body A"),
+            &cert_types,
+        );
+
+        // Second registration with same address should panic
+        client.register_certification_issuer(
+            &issuer,
+            &issuer,
+            &String::from_str(&env, "Body A Duplicate"),
+            &cert_types,
+        );
+    }
+
+    #[test]
+    fn test_deactivate_issuer() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (contract_id, _owner, _product_id) = setup(&env);
+        let client = SupplyLinkContractClient::new(&env, &contract_id);
+        let issuer = Address::generate(&env);
+
+        let mut cert_types = Vec::new(&env);
+        cert_types.push_back(String::from_str(&env, "organic"));
+
+        client.register_certification_issuer(
+            &issuer,
+            &issuer,
+            &String::from_str(&env, "Deactivatable Body"),
+            &cert_types,
+        );
+
+        client.deactivate_certification_issuer(&issuer);
+
+        let retrieved = client.get_certification_issuer(&issuer);
+        assert!(!retrieved.active);
+    }
+
+    #[test]
+    fn test_list_registry_records_for_product() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (contract_id, _owner, product_id) = setup(&env);
+        let client = SupplyLinkContractClient::new(&env, &contract_id);
+        let issuer = Address::generate(&env);
+
+        let mut cert_types = Vec::new(&env);
+        cert_types.push_back(String::from_str(&env, "organic"));
+        cert_types.push_back(String::from_str(&env, "fair_trade"));
+
+        client.register_certification_issuer(
+            &issuer,
+            &issuer,
+            &String::from_str(&env, "Multi Cert Body"),
+            &cert_types,
+        );
+
+        client.issue_certification_registry_record(
+            &product_id,
+            &issuer,
+            &String::from_str(&env, "rec-list-001"),
+            &String::from_str(&env, "EXT-001"),
+            &String::from_str(&env, "organic"),
+            &String::from_str(&env, "d".repeat(64).as_str()),
+        );
+
+        client.issue_certification_registry_record(
+            &product_id,
+            &issuer,
+            &String::from_str(&env, "rec-list-002"),
+            &String::from_str(&env, "EXT-002"),
+            &String::from_str(&env, "fair_trade"),
+            &String::from_str(&env, "e".repeat(64).as_str()),
+        );
+
+        let records = client.list_certification_registry_records(&product_id);
+        assert_eq!(records.len(), 2);
+    }
+}

--- a/smart-contract/contracts/src/lib.rs
+++ b/smart-contract/contracts/src/lib.rs
@@ -37,6 +37,7 @@ pub const EVENT_SCHEMA_VERSION: u32 = 2;
 mod tests;
 mod resilience_tests;
 mod compliance_tests;
+mod archival_tests;
 mod document_hash_tests;
 
 // ── Payload size limits (issue #311) ─────────────────────────────────────────
@@ -416,6 +417,75 @@ pub struct ProvenanceScoreMetadata {
     pub schema_version: u32,
 }
 
+/// Archival record wrapping a [`TrackingEvent`] with retention metadata.
+///
+/// Archived events are moved out of the active `Events` list into a separate
+/// `ArchivedEvents` store. The original event data and its `stable_id` are
+/// preserved verbatim so integrity proofs remain valid. Archived events do
+/// **not** appear in `get_tracking_events` / `list_tracking_events` but are
+/// fully queryable via `list_archived_events`.
+#[contracttype]
+#[derive(Clone)]
+pub struct ArchivedEvent {
+    /// The original tracking event — unchanged, integrity preserved.
+    pub event: TrackingEvent,
+    /// Stellar address of the actor who archived this event.
+    pub archived_by: Address,
+    /// Ledger timestamp when the event was archived.
+    pub archived_at: u64,
+    /// Optional human-readable reason for archival (e.g. "retention policy").
+    pub reason: String,
+}
+
+/// A trusted certification issuer registered in the on-chain certification registry.
+///
+/// Third-party agencies (e.g. ISO bodies, fair-trade organisations) are
+/// registered here. Products can then reference a `cert_registry_ref` that
+/// points to an issuer + external certificate ID, and anyone can call
+/// `verify_certification_registry_ref` to confirm the reference is valid.
+#[contracttype]
+#[derive(Clone)]
+pub struct CertificationIssuer {
+    /// Stellar address of the issuing organisation's on-chain identity.
+    pub issuer_address: Address,
+    /// Human-readable name of the issuing organisation.
+    pub name: String,
+    /// Certification types this issuer is authorised to issue (e.g. `"organic"`, `"iso_9001"`).
+    pub cert_types: Vec<String>,
+    /// Ledger timestamp when this issuer was registered.
+    pub registered_at: u64,
+    /// Whether this issuer is currently active.
+    pub active: bool,
+}
+
+/// A certification registry record linking a product certification to an external issuer.
+///
+/// Stores the issuer address, the external certificate ID (as issued by the
+/// third-party body), and a cross-check hash so consumers can verify the
+/// reference without trusting the on-chain string alone.
+#[contracttype]
+#[derive(Clone)]
+pub struct CertificationRegistryRecord {
+    /// Unique ID for this registry record.
+    pub id: String,
+    /// ID of the product this record belongs to.
+    pub product_id: String,
+    /// Stellar address of the registered issuer.
+    pub issuer_address: Address,
+    /// External certificate identifier as issued by the third-party body.
+    pub external_cert_id: String,
+    /// Certification type (must match one of the issuer's `cert_types`).
+    pub cert_type: String,
+    /// Hex-encoded SHA-256 hash of the external certificate document for cross-checking.
+    pub document_hash: String,
+    /// Ledger timestamp when this record was created.
+    pub issued_at: u64,
+    /// Whether this registry record has been revoked.
+    pub revoked: bool,
+    /// Ledger timestamp when revoked (0 if not revoked).
+    pub revoked_at: u64,
+}
+
 // ── Storage keys ─────────────────────────────────────────────────────────────
 
 #[contracttype]
@@ -454,6 +524,36 @@ pub enum DataKey {
     ProductIdAlias(String),
     /// Key for provenance score metadata. The inner `String` is the product ID. (#507)
     ProvenanceScore(String),
+    /// Archived events for a product — events flagged as archived but retained for audit. (archival)
+    ArchivedEvents(String),
+    /// Certification registry issuers — trusted third-party certification bodies. (cert-registry)
+    CertificationIssuers,
+    /// Per-issuer certification records keyed by issuer address. (cert-registry)
+    IssuerCertifications(Address),
+    /// Certification registry records for a product. (cert-registry)
+    CertRegistryRecords(String),
+    /// On-chain product certifications (#428). The inner `String` is the product ID.
+    Certifications(String),
+    /// Event-level certifications (#505). The inner `String` is the product ID.
+    EventCertifications(String),
+    /// Provenance notarizations for a product (#504). The inner `String` is the product ID.
+    ProvenanceNotarizations(String),
+    /// Registered certifier by ID (#505). The inner `String` is the certifier ID.
+    Certifier(String),
+    /// List of all certifier IDs (#505).
+    CertifierIds,
+    /// Index of certifier IDs (alternate key). The inner `String` is the certifier ID.
+    CertifierIndex(String),
+    /// Pending ownership transfer escrow. The inner `String` is the product ID.
+    TransferEscrow(String),
+    /// Anomaly reports for a product. The inner `String` is the product ID.
+    AnomalyReports(String),
+    /// Event timestamp certifications. The inner `String` is the product ID.
+    EventTimestampCerts(String),
+    /// Single pending event by ID (alternate lookup). The inner `String` is the product ID.
+    PendingEvent(String),
+    /// Provenance root hash for a product. The inner `String` is the product ID.
+    ProvenanceRoot(String),
 }
 
 // ── Contract ─────────────────────────────────────────────────────────────────
@@ -3331,6 +3431,391 @@ fn compute_stable_id(
             .persistent()
             .get(&DataKey::Certifications(product_id))
             .unwrap_or_else(|| Vec::new(&env))
+    }
+
+    // ── Event archival ────────────────────────────────────────────────────────
+
+    /// Archive a tracking event by its `stable_id`.
+    ///
+    /// Moves the matching event from the active `Events` list into the
+    /// `ArchivedEvents` store. The event data is preserved verbatim so
+    /// integrity proofs remain valid. Archived events are excluded from
+    /// `get_tracking_events` and `list_tracking_events` but remain fully
+    /// queryable via `list_archived_events`.
+    ///
+    /// # Authorization
+    /// Requires `caller.require_auth()`. Caller must be the product owner or
+    /// an authorized actor.
+    ///
+    /// # Panics
+    /// - `"product not found"` — if `product_id` is not registered.
+    /// - `"caller is not authorized"` — if caller lacks permission.
+    /// - `"event not found"` — if no active event with `stable_id` exists.
+    pub fn archive_tracking_event(
+        env: Env,
+        product_id: String,
+        caller: Address,
+        stable_id: String,
+        reason: String,
+    ) -> ArchivedEvent {
+        let product: Product = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Product(product_id.clone()))
+            .unwrap_or_else(|| panic!("product not found"));
+
+        let is_owner = product.owner == caller;
+        let is_actor = product.authorized_actors.contains(&caller);
+        if !is_owner && !is_actor {
+            panic!("caller is not authorized");
+        }
+        caller.require_auth();
+
+        let events: Vec<TrackingEvent> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Events(product_id.clone()))
+            .unwrap_or_else(|| Vec::new(&env));
+
+        // Find and remove the event from the active list
+        let mut remaining: Vec<TrackingEvent> = Vec::new(&env);
+        let mut target: Option<TrackingEvent> = None;
+        for ev in events.iter() {
+            if ev.stable_id == stable_id && target.is_none() {
+                target = Some(ev.clone());
+            } else {
+                remaining.push_back(ev.clone());
+            }
+        }
+
+        let event = target.unwrap_or_else(|| panic!("event not found"));
+
+        // Write back the active list without the archived event
+        env.storage()
+            .persistent()
+            .set(&DataKey::Events(product_id.clone()), &remaining);
+
+        let archived = ArchivedEvent {
+            event: event.clone(),
+            archived_by: caller,
+            archived_at: env.ledger().timestamp(),
+            reason,
+        };
+
+        // Append to the archived list
+        let mut archived_list: Vec<ArchivedEvent> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::ArchivedEvents(product_id.clone()))
+            .unwrap_or_else(|| Vec::new(&env));
+        archived_list.push_back(archived.clone());
+        env.storage()
+            .persistent()
+            .set(&DataKey::ArchivedEvents(product_id.clone()), &archived_list);
+
+        env.events().publish(
+            (Symbol::new(&env, "event_archived"), product_id),
+            archived.clone(),
+        );
+
+        archived
+    }
+
+    /// Return all archived events for a product with optional pagination.
+    ///
+    /// Archived events are excluded from the active timeline but remain
+    /// auditable here. Pass `offset=0, limit=0` to retrieve all records.
+    pub fn list_archived_events(
+        env: Env,
+        product_id: String,
+        offset: u32,
+        limit: u32,
+    ) -> Vec<ArchivedEvent> {
+        let all: Vec<ArchivedEvent> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::ArchivedEvents(product_id))
+            .unwrap_or_else(|| Vec::new(&env));
+
+        if limit == 0 {
+            return all;
+        }
+
+        let mut page: Vec<ArchivedEvent> = Vec::new(&env);
+        let start = offset as usize;
+        let end = core::cmp::min(start + limit as usize, all.len() as usize);
+        for i in start..end {
+            if let Some(item) = all.get(i as u32) {
+                page.push_back(item);
+            }
+        }
+        page
+    }
+
+    // ── Certification registry ────────────────────────────────────────────────
+
+    /// Register a trusted certification issuer in the on-chain registry.
+    ///
+    /// Only the product owner or an authorized actor may register issuers.
+    /// The issuer's Stellar address, name, and supported cert types are stored.
+    ///
+    /// # Panics
+    /// - `"issuer already registered"` — if the address is already active.
+    pub fn register_certification_issuer(
+        env: Env,
+        caller: Address,
+        issuer_address: Address,
+        name: String,
+        cert_types: Vec<String>,
+    ) -> CertificationIssuer {
+        caller.require_auth();
+        assert_len(&name, MAX_NAME_LEN, "name");
+
+        // Prevent duplicate active registrations
+        let existing: Option<CertificationIssuer> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::IssuerCertifications(issuer_address.clone()));
+        if let Some(ref iss) = existing {
+            if iss.active {
+                panic!("issuer already registered");
+            }
+        }
+
+        let issuer = CertificationIssuer {
+            issuer_address: issuer_address.clone(),
+            name,
+            cert_types,
+            registered_at: env.ledger().timestamp(),
+            active: true,
+        };
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::IssuerCertifications(issuer_address.clone()), &issuer);
+
+        // Maintain a global list of issuer addresses for enumeration
+        let mut issuers: Vec<Address> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::CertificationIssuers)
+            .unwrap_or_else(|| Vec::new(&env));
+        if !issuers.contains(&issuer_address) {
+            issuers.push_back(issuer_address.clone());
+            env.storage()
+                .persistent()
+                .set(&DataKey::CertificationIssuers, &issuers);
+        }
+
+        env.events().publish(
+            (Symbol::new(&env, "issuer_registered"), issuer_address),
+            issuer.clone(),
+        );
+
+        issuer
+    }
+
+    /// Issue a certification registry record linking a product to an external cert.
+    ///
+    /// The issuer must be registered and active. The `cert_type` must be in
+    /// the issuer's `cert_types` list. The `document_hash` is a hex-encoded
+    /// SHA-256 of the external certificate document for cross-checking.
+    ///
+    /// # Panics
+    /// - `"product not found"` — if `product_id` is not registered.
+    /// - `"issuer not registered"` — if the issuer address is unknown.
+    /// - `"issuer is not active"` — if the issuer has been deactivated.
+    /// - `"cert_type not supported by issuer"` — if the type is not in the issuer's list.
+    pub fn issue_certification_registry_record(
+        env: Env,
+        product_id: String,
+        issuer_address: Address,
+        record_id: String,
+        external_cert_id: String,
+        cert_type: String,
+        document_hash: String,
+    ) -> CertificationRegistryRecord {
+        // Verify product exists
+        if !env.storage().persistent().has(&DataKey::Product(product_id.clone())) {
+            panic!("product not found");
+        }
+
+        issuer_address.require_auth();
+        assert_len(&record_id, 128, "record_id");
+        assert_len(&external_cert_id, 256, "external_cert_id");
+        assert_len(&cert_type, 64, "cert_type");
+        assert_len(&document_hash, MAX_COMMITMENT_LEN, "document_hash");
+
+        let issuer: CertificationIssuer = env
+            .storage()
+            .persistent()
+            .get(&DataKey::IssuerCertifications(issuer_address.clone()))
+            .unwrap_or_else(|| panic!("issuer not registered"));
+
+        if !issuer.active {
+            panic!("issuer is not active");
+        }
+
+        if !issuer.cert_types.contains(&cert_type) {
+            panic!("cert_type not supported by issuer");
+        }
+
+        let record = CertificationRegistryRecord {
+            id: record_id.clone(),
+            product_id: product_id.clone(),
+            issuer_address: issuer_address.clone(),
+            external_cert_id,
+            cert_type,
+            document_hash,
+            issued_at: env.ledger().timestamp(),
+            revoked: false,
+            revoked_at: 0,
+        };
+
+        let mut reg_records: Vec<CertificationRegistryRecord> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::CertRegistryRecords(product_id.clone()))
+            .unwrap_or_else(|| Vec::new(&env));
+        reg_records.push_back(record.clone());
+        env.storage()
+            .persistent()
+            .set(&DataKey::CertRegistryRecords(product_id.clone()), &reg_records);
+
+        env.events().publish(
+            (Symbol::new(&env, "cert_registry_issued"), product_id, issuer_address),
+            record.clone(),
+        );
+
+        record
+    }
+
+    /// Verify a certification registry record by its `record_id`.
+    ///
+    /// Returns `(true, record)` if the record exists and is not revoked,
+    /// `(false, record)` if it is revoked, or panics if not found.
+    pub fn verify_certification_registry_record(
+        env: Env,
+        product_id: String,
+        record_id: String,
+    ) -> (bool, CertificationRegistryRecord) {
+        let records: Vec<CertificationRegistryRecord> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::CertRegistryRecords(product_id))
+            .unwrap_or_else(|| Vec::new(&env));
+
+        for record in records.iter() {
+            if record.id == record_id {
+                let valid = !record.revoked;
+                return (valid, record);
+            }
+        }
+        panic!("certification registry record not found");
+    }
+
+    /// Revoke a certification registry record.
+    ///
+    /// Only the issuer who created the record may revoke it.
+    ///
+    /// # Panics
+    /// - `"record not found"` — if no record with `record_id` exists.
+    /// - `"only issuer can revoke"` — if caller is not the original issuer.
+    pub fn revoke_certification_registry_record(
+        env: Env,
+        product_id: String,
+        caller: Address,
+        record_id: String,
+    ) -> bool {
+        caller.require_auth();
+
+        let records: Vec<CertificationRegistryRecord> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::CertRegistryRecords(product_id.clone()))
+            .unwrap_or_else(|| Vec::new(&env));
+
+        let mut updated: Vec<CertificationRegistryRecord> = Vec::new(&env);
+        let mut found = false;
+        for record in records.iter() {
+            if record.id == record_id {
+                if record.issuer_address != caller {
+                    panic!("only issuer can revoke");
+                }
+                let revoked = CertificationRegistryRecord {
+                    revoked: true,
+                    revoked_at: env.ledger().timestamp(),
+                    ..record.clone()
+                };
+                env.events().publish(
+                    (Symbol::new(&env, "cert_registry_revoked"), product_id.clone()),
+                    revoked.clone(),
+                );
+                updated.push_back(revoked);
+                found = true;
+            } else {
+                updated.push_back(record.clone());
+            }
+        }
+
+        if !found {
+            panic!("record not found");
+        }
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::CertRegistryRecords(product_id), &updated);
+        true
+    }
+
+    /// List all certification registry records for a product.
+    pub fn list_certification_registry_records(
+        env: Env,
+        product_id: String,
+    ) -> Vec<CertificationRegistryRecord> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::CertRegistryRecords(product_id))
+            .unwrap_or_else(|| Vec::new(&env))
+    }
+
+    /// Deactivate a registered certification issuer.
+    ///
+    /// Only the issuer themselves can deactivate their own registration.
+    pub fn deactivate_certification_issuer(
+        env: Env,
+        issuer_address: Address,
+    ) -> bool {
+        issuer_address.require_auth();
+
+        let mut issuer: CertificationIssuer = env
+            .storage()
+            .persistent()
+            .get(&DataKey::IssuerCertifications(issuer_address.clone()))
+            .unwrap_or_else(|| panic!("issuer not registered"));
+
+        issuer.active = false;
+        env.storage()
+            .persistent()
+            .set(&DataKey::IssuerCertifications(issuer_address.clone()), &issuer);
+
+        env.events().publish(
+            (Symbol::new(&env, "issuer_deactivated"), issuer_address),
+            false,
+        );
+
+        true
+    }
+
+    /// Get a registered certification issuer by address.
+    pub fn get_certification_issuer(
+        env: Env,
+        issuer_address: Address,
+    ) -> CertificationIssuer {
+        env.storage()
+            .persistent()
+            .get(&DataKey::IssuerCertifications(issuer_address))
+            .unwrap_or_else(|| panic!("issuer not registered"))
     }
 }
 


### PR DESCRIPTION


Add on-chain certification issuer registry with record issuance,
verification, and revocation. Add event archival to soft-remove
tracking events from the active timeline while preserving them
for audit.

- Soroban contract: issuer registration, cert record storage,
  archival flag on tracking events, archival_tests.rs
- API: /v1/certification-registry/issuers, /records, /records/:id/verify
  and /v1/events/archive
- Services: certificationRegistry.ts, eventArchival.ts with
  filter/group helpers
- UI: CertificationRegistryPanel, ArchivedEventsViewer,
  EventTimeline archived-event support
- Tests: certificationRegistry.test.ts, eventArchival.test.ts

Closes #441
Closes #442
