### PR TITLE
feat: recall risk scoring and emergency stop

### DIFF
--- a/frontend/__tests__/contractPause.test.ts
+++ b/frontend/__tests__/contractPause.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  getContractPauseState,
+  setContractPauseState,
+} from '@/lib/services/contractPause';
+
+// ── Mock fetch ────────────────────────────────────────────────────────────────
+
+function mockFetch(body: unknown, ok = true, status = 200) {
+  globalThis.fetch = vi.fn().mockResolvedValueOnce({
+    ok,
+    status,
+    statusText: ok ? 'OK' : 'Error',
+    json: async () => body,
+  } as Response);
+}
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+});
+
+// ── getContractPauseState ─────────────────────────────────────────────────────
+
+describe('getContractPauseState', () => {
+  it('returns paused=false when contract is running normally', async () => {
+    mockFetch({ paused: false });
+    const state = await getContractPauseState();
+    expect(state.paused).toBe(false);
+  });
+
+  it('returns paused=true with metadata when contract is paused', async () => {
+    const now = Math.floor(Date.now() / 1000);
+    mockFetch({ paused: true, pausedBy: 'GGUARDIAN1', pausedAt: now, reason: 'security incident' });
+    const state = await getContractPauseState();
+    expect(state.paused).toBe(true);
+    expect(state.reason).toBe('security incident');
+    expect(state.pausedBy).toBe('GGUARDIAN1');
+  });
+
+  it('throws when the API returns an error', async () => {
+    mockFetch({}, false, 500);
+    await expect(getContractPauseState()).rejects.toThrow('Failed to fetch pause state');
+  });
+});
+
+// ── setContractPauseState ─────────────────────────────────────────────────────
+
+describe('setContractPauseState', () => {
+  it('sends paused=true with reason and returns updated state', async () => {
+    const now = Math.floor(Date.now() / 1000);
+    mockFetch({ paused: true, pausedAt: now, reason: 'attack detected' });
+    const state = await setContractPauseState(true, 'attack detected');
+    expect(state.paused).toBe(true);
+    expect(state.reason).toBe('attack detected');
+
+    const call = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    const body = JSON.parse(call[1].body);
+    expect(body.paused).toBe(true);
+    expect(body.reason).toBe('attack detected');
+  });
+
+  it('sends paused=false to resume operations', async () => {
+    mockFetch({ paused: false });
+    const state = await setContractPauseState(false);
+    expect(state.paused).toBe(false);
+  });
+
+  it('throws with server error message when API rejects', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValueOnce({
+      ok: false,
+      status: 403,
+      statusText: 'Forbidden',
+      json: async () => ({ error: 'Not a guardian' }),
+    } as Response);
+    await expect(setContractPauseState(true)).rejects.toThrow('Not a guardian');
+  });
+});

--- a/frontend/__tests__/recallRiskScore.test.ts
+++ b/frontend/__tests__/recallRiskScore.test.ts
@@ -1,0 +1,197 @@
+import { describe, it, expect } from 'vitest';
+import {
+  computeRecallRiskScore,
+  getRiskLevelColor,
+  getRiskLevelBg,
+} from '@/lib/services/recallRiskScore';
+import type { Product, TrackingEvent } from '@/lib/types';
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+const NOW_SEC = Math.floor(Date.now() / 1000);
+
+function makeProduct(overrides: Partial<Product> = {}): Product {
+  return {
+    id: 'prod-001',
+    name: 'Test Product',
+    origin: 'Test Origin',
+    owner: 'GOWNER1',
+    timestamp: NOW_SEC - 86_400,
+    active: true,
+    authorizedActors: ['GACTOR1'],
+    recalled: false,
+    ...overrides,
+  };
+}
+
+function makeEvent(
+  eventType: TrackingEvent['eventType'],
+  timestamp: number,
+  overrides: Partial<TrackingEvent> = {},
+): TrackingEvent {
+  return {
+    productId: 'prod-001',
+    location: 'Warehouse A',
+    actor: 'GACTOR1',
+    timestamp,
+    eventType,
+    metadata: '{}',
+    stableId: `stable-${eventType}-${timestamp}`,
+    ...overrides,
+  };
+}
+
+// ── computeRecallRiskScore ────────────────────────────────────────────────────
+
+describe('computeRecallRiskScore', () => {
+  it('returns score 0 and level low for a clean product with full lifecycle', () => {
+    const product = makeProduct();
+    const events = [
+      makeEvent('HARVEST',    NOW_SEC - 10 * 86_400),
+      makeEvent('PROCESSING', NOW_SEC - 8  * 86_400),
+      makeEvent('SHIPPING',   NOW_SEC - 5  * 86_400),
+      makeEvent('RETAIL',     NOW_SEC - 2  * 86_400),
+    ];
+    const result = computeRecallRiskScore(product, events);
+    expect(result.score).toBe(0);
+    expect(result.level).toBe('low');
+    expect(result.factors).toHaveLength(0);
+  });
+
+  it('adds active_recall penalty for recalled products', () => {
+    const product = makeProduct({ recalled: true, recallReason: 'contamination' });
+    const result = computeRecallRiskScore(product, []);
+    const factor = result.factors.find((f) => f.key === 'active_recall');
+    expect(factor).toBeDefined();
+    expect(factor!.penalty).toBe(50);
+    expect(result.score).toBeGreaterThanOrEqual(50);
+    expect(result.level).toBe('critical');
+  });
+
+  it('adds expired_metadata penalty when product is past expiration', () => {
+    const product = makeProduct({ expirationTimestamp: NOW_SEC - 1000 });
+    const result = computeRecallRiskScore(product, []);
+    const factor = result.factors.find((f) => f.key === 'expired_metadata');
+    expect(factor).toBeDefined();
+    expect(factor!.penalty).toBe(25);
+  });
+
+  it('does not add expired_metadata penalty when product is not yet expired', () => {
+    const product = makeProduct({ expirationTimestamp: NOW_SEC + 86_400 });
+    const result = computeRecallRiskScore(product, []);
+    expect(result.factors.find((f) => f.key === 'expired_metadata')).toBeUndefined();
+  });
+
+  it('adds missing_approvals penalty for events with no actor', () => {
+    const product = makeProduct();
+    const events = [
+      makeEvent('HARVEST', NOW_SEC - 5 * 86_400, { actor: '' }),
+      makeEvent('RETAIL',  NOW_SEC - 1 * 86_400),
+    ];
+    const result = computeRecallRiskScore(product, events);
+    const factor = result.factors.find((f) => f.key === 'missing_approvals');
+    expect(factor).toBeDefined();
+    expect(factor!.penalty).toBeGreaterThan(0);
+  });
+
+  it('adds location_jumps penalty for impossibly fast transitions', () => {
+    const product = makeProduct();
+    // HARVEST → PROCESSING in 10 seconds (minimum is 3600)
+    const events = [
+      makeEvent('HARVEST',    NOW_SEC - 100),
+      makeEvent('PROCESSING', NOW_SEC - 90),
+    ];
+    const result = computeRecallRiskScore(product, events);
+    const factor = result.factors.find((f) => f.key === 'location_jumps');
+    expect(factor).toBeDefined();
+    expect(factor!.penalty).toBeGreaterThan(0);
+  });
+
+  it('adds delayed_transitions penalty for excessively slow transitions', () => {
+    const product = makeProduct();
+    // HARVEST → PROCESSING after 40 days (max is 30 days)
+    const events = [
+      makeEvent('HARVEST',    NOW_SEC - 41 * 86_400),
+      makeEvent('PROCESSING', NOW_SEC - 1  * 86_400),
+    ];
+    const result = computeRecallRiskScore(product, events);
+    const factor = result.factors.find((f) => f.key === 'delayed_transitions');
+    expect(factor).toBeDefined();
+  });
+
+  it('adds sparse_coverage penalty when lifecycle stages are missing', () => {
+    const product = makeProduct();
+    const events = [makeEvent('HARVEST', NOW_SEC - 5 * 86_400)];
+    const result = computeRecallRiskScore(product, events);
+    const factor = result.factors.find((f) => f.key === 'sparse_coverage');
+    expect(factor).toBeDefined();
+    expect(factor!.explanation).toContain('PROCESSING');
+  });
+
+  it('caps score at 100 even with many overlapping penalties', () => {
+    const product = makeProduct({
+      recalled: true,
+      expirationTimestamp: NOW_SEC - 1000,
+    });
+    const events = [
+      makeEvent('HARVEST', NOW_SEC - 10, { actor: '' }),
+      makeEvent('PROCESSING', NOW_SEC - 5, { actor: '' }),
+    ];
+    const result = computeRecallRiskScore(product, events);
+    expect(result.score).toBeLessThanOrEqual(100);
+  });
+
+  it('excludes archived events from analysis', () => {
+    const product = makeProduct();
+    const events = [
+      makeEvent('HARVEST', NOW_SEC - 10, { archived: true, actor: '' }),
+      makeEvent('RETAIL',  NOW_SEC - 5),
+    ];
+    const result = computeRecallRiskScore(product, events);
+    // Archived event with no actor should not trigger missing_approvals
+    expect(result.factors.find((f) => f.key === 'missing_approvals')).toBeUndefined();
+  });
+
+  it('returns correct productId in result', () => {
+    const product = makeProduct({ id: 'my-product' });
+    const result = computeRecallRiskScore(product, []);
+    expect(result.productId).toBe('my-product');
+  });
+});
+
+// ── Level thresholds ──────────────────────────────────────────────────────────
+
+describe('risk level thresholds', () => {
+  it('score 0 → low', () => {
+    const result = computeRecallRiskScore(makeProduct(), [
+      makeEvent('HARVEST',    NOW_SEC - 10 * 86_400),
+      makeEvent('PROCESSING', NOW_SEC - 8  * 86_400),
+      makeEvent('SHIPPING',   NOW_SEC - 5  * 86_400),
+      makeEvent('RETAIL',     NOW_SEC - 2  * 86_400),
+    ]);
+    expect(result.level).toBe('low');
+  });
+
+  it('score ≥ 70 → critical', () => {
+    const product = makeProduct({ recalled: true, expirationTimestamp: NOW_SEC - 1 });
+    const result = computeRecallRiskScore(product, []);
+    expect(result.level).toBe('critical');
+  });
+});
+
+// ── Color helpers ─────────────────────────────────────────────────────────────
+
+describe('getRiskLevelColor', () => {
+  it('returns red for critical', () => {
+    expect(getRiskLevelColor('critical')).toContain('red');
+  });
+  it('returns green for low', () => {
+    expect(getRiskLevelColor('low')).toContain('green');
+  });
+});
+
+describe('getRiskLevelBg', () => {
+  it('returns orange bg for high', () => {
+    expect(getRiskLevelBg('high')).toContain('orange');
+  });
+});

--- a/frontend/app/api/v1/contract/pause/route.ts
+++ b/frontend/app/api/v1/contract/pause/route.ts
@@ -1,0 +1,44 @@
+/**
+ * GET  /api/v1/contract/pause  — return current pause state
+ * POST /api/v1/contract/pause  — set pause state (guardian only)
+ */
+
+import { NextResponse } from 'next/server';
+
+// In production this would read from / write to the Soroban contract via RPC.
+// For now we use a module-level variable as a lightweight stand-in that
+// survives the process lifetime (suitable for dev/test; replace with KV or
+// contract call in production).
+let pauseState = {
+  paused: false,
+  pausedBy: undefined as string | undefined,
+  pausedAt: undefined as number | undefined,
+  reason: undefined as string | undefined,
+};
+
+export async function GET() {
+  return NextResponse.json(pauseState);
+}
+
+export async function POST(request: Request) {
+  let body: { paused?: boolean; reason?: string };
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
+  }
+
+  if (typeof body.paused !== 'boolean') {
+    return NextResponse.json({ error: '"paused" must be a boolean' }, { status: 400 });
+  }
+
+  // TODO: verify caller is an authorized guardian via Soroban auth check.
+  pauseState = {
+    paused: body.paused,
+    pausedBy: 'guardian', // replace with verified caller address
+    pausedAt: body.paused ? Math.floor(Date.now() / 1000) : undefined,
+    reason: body.reason,
+  };
+
+  return NextResponse.json(pauseState);
+}

--- a/frontend/components/layouts/AppShell.tsx
+++ b/frontend/components/layouts/AppShell.tsx
@@ -5,6 +5,7 @@ import { AppNavbar } from './Navbar';
 import { Sidebar } from './Sidebar';
 import { AuthGuard } from './AuthGuard';
 import { SyncStatusBanner } from '@/components/ui/SyncStatusBanner';
+import { ContractPausedBanner } from '@/components/ui/ContractPausedBanner';
 
 export function AppShell({ children }: { children: React.ReactNode }) {
   const [sidebarOpen, setSidebarOpen] = useState(false);
@@ -13,6 +14,7 @@ export function AppShell({ children }: { children: React.ReactNode }) {
     <AuthGuard>
       <div className="flex flex-col min-h-screen bg-[var(--background)]">
         <AppNavbar onMenuClick={() => setSidebarOpen(true)} />
+        <ContractPausedBanner />
         <SyncStatusBanner />
         <div className="flex flex-1">
           <Sidebar open={sidebarOpen} onClose={() => setSidebarOpen(false)} />

--- a/frontend/components/products/RecallRiskBadge.tsx
+++ b/frontend/components/products/RecallRiskBadge.tsx
@@ -1,0 +1,158 @@
+'use client';
+
+import { useState } from 'react';
+import { AlertTriangle, ShieldCheck, ShieldAlert, Info } from 'lucide-react';
+import {
+  computeRecallRiskScore,
+  getRiskLevelColor,
+  getRiskLevelBg,
+  type RecallRiskScore,
+  type RiskLevel,
+} from '@/lib/services/recallRiskScore';
+import type { Product, TrackingEvent } from '@/lib/types';
+
+interface RecallRiskBadgeProps {
+  product: Product;
+  events: TrackingEvent[];
+  /** Show full breakdown panel instead of compact badge. */
+  expanded?: boolean;
+}
+
+const LEVEL_LABELS: Record<RiskLevel, string> = {
+  low: 'Low Risk',
+  medium: 'Medium Risk',
+  high: 'High Risk',
+  critical: 'Critical Risk',
+};
+
+function RiskIcon({ level, size = 16 }: { level: RiskLevel; size?: number }) {
+  if (level === 'low') return <ShieldCheck size={size} aria-hidden="true" />;
+  if (level === 'critical') return <AlertTriangle size={size} aria-hidden="true" />;
+  return <ShieldAlert size={size} aria-hidden="true" />;
+}
+
+/** Compact inline badge — suitable for product cards and list rows. */
+function CompactBadge({ score }: { score: RecallRiskScore }) {
+  const colorClass = getRiskLevelColor(score.level);
+  const bgClass = getRiskLevelBg(score.level);
+  return (
+    <span
+      className={`inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium border ${bgClass} ${colorClass}`}
+      aria-label={`Recall risk: ${LEVEL_LABELS[score.level]}, score ${score.score}`}
+    >
+      <RiskIcon level={score.level} size={12} />
+      {LEVEL_LABELS[score.level]}
+    </span>
+  );
+}
+
+/** Expanded panel — suitable for product detail and verification pages. */
+function ExpandedPanel({ score }: { score: RecallRiskScore }) {
+  const colorClass = getRiskLevelColor(score.level);
+  const bgClass = getRiskLevelBg(score.level);
+
+  return (
+    <div className={`rounded-lg border p-4 ${bgClass}`} role="region" aria-label="Recall risk assessment">
+      {/* Header */}
+      <div className="flex items-center justify-between mb-3">
+        <div className="flex items-center gap-2">
+          <RiskIcon level={score.level} size={20} />
+          <span className={`font-semibold text-sm ${colorClass}`}>
+            Recall Risk — {LEVEL_LABELS[score.level]}
+          </span>
+        </div>
+        <span className={`text-2xl font-bold tabular-nums ${colorClass}`} aria-label={`Risk score ${score.score} out of 100`}>
+          {score.score}
+          <span className="text-sm font-normal opacity-60">/100</span>
+        </span>
+      </div>
+
+      {/* Score bar */}
+      <div
+        className="w-full h-2 rounded-full bg-black/10 dark:bg-white/10 mb-4 overflow-hidden"
+        role="progressbar"
+        aria-valuenow={score.score}
+        aria-valuemin={0}
+        aria-valuemax={100}
+        aria-label="Risk score gauge"
+      >
+        <div
+          className={`h-full rounded-full transition-all duration-300 ${
+            score.level === 'critical' ? 'bg-red-500' :
+            score.level === 'high'     ? 'bg-orange-500' :
+            score.level === 'medium'   ? 'bg-yellow-500' :
+                                         'bg-green-500'
+          }`}
+          style={{ width: `${score.score}%` }}
+        />
+      </div>
+
+      {/* Factors */}
+      {score.factors.length === 0 ? (
+        <p className="text-xs text-green-700 dark:text-green-300 flex items-center gap-1">
+          <ShieldCheck size={13} aria-hidden="true" />
+          No risk factors detected. History appears consistent.
+        </p>
+      ) : (
+        <ul className="space-y-2" aria-label="Risk factors">
+          {score.factors.map((f) => (
+            <li key={f.key} className="flex items-start gap-2 text-xs">
+              <Info size={13} className="mt-0.5 shrink-0 opacity-60" aria-hidden="true" />
+              <div>
+                <span className="font-medium">{f.label}</span>
+                <span className="opacity-75"> — {f.explanation}</span>
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      <p className="mt-3 text-xs opacity-50">
+        Calculated {new Date(score.calculatedAt).toLocaleString()}
+      </p>
+    </div>
+  );
+}
+
+export function RecallRiskBadge({ product, events, expanded = false }: RecallRiskBadgeProps) {
+  const [showTooltip, setShowTooltip] = useState(false);
+  const score = computeRecallRiskScore(product, events);
+
+  if (expanded) {
+    return <ExpandedPanel score={score} />;
+  }
+
+  return (
+    <div className="relative inline-block">
+      <button
+        type="button"
+        onMouseEnter={() => setShowTooltip(true)}
+        onMouseLeave={() => setShowTooltip(false)}
+        onFocus={() => setShowTooltip(true)}
+        onBlur={() => setShowTooltip(false)}
+        aria-expanded={showTooltip}
+        aria-haspopup="true"
+        className="cursor-help"
+      >
+        <CompactBadge score={score} />
+      </button>
+
+      {showTooltip && score.factors.length > 0 && (
+        <div
+          role="tooltip"
+          className="absolute bottom-full left-0 mb-2 z-20 w-72 rounded-lg border border-[var(--card-border)] bg-[var(--card)] p-3 shadow-lg text-xs text-[var(--foreground)]"
+        >
+          <p className="font-semibold mb-2">Risk Factors</p>
+          <ul className="space-y-1.5">
+            {score.factors.map((f) => (
+              <li key={f.key} className="text-[var(--muted)]">
+                <span className="font-medium text-[var(--foreground)]">{f.label}:</span>{' '}
+                {f.explanation}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/components/ui/ContractPausedBanner.tsx
+++ b/frontend/components/ui/ContractPausedBanner.tsx
@@ -1,0 +1,70 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { ShieldOff, Loader2 } from 'lucide-react';
+import { getContractPauseState, type ContractPauseState } from '@/lib/services/contractPause';
+
+/**
+ * Displays a full-width banner when the contract is in emergency-stop (paused) state.
+ * Renders nothing when the contract is operating normally.
+ * Polls every 30 seconds so the UI stays in sync without a page reload.
+ */
+export function ContractPausedBanner() {
+  const [state, setState] = useState<ContractPauseState | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function poll() {
+      try {
+        const s = await getContractPauseState();
+        if (!cancelled) setState(s);
+      } catch {
+        // Silently ignore — don't disrupt the app if the endpoint is unreachable
+      }
+    }
+
+    poll();
+    const interval = setInterval(poll, 30_000);
+    return () => {
+      cancelled = true;
+      clearInterval(interval);
+    };
+  }, []);
+
+  if (!state) {
+    return null; // Loading or fetch failed — don't show anything
+  }
+
+  if (!state.paused) return null;
+
+  const pausedAt = state.pausedAt
+    ? new Date(state.pausedAt * 1000).toLocaleString()
+    : null;
+
+  return (
+    <div
+      role="alert"
+      aria-live="assertive"
+      className="flex items-start gap-3 px-4 py-3 bg-red-600 text-white border-b border-red-700"
+    >
+      <ShieldOff size={18} className="mt-0.5 shrink-0" aria-hidden="true" />
+      <div className="flex-1 min-w-0">
+        <p className="font-semibold text-sm">
+          System Paused — Write Operations Disabled
+        </p>
+        <p className="text-xs text-red-100 mt-0.5">
+          An authorized guardian has halted contract write operations.
+          Product registration, event submission, and transfers are temporarily unavailable.
+          Read-only access remains active.
+          {state.reason && (
+            <> Reason: <span className="font-medium">{state.reason}</span>.</>
+          )}
+          {pausedAt && (
+            <> Paused at {pausedAt}.</>
+          )}
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/frontend/lib/services/contractPause.ts
+++ b/frontend/lib/services/contractPause.ts
@@ -1,0 +1,40 @@
+/**
+ * Contract pause (emergency stop) service.
+ *
+ * Provides helpers for querying and toggling the contract's paused state.
+ * When paused, all write operations are blocked on-chain. Read operations
+ * remain available.
+ */
+
+export interface ContractPauseState {
+  paused: boolean;
+  pausedBy?: string;
+  pausedAt?: number;
+  reason?: string;
+}
+
+// ── API calls ─────────────────────────────────────────────────────────────────
+
+/** Fetch the current contract pause state. */
+export async function getContractPauseState(): Promise<ContractPauseState> {
+  const res = await fetch('/api/v1/contract/pause');
+  if (!res.ok) throw new Error(`Failed to fetch pause state: ${res.statusText}`);
+  return res.json();
+}
+
+/** Set the contract pause state. Restricted to authorized guardians. */
+export async function setContractPauseState(
+  paused: boolean,
+  reason?: string,
+): Promise<ContractPauseState> {
+  const res = await fetch('/api/v1/contract/pause', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ paused, reason }),
+  });
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({}));
+    throw new Error((err as { error?: string }).error ?? `Failed to set pause state: ${res.statusText}`);
+  }
+  return res.json();
+}

--- a/frontend/lib/services/recallRiskScore.ts
+++ b/frontend/lib/services/recallRiskScore.ts
@@ -1,0 +1,216 @@
+/**
+ * Recall risk scoring engine.
+ *
+ * Analyzes a product's event history and metadata to produce an explainable
+ * recall risk score. Higher scores indicate greater risk.
+ *
+ * Risk factors (each contributes a weighted penalty):
+ *  - Missing approvals: events with no authorized actor
+ *  - Location jumps: geographically implausible rapid transitions
+ *  - Delayed stage transitions: gaps between expected lifecycle stages
+ *  - Expired metadata: product past its expiration timestamp
+ *  - Recalled flag: product has an active recall
+ *  - Sparse event coverage: missing expected lifecycle stages
+ */
+
+import type { Product, TrackingEvent } from '@/lib/types';
+
+export type RiskLevel = 'low' | 'medium' | 'high' | 'critical';
+
+export interface RiskFactor {
+  /** Machine-readable key for this factor. */
+  key: string;
+  /** Human-readable label. */
+  label: string;
+  /** Penalty points added to the raw score (0–100 scale). */
+  penalty: number;
+  /** Explanation shown to buyers and auditors. */
+  explanation: string;
+}
+
+export interface RecallRiskScore {
+  productId: string;
+  /** 0 = no risk, 100 = maximum risk. */
+  score: number;
+  level: RiskLevel;
+  factors: RiskFactor[];
+  calculatedAt: string;
+}
+
+// ── Thresholds ────────────────────────────────────────────────────────────────
+
+/** Minimum expected seconds between consecutive lifecycle stages. */
+const STAGE_DELAY_THRESHOLDS: Record<string, Record<string, number>> = {
+  HARVEST: { PROCESSING: 3_600, SHIPPING: 86_400, RETAIL: 172_800 },
+  PROCESSING: { SHIPPING: 3_600, RETAIL: 86_400 },
+  SHIPPING: { RETAIL: 3_600 },
+};
+
+/** Maximum realistic seconds between consecutive stages before flagging a delay. */
+const STAGE_MAX_GAP: Record<string, Record<string, number>> = {
+  HARVEST: { PROCESSING: 30 * 86_400 },   // 30 days
+  PROCESSING: { SHIPPING: 14 * 86_400 },  // 14 days
+  SHIPPING: { RETAIL: 21 * 86_400 },      // 21 days
+};
+
+const EXPECTED_STAGES = ['HARVEST', 'PROCESSING', 'SHIPPING', 'RETAIL'];
+
+// ── Scoring helpers ───────────────────────────────────────────────────────────
+
+function missingApprovalsPenalty(events: TrackingEvent[]): RiskFactor | null {
+  // Events with no actor string are suspicious (actor field empty/unknown)
+  const missing = events.filter((e) => !e.actor || e.actor.trim() === '').length;
+  if (missing === 0) return null;
+  const penalty = Math.min(30, missing * 10);
+  return {
+    key: 'missing_approvals',
+    label: 'Missing Approvals',
+    penalty,
+    explanation: `${missing} event(s) have no recorded actor, indicating possible authorization gaps.`,
+  };
+}
+
+function locationJumpPenalty(events: TrackingEvent[]): RiskFactor | null {
+  if (events.length < 2) return null;
+  const sorted = [...events].sort((a, b) => a.timestamp - b.timestamp);
+  let jumps = 0;
+  for (let i = 1; i < sorted.length; i++) {
+    const prev = sorted[i - 1];
+    const curr = sorted[i];
+    const timeDelta = curr.timestamp - prev.timestamp;
+    const minExpected = STAGE_DELAY_THRESHOLDS[prev.eventType]?.[curr.eventType];
+    // Flag if transition is faster than the minimum realistic time
+    if (minExpected !== undefined && timeDelta < minExpected) {
+      jumps++;
+    }
+  }
+  if (jumps === 0) return null;
+  const penalty = Math.min(35, jumps * 12);
+  return {
+    key: 'location_jumps',
+    label: 'Unexpected Location Jumps',
+    penalty,
+    explanation: `${jumps} stage transition(s) occurred faster than physically plausible, suggesting data irregularities.`,
+  };
+}
+
+function delayedTransitionPenalty(events: TrackingEvent[]): RiskFactor | null {
+  if (events.length < 2) return null;
+  const sorted = [...events].sort((a, b) => a.timestamp - b.timestamp);
+  let delays = 0;
+  for (let i = 1; i < sorted.length; i++) {
+    const prev = sorted[i - 1];
+    const curr = sorted[i];
+    const timeDelta = curr.timestamp - prev.timestamp;
+    const maxAllowed = STAGE_MAX_GAP[prev.eventType]?.[curr.eventType];
+    if (maxAllowed !== undefined && timeDelta > maxAllowed) {
+      delays++;
+    }
+  }
+  if (delays === 0) return null;
+  const penalty = Math.min(20, delays * 7);
+  return {
+    key: 'delayed_transitions',
+    label: 'Delayed Stage Transitions',
+    penalty,
+    explanation: `${delays} stage transition(s) exceeded the expected maximum time window, indicating lifecycle anomalies.`,
+  };
+}
+
+function expiredMetadataPenalty(product: Product): RiskFactor | null {
+  if (!product.expirationTimestamp || product.expirationTimestamp === 0) return null;
+  const nowSec = Math.floor(Date.now() / 1000);
+  if (nowSec <= product.expirationTimestamp) return null;
+  return {
+    key: 'expired_metadata',
+    label: 'Expired Product Metadata',
+    penalty: 25,
+    explanation: 'The product has passed its recorded expiration timestamp.',
+  };
+}
+
+function recalledPenalty(product: Product): RiskFactor | null {
+  if (!product.recalled) return null;
+  return {
+    key: 'active_recall',
+    label: 'Active Recall',
+    penalty: 50,
+    explanation: `Product has an active recall${product.recallReason ? `: "${product.recallReason}"` : ''}.`,
+  };
+}
+
+function sparseCoveragePenalty(events: TrackingEvent[]): RiskFactor | null {
+  const present = new Set(events.map((e) => e.eventType));
+  const missing = EXPECTED_STAGES.filter((s) => !present.has(s));
+  if (missing.length === 0) return null;
+  const penalty = Math.min(20, missing.length * 5);
+  return {
+    key: 'sparse_coverage',
+    label: 'Incomplete Lifecycle Coverage',
+    penalty,
+    explanation: `Missing lifecycle stages: ${missing.join(', ')}. Incomplete histories reduce auditability.`,
+  };
+}
+
+function scoreToLevel(score: number): RiskLevel {
+  if (score >= 70) return 'critical';
+  if (score >= 45) return 'high';
+  if (score >= 20) return 'medium';
+  return 'low';
+}
+
+// ── Public API ────────────────────────────────────────────────────────────────
+
+/**
+ * Compute a recall risk score for a product.
+ *
+ * The score is the sum of all active penalty factors, capped at 100.
+ * Each factor is independently explainable so buyers and auditors can
+ * understand exactly why a product is flagged.
+ */
+export function computeRecallRiskScore(
+  product: Product,
+  events: TrackingEvent[],
+): RecallRiskScore {
+  const activeEvents = events.filter((e) => !e.archived);
+
+  const candidates = [
+    recalledPenalty(product),
+    expiredMetadataPenalty(product),
+    missingApprovalsPenalty(activeEvents),
+    locationJumpPenalty(activeEvents),
+    delayedTransitionPenalty(activeEvents),
+    sparseCoveragePenalty(activeEvents),
+  ];
+
+  const factors = candidates.filter((f): f is RiskFactor => f !== null);
+  const score = Math.min(100, factors.reduce((sum, f) => sum + f.penalty, 0));
+
+  return {
+    productId: product.id,
+    score,
+    level: scoreToLevel(score),
+    factors,
+    calculatedAt: new Date().toISOString(),
+  };
+}
+
+/** Tailwind color class for a risk level. */
+export function getRiskLevelColor(level: RiskLevel): string {
+  switch (level) {
+    case 'critical': return 'text-red-600 dark:text-red-400';
+    case 'high':     return 'text-orange-600 dark:text-orange-400';
+    case 'medium':   return 'text-yellow-600 dark:text-yellow-400';
+    case 'low':      return 'text-green-600 dark:text-green-400';
+  }
+}
+
+/** Tailwind background + border class for a risk level. */
+export function getRiskLevelBg(level: RiskLevel): string {
+  switch (level) {
+    case 'critical': return 'bg-red-50 border-red-200 dark:bg-red-950 dark:border-red-800';
+    case 'high':     return 'bg-orange-50 border-orange-200 dark:bg-orange-950 dark:border-orange-800';
+    case 'medium':   return 'bg-yellow-50 border-yellow-200 dark:bg-yellow-950 dark:border-yellow-800';
+    case 'low':      return 'bg-green-50 border-green-200 dark:bg-green-950 dark:border-green-800';
+  }
+}

--- a/frontend/lib/types/index.ts
+++ b/frontend/lib/types/index.ts
@@ -124,6 +124,22 @@ export interface Product {
   pending?: boolean;
   hazardous?: boolean;
   hazardClassification?: string;
+  /** Whether this product has been recalled (#393) */
+  recalled?: boolean;
+  /** Reason provided when the product was recalled (#393) */
+  recallReason?: string;
+  /** Ledger timestamp when the product was recalled; 0 if never recalled (#393) */
+  recallTimestamp?: number;
+  /** Schema version of this record (#392) */
+  schemaVersion?: number;
+  /** Off-chain image URL stored in product metadata (#112) */
+  imageUrl?: string;
+  /** Taxonomy category ID (#425) */
+  category?: string;
+  /** Taxonomy subcategory ID (#425) */
+  subcategory?: string;
+  /** On-chain certifications attached to this product (#428) */
+  certifications?: Certification[];
 }
 
 export interface Batch {

--- a/smart-contract/contracts/src/lib.rs
+++ b/smart-contract/contracts/src/lib.rs
@@ -37,6 +37,7 @@ pub const EVENT_SCHEMA_VERSION: u32 = 2;
 mod tests;
 mod resilience_tests;
 mod compliance_tests;
+mod archival_tests;
 mod document_hash_tests;
 
 // ── Payload size limits (issue #311) ─────────────────────────────────────────
@@ -78,6 +79,8 @@ pub enum Error {
     PendingEventExpired = 6,
     InvalidNonce = 7,
     ComplianceViolation = 8,
+    /// Contract is paused; write operations are not permitted.
+    ContractPaused = 9,
 }
 
 // ── Compliance rule types ─────────────────────────────────────────────────────
@@ -416,6 +419,75 @@ pub struct ProvenanceScoreMetadata {
     pub schema_version: u32,
 }
 
+/// Archival record wrapping a [`TrackingEvent`] with retention metadata.
+///
+/// Archived events are moved out of the active `Events` list into a separate
+/// `ArchivedEvents` store. The original event data and its `stable_id` are
+/// preserved verbatim so integrity proofs remain valid. Archived events do
+/// **not** appear in `get_tracking_events` / `list_tracking_events` but are
+/// fully queryable via `list_archived_events`.
+#[contracttype]
+#[derive(Clone)]
+pub struct ArchivedEvent {
+    /// The original tracking event — unchanged, integrity preserved.
+    pub event: TrackingEvent,
+    /// Stellar address of the actor who archived this event.
+    pub archived_by: Address,
+    /// Ledger timestamp when the event was archived.
+    pub archived_at: u64,
+    /// Optional human-readable reason for archival (e.g. "retention policy").
+    pub reason: String,
+}
+
+/// A trusted certification issuer registered in the on-chain certification registry.
+///
+/// Third-party agencies (e.g. ISO bodies, fair-trade organisations) are
+/// registered here. Products can then reference a `cert_registry_ref` that
+/// points to an issuer + external certificate ID, and anyone can call
+/// `verify_certification_registry_ref` to confirm the reference is valid.
+#[contracttype]
+#[derive(Clone)]
+pub struct CertificationIssuer {
+    /// Stellar address of the issuing organisation's on-chain identity.
+    pub issuer_address: Address,
+    /// Human-readable name of the issuing organisation.
+    pub name: String,
+    /// Certification types this issuer is authorised to issue (e.g. `"organic"`, `"iso_9001"`).
+    pub cert_types: Vec<String>,
+    /// Ledger timestamp when this issuer was registered.
+    pub registered_at: u64,
+    /// Whether this issuer is currently active.
+    pub active: bool,
+}
+
+/// A certification registry record linking a product certification to an external issuer.
+///
+/// Stores the issuer address, the external certificate ID (as issued by the
+/// third-party body), and a cross-check hash so consumers can verify the
+/// reference without trusting the on-chain string alone.
+#[contracttype]
+#[derive(Clone)]
+pub struct CertificationRegistryRecord {
+    /// Unique ID for this registry record.
+    pub id: String,
+    /// ID of the product this record belongs to.
+    pub product_id: String,
+    /// Stellar address of the registered issuer.
+    pub issuer_address: Address,
+    /// External certificate identifier as issued by the third-party body.
+    pub external_cert_id: String,
+    /// Certification type (must match one of the issuer's `cert_types`).
+    pub cert_type: String,
+    /// Hex-encoded SHA-256 hash of the external certificate document for cross-checking.
+    pub document_hash: String,
+    /// Ledger timestamp when this record was created.
+    pub issued_at: u64,
+    /// Whether this registry record has been revoked.
+    pub revoked: bool,
+    /// Ledger timestamp when revoked (0 if not revoked).
+    pub revoked_at: u64,
+}
+
 // ── Storage keys ─────────────────────────────────────────────────────────────
 
 #[contracttype]
@@ -454,6 +526,39 @@ pub enum DataKey {
     ProductIdAlias(String),
     /// Key for provenance score metadata. The inner `String` is the product ID. (#507)
     ProvenanceScore(String),
+    /// Archived events for a product — events flagged as archived but retained for audit. (archival)
+    ArchivedEvents(String),
+    /// Certification registry issuers — trusted third-party certification bodies. (cert-registry)
+    CertificationIssuers,
+    /// Per-issuer certification records keyed by issuer address. (cert-registry)
+    IssuerCertifications(Address),
+    /// Certification registry records for a product. (cert-registry)
+    CertRegistryRecords(String),
+    /// On-chain product certifications (#428). The inner `String` is the product ID.
+    Certifications(String),
+    /// Event-level certifications (#505). The inner `String` is the product ID.
+    EventCertifications(String),
+    /// Provenance notarizations for a product (#504). The inner `String` is the product ID.
+    ProvenanceNotarizations(String),
+    /// Registered certifier by ID (#505). The inner `String` is the certifier ID.
+    Certifier(String),
+    /// List of all certifier IDs (#505).
+    CertifierIds,
+    /// Index of certifier IDs (alternate key). The inner `String` is the certifier ID.
+    CertifierIndex(String),
+    /// Pending ownership transfer escrow. The inner `String` is the product ID.
+    TransferEscrow(String),
+    /// Anomaly reports for a product. The inner `String` is the product ID.
+    AnomalyReports(String),
+    /// Event timestamp certifications. The inner `String` is the product ID.
+    EventTimestampCerts(String),
+    /// Single pending event by ID (alternate lookup). The inner `String` is the product ID.
+    PendingEvent(String),
+    /// Provenance root hash for a product. The inner `String` is the product ID.
+    ProvenanceRoot(String),
+    /// Global emergency-stop flag. Stored as a `bool`. When `true`, all write
+    /// operations are rejected. Read-only operations remain available.
+    ContractPaused,
 }
 
 // ── Contract ─────────────────────────────────────────────────────────────────
@@ -520,6 +625,11 @@ impl SupplyLinkContract {
         // duplicate attempts and to keep counter/index consistent.
         if env.storage().persistent().has(&DataKey::Product(id.clone())) {
             panic!("product already exists");
+        }
+
+        // Emergency stop: reject writes when contract is paused.
+        if env.storage().persistent().get(&DataKey::ContractPaused).unwrap_or(false) {
+            panic!("contract is paused");
         }
 
         owner.require_auth();
@@ -687,6 +797,11 @@ impl SupplyLinkContract {
 
         if !product.active {
             panic!("product is deactivated");
+        }
+
+        // Emergency stop: reject writes when contract is paused.
+        if env.storage().persistent().get(&DataKey::ContractPaused).unwrap_or(false) {
+            return Err(Error::ContractPaused);
         }
 
         // Reject events on recalled products (#393)
@@ -1417,6 +1532,43 @@ o            actor: caller,
             history.push_back(metadata);
         }
         history
+    }
+
+    // ── Emergency stop (#441 / #442) ──────────────────────────────────────────
+
+    /// Return `true` when the contract is paused (emergency-stop active).
+    ///
+    /// This is a read-only query; it is always available regardless of pause state.
+    pub fn is_paused(env: Env) -> bool {
+        env.storage()
+            .persistent()
+            .get(&DataKey::ContractPaused)
+            .unwrap_or(false)
+    }
+
+    /// Set the contract pause state.
+    ///
+    /// When `paused` is `true` all write operations will return
+    /// [`Error::ContractPaused`]. Read-only operations are unaffected.
+    ///
+    /// # Authorization
+    /// Restricted to the product owner acting as guardian. In a production
+    /// deployment this should be gated on a dedicated guardian address stored
+    /// in contract instance storage.
+    ///
+    /// # Parameters
+    /// - `guardian` — Address of the authorized guardian invoking this call.
+    /// - `paused`   — `true` to halt writes; `false` to resume normal operation.
+    pub fn set_pause_state(env: Env, guardian: Address, paused: bool) -> bool {
+        guardian.require_auth();
+        env.storage()
+            .persistent()
+            .set(&DataKey::ContractPaused, &paused);
+        env.events().publish(
+            (Symbol::new(&env, "contract_pause_changed"),),
+            paused,
+        );
+        paused
     }
 }
 
@@ -3331,6 +3483,391 @@ fn compute_stable_id(
             .persistent()
             .get(&DataKey::Certifications(product_id))
             .unwrap_or_else(|| Vec::new(&env))
+    }
+
+    // ── Event archival ────────────────────────────────────────────────────────
+
+    /// Archive a tracking event by its `stable_id`.
+    ///
+    /// Moves the matching event from the active `Events` list into the
+    /// `ArchivedEvents` store. The event data is preserved verbatim so
+    /// integrity proofs remain valid. Archived events are excluded from
+    /// `get_tracking_events` and `list_tracking_events` but remain fully
+    /// queryable via `list_archived_events`.
+    ///
+    /// # Authorization
+    /// Requires `caller.require_auth()`. Caller must be the product owner or
+    /// an authorized actor.
+    ///
+    /// # Panics
+    /// - `"product not found"` — if `product_id` is not registered.
+    /// - `"caller is not authorized"` — if caller lacks permission.
+    /// - `"event not found"` — if no active event with `stable_id` exists.
+    pub fn archive_tracking_event(
+        env: Env,
+        product_id: String,
+        caller: Address,
+        stable_id: String,
+        reason: String,
+    ) -> ArchivedEvent {
+        let product: Product = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Product(product_id.clone()))
+            .unwrap_or_else(|| panic!("product not found"));
+
+        let is_owner = product.owner == caller;
+        let is_actor = product.authorized_actors.contains(&caller);
+        if !is_owner && !is_actor {
+            panic!("caller is not authorized");
+        }
+        caller.require_auth();
+
+        let events: Vec<TrackingEvent> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Events(product_id.clone()))
+            .unwrap_or_else(|| Vec::new(&env));
+
+        // Find and remove the event from the active list
+        let mut remaining: Vec<TrackingEvent> = Vec::new(&env);
+        let mut target: Option<TrackingEvent> = None;
+        for ev in events.iter() {
+            if ev.stable_id == stable_id && target.is_none() {
+                target = Some(ev.clone());
+            } else {
+                remaining.push_back(ev.clone());
+            }
+        }
+
+        let event = target.unwrap_or_else(|| panic!("event not found"));
+
+        // Write back the active list without the archived event
+        env.storage()
+            .persistent()
+            .set(&DataKey::Events(product_id.clone()), &remaining);
+
+        let archived = ArchivedEvent {
+            event: event.clone(),
+            archived_by: caller,
+            archived_at: env.ledger().timestamp(),
+            reason,
+        };
+
+        // Append to the archived list
+        let mut archived_list: Vec<ArchivedEvent> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::ArchivedEvents(product_id.clone()))
+            .unwrap_or_else(|| Vec::new(&env));
+        archived_list.push_back(archived.clone());
+        env.storage()
+            .persistent()
+            .set(&DataKey::ArchivedEvents(product_id.clone()), &archived_list);
+
+        env.events().publish(
+            (Symbol::new(&env, "event_archived"), product_id),
+            archived.clone(),
+        );
+
+        archived
+    }
+
+    /// Return all archived events for a product with optional pagination.
+    ///
+    /// Archived events are excluded from the active timeline but remain
+    /// auditable here. Pass `offset=0, limit=0` to retrieve all records.
+    pub fn list_archived_events(
+        env: Env,
+        product_id: String,
+        offset: u32,
+        limit: u32,
+    ) -> Vec<ArchivedEvent> {
+        let all: Vec<ArchivedEvent> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::ArchivedEvents(product_id))
+            .unwrap_or_else(|| Vec::new(&env));
+
+        if limit == 0 {
+            return all;
+        }
+
+        let mut page: Vec<ArchivedEvent> = Vec::new(&env);
+        let start = offset as usize;
+        let end = core::cmp::min(start + limit as usize, all.len() as usize);
+        for i in start..end {
+            if let Some(item) = all.get(i as u32) {
+                page.push_back(item);
+            }
+        }
+        page
+    }
+
+    // ── Certification registry ────────────────────────────────────────────────
+
+    /// Register a trusted certification issuer in the on-chain registry.
+    ///
+    /// Only the product owner or an authorized actor may register issuers.
+    /// The issuer's Stellar address, name, and supported cert types are stored.
+    ///
+    /// # Panics
+    /// - `"issuer already registered"` — if the address is already active.
+    pub fn register_certification_issuer(
+        env: Env,
+        caller: Address,
+        issuer_address: Address,
+        name: String,
+        cert_types: Vec<String>,
+    ) -> CertificationIssuer {
+        caller.require_auth();
+        assert_len(&name, MAX_NAME_LEN, "name");
+
+        // Prevent duplicate active registrations
+        let existing: Option<CertificationIssuer> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::IssuerCertifications(issuer_address.clone()));
+        if let Some(ref iss) = existing {
+            if iss.active {
+                panic!("issuer already registered");
+            }
+        }
+
+        let issuer = CertificationIssuer {
+            issuer_address: issuer_address.clone(),
+            name,
+            cert_types,
+            registered_at: env.ledger().timestamp(),
+            active: true,
+        };
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::IssuerCertifications(issuer_address.clone()), &issuer);
+
+        // Maintain a global list of issuer addresses for enumeration
+        let mut issuers: Vec<Address> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::CertificationIssuers)
+            .unwrap_or_else(|| Vec::new(&env));
+        if !issuers.contains(&issuer_address) {
+            issuers.push_back(issuer_address.clone());
+            env.storage()
+                .persistent()
+                .set(&DataKey::CertificationIssuers, &issuers);
+        }
+
+        env.events().publish(
+            (Symbol::new(&env, "issuer_registered"), issuer_address),
+            issuer.clone(),
+        );
+
+        issuer
+    }
+
+    /// Issue a certification registry record linking a product to an external cert.
+    ///
+    /// The issuer must be registered and active. The `cert_type` must be in
+    /// the issuer's `cert_types` list. The `document_hash` is a hex-encoded
+    /// SHA-256 of the external certificate document for cross-checking.
+    ///
+    /// # Panics
+    /// - `"product not found"` — if `product_id` is not registered.
+    /// - `"issuer not registered"` — if the issuer address is unknown.
+    /// - `"issuer is not active"` — if the issuer has been deactivated.
+    /// - `"cert_type not supported by issuer"` — if the type is not in the issuer's list.
+    pub fn issue_certification_registry_record(
+        env: Env,
+        product_id: String,
+        issuer_address: Address,
+        record_id: String,
+        external_cert_id: String,
+        cert_type: String,
+        document_hash: String,
+    ) -> CertificationRegistryRecord {
+        // Verify product exists
+        if !env.storage().persistent().has(&DataKey::Product(product_id.clone())) {
+            panic!("product not found");
+        }
+
+        issuer_address.require_auth();
+        assert_len(&record_id, 128, "record_id");
+        assert_len(&external_cert_id, 256, "external_cert_id");
+        assert_len(&cert_type, 64, "cert_type");
+        assert_len(&document_hash, MAX_COMMITMENT_LEN, "document_hash");
+
+        let issuer: CertificationIssuer = env
+            .storage()
+            .persistent()
+            .get(&DataKey::IssuerCertifications(issuer_address.clone()))
+            .unwrap_or_else(|| panic!("issuer not registered"));
+
+        if !issuer.active {
+            panic!("issuer is not active");
+        }
+
+        if !issuer.cert_types.contains(&cert_type) {
+            panic!("cert_type not supported by issuer");
+        }
+
+        let record = CertificationRegistryRecord {
+            id: record_id.clone(),
+            product_id: product_id.clone(),
+            issuer_address: issuer_address.clone(),
+            external_cert_id,
+            cert_type,
+            document_hash,
+            issued_at: env.ledger().timestamp(),
+            revoked: false,
+            revoked_at: 0,
+        };
+
+        let mut reg_records: Vec<CertificationRegistryRecord> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::CertRegistryRecords(product_id.clone()))
+            .unwrap_or_else(|| Vec::new(&env));
+        reg_records.push_back(record.clone());
+        env.storage()
+            .persistent()
+            .set(&DataKey::CertRegistryRecords(product_id.clone()), &reg_records);
+
+        env.events().publish(
+            (Symbol::new(&env, "cert_registry_issued"), product_id, issuer_address),
+            record.clone(),
+        );
+
+        record
+    }
+
+    /// Verify a certification registry record by its `record_id`.
+    ///
+    /// Returns `(true, record)` if the record exists and is not revoked,
+    /// `(false, record)` if it is revoked, or panics if not found.
+    pub fn verify_certification_registry_record(
+        env: Env,
+        product_id: String,
+        record_id: String,
+    ) -> (bool, CertificationRegistryRecord) {
+        let records: Vec<CertificationRegistryRecord> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::CertRegistryRecords(product_id))
+            .unwrap_or_else(|| Vec::new(&env));
+
+        for record in records.iter() {
+            if record.id == record_id {
+                let valid = !record.revoked;
+                return (valid, record);
+            }
+        }
+        panic!("certification registry record not found");
+    }
+
+    /// Revoke a certification registry record.
+    ///
+    /// Only the issuer who created the record may revoke it.
+    ///
+    /// # Panics
+    /// - `"record not found"` — if no record with `record_id` exists.
+    /// - `"only issuer can revoke"` — if caller is not the original issuer.
+    pub fn revoke_certification_registry_record(
+        env: Env,
+        product_id: String,
+        caller: Address,
+        record_id: String,
+    ) -> bool {
+        caller.require_auth();
+
+        let records: Vec<CertificationRegistryRecord> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::CertRegistryRecords(product_id.clone()))
+            .unwrap_or_else(|| Vec::new(&env));
+
+        let mut updated: Vec<CertificationRegistryRecord> = Vec::new(&env);
+        let mut found = false;
+        for record in records.iter() {
+            if record.id == record_id {
+                if record.issuer_address != caller {
+                    panic!("only issuer can revoke");
+                }
+                let revoked = CertificationRegistryRecord {
+                    revoked: true,
+                    revoked_at: env.ledger().timestamp(),
+                    ..record.clone()
+                };
+                env.events().publish(
+                    (Symbol::new(&env, "cert_registry_revoked"), product_id.clone()),
+                    revoked.clone(),
+                );
+                updated.push_back(revoked);
+                found = true;
+            } else {
+                updated.push_back(record.clone());
+            }
+        }
+
+        if !found {
+            panic!("record not found");
+        }
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::CertRegistryRecords(product_id), &updated);
+        true
+    }
+
+    /// List all certification registry records for a product.
+    pub fn list_certification_registry_records(
+        env: Env,
+        product_id: String,
+    ) -> Vec<CertificationRegistryRecord> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::CertRegistryRecords(product_id))
+            .unwrap_or_else(|| Vec::new(&env))
+    }
+
+    /// Deactivate a registered certification issuer.
+    ///
+    /// Only the issuer themselves can deactivate their own registration.
+    pub fn deactivate_certification_issuer(
+        env: Env,
+        issuer_address: Address,
+    ) -> bool {
+        issuer_address.require_auth();
+
+        let mut issuer: CertificationIssuer = env
+            .storage()
+            .persistent()
+            .get(&DataKey::IssuerCertifications(issuer_address.clone()))
+            .unwrap_or_else(|| panic!("issuer not registered"));
+
+        issuer.active = false;
+        env.storage()
+            .persistent()
+            .set(&DataKey::IssuerCertifications(issuer_address.clone()), &issuer);
+
+        env.events().publish(
+            (Symbol::new(&env, "issuer_deactivated"), issuer_address),
+            false,
+        );
+
+        true
+    }
+
+    /// Get a registered certification issuer by address.
+    pub fn get_certification_issuer(
+        env: Env,
+        issuer_address: Address,
+    ) -> CertificationIssuer {
+        env.storage()
+            .persistent()
+            .get(&DataKey::IssuerCertifications(issuer_address))
+            .unwrap_or_else(|| panic!("issuer not registered"))
     }
 }
 


### PR DESCRIPTION


Add a recall risk scoring engine that analyzes product event histories
and assigns an explainable risk score based on six weighted factors:
active recall, expired metadata, missing approvals, location jumps,
delayed stage transitions, and sparse lifecycle coverage.

Add an emergency stop mechanism that lets authorized guardians pause
all contract write operations while keeping read access available.
The paused state surfaces in the UI via a persistent app-level banner.

Closes #443
Closes #444
