### PR TITLE
Enhance event trust and provenance scoring features with actor reputa…

### DIFF
--- a/frontend/__tests__/eventTrust.test.ts
+++ b/frontend/__tests__/eventTrust.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from 'vitest';
+import type { TrackingEvent } from '@/lib/types';
+import {
+  calculateActorReputations,
+  calculateEventTrust,
+  averageActorTrustWeight,
+} from '@/lib/services/eventTrust';
+import { calculateProvenanceScore } from '@/lib/utils/provenanceScore';
+
+function makeEvent(overrides: Partial<TrackingEvent> = {}): TrackingEvent {
+  return {
+    productId: 'prod-001',
+    location: 'Warehouse A',
+    actor: 'GACTOR123',
+    timestamp: 1710000000,
+    eventType: 'PROCESSING',
+    metadata: JSON.stringify({ approved: true, batch: 'B1' }),
+    stableId: 'evt-001',
+    ...overrides,
+  };
+}
+
+describe('Event Trust', () => {
+  it('calculates actor reputation from historical events', () => {
+    const events: TrackingEvent[] = [
+      makeEvent({ actor: 'GACTOR123', timestamp: 1710000000 }),
+      makeEvent({ actor: 'GACTOR123', timestamp: 1710003600 }),
+      makeEvent({ actor: 'GACTOR123', timestamp: 1710007200 }),
+    ];
+
+    const reputations = calculateActorReputations(events);
+    expect(reputations).toHaveLength(1);
+    expect(reputations[0].actor).toBe('GACTOR123');
+    expect(reputations[0].trust_weight).toBeGreaterThan(50);
+    expect(reputations[0].approvalCompliance).toBe(100);
+    expect(reputations[0].timelinessScore).toBeGreaterThan(0);
+  });
+
+  it('flags an actor as blacklisted when recall or quality issue metadata exists', () => {
+    const events: TrackingEvent[] = [
+      makeEvent({ actor: 'GACTOR999', metadata: JSON.stringify({ recall: true }) }),
+    ];
+
+    const reputations = calculateActorReputations(events);
+    expect(reputations[0].blacklisted).toBe(true);
+    expect(reputations[0].trust_weight).toBe(0);
+  });
+
+  it('computes event trust from actor reputation and metadata completeness', () => {
+    const events: TrackingEvent[] = [
+      makeEvent({ actor: 'GACTOR123', timestamp: 1710000000 }),
+      makeEvent({ actor: 'GACTOR123', timestamp: 1710003600 }),
+    ];
+
+    const reputations = calculateActorReputations(events);
+    const eventTrust = calculateEventTrust(events[1], reputations[0]);
+
+    expect(eventTrust.actorTrustWeight).toBe(reputations[0].trust_weight);
+    expect(eventTrust.eventTrustWeight).toBeGreaterThanOrEqual(50);
+    expect(eventTrust.status).toMatch(/trusted|neutral|suspicious/);
+  });
+
+  it('includes average actor reputation in provenance scoring', () => {
+    const events: TrackingEvent[] = [
+      makeEvent({ actor: 'GACTOR123', timestamp: 1710000000 }),
+      makeEvent({ actor: 'GACTOR456', timestamp: 1710003600, metadata: JSON.stringify({ approved: false }) }),
+    ];
+
+    const reputations = calculateActorReputations(events);
+    const averageTrust = averageActorTrustWeight(reputations);
+    const scoreWithTrust = calculateProvenanceScore(events, undefined, averageTrust);
+    const scoreWithoutTrust = calculateProvenanceScore(events, undefined, 50);
+
+    expect(scoreWithTrust.actorReputation).toBeGreaterThanOrEqual(0);
+    expect(scoreWithTrust.total).toBeGreaterThanOrEqual(scoreWithoutTrust.total);
+  });
+});

--- a/frontend/components/products/EventTimeline.tsx
+++ b/frontend/components/products/EventTimeline.tsx
@@ -1,8 +1,9 @@
 'use client';
 
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { Archive } from 'lucide-react';
 import type { TrackingEvent, EventType } from '@/lib/types';
+import { calculateActorReputations, calculateEventTrust, getEventTrustBadgeClass } from '@/lib/services/eventTrust';
 import { PrivateMetadataViewer } from './PrivateMetadataViewer';
 
 const DEFAULT_EVENT_LABELS: Record<EventType, string> = {
@@ -48,6 +49,17 @@ export function EventTimeline({
 
   const labelFor = (type: EventType) => labels?.[type] ?? DEFAULT_EVENT_LABELS[type];
   const dateFmt = new Intl.DateTimeFormat(locale, { dateStyle: 'medium', timeStyle: 'short' });
+
+  const eventTrusts = useMemo(() => {
+    const reputations = calculateActorReputations(events);
+    const reputationByActor = new Map(reputations.map((r) => [r.actor, r]));
+    return new Map(
+      events.map((event) => {
+        const trust = calculateEventTrust(event, reputationByActor.get(event.actor));
+        return [event.stableId ?? `${event.actor}-${event.timestamp}`, trust] as const;
+      }),
+    );
+  }, [events]);
 
   const activeEvents = hideArchivedByDefault && !showArchived
     ? events.filter((e) => !e.archived)
@@ -110,7 +122,20 @@ export function EventTimeline({
                 )}
               </div>
               <p className="text-sm text-[var(--foreground)]">{event.location}</p>
-              <p className="text-xs text-[var(--muted)] font-mono mt-0.5 truncate">{event.actor}</p>
+              <div className="flex flex-wrap items-center gap-2 mt-1">
+                <p className="text-xs text-[var(--muted)] font-mono truncate">{event.actor}</p>
+                {eventTrusts.get(event.stableId ?? `${event.actor}-${event.timestamp}`) && (
+                  <span
+                    className={`inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[11px] font-medium ${getEventTrustBadgeClass(
+                      eventTrusts.get(event.stableId ?? `${event.actor}-${event.timestamp}`)!.status,
+                    )}`}
+                    title={`Actor trust ${eventTrusts.get(event.stableId ?? `${event.actor}-${event.timestamp}`)!.eventTrustWeight}%`}
+                  >
+                    {eventTrusts.get(event.stableId ?? `${event.actor}-${event.timestamp}`)!.status}
+                    <span className="font-semibold">{eventTrusts.get(event.stableId ?? `${event.actor}-${event.timestamp}`)!.eventTrustWeight}%</span>
+                  </span>
+                )}
+              </div>
               {(event as TrackingEvent & { privateMetadata?: boolean; metadataCommitment?: string }).privateMetadata &&
               (event as TrackingEvent & { metadataCommitment?: string }).metadataCommitment ? (
                 <div className="mt-2">

--- a/frontend/components/products/ProvenanceScoreGauge.tsx
+++ b/frontend/components/products/ProvenanceScoreGauge.tsx
@@ -1,7 +1,8 @@
 'use client';
 
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import type { TrackingEvent, Product } from '@/lib/types';
+import { calculateActorReputations, averageActorTrustWeight } from '@/lib/services/eventTrust';
 import {
   calculateProvenanceScore,
   getProvenanceScorePercentage,
@@ -16,7 +17,12 @@ interface Props {
 
 export function ProvenanceScoreGauge({ events, product }: Props) {
   const [showTooltip, setShowTooltip] = useState(false);
-  const breakdown = calculateProvenanceScore(events, product);
+  const actorReputations = useMemo(() => calculateActorReputations(events), [events]);
+  const averageTrust = useMemo(
+    () => averageActorTrustWeight(actorReputations),
+    [actorReputations],
+  );
+  const breakdown = calculateProvenanceScore(events, product, averageTrust);
   const percentage = getProvenanceScorePercentage(breakdown);
   const label = getProvenanceScoreLabel(percentage);
   const colorClass = getProvenanceScoreColor(percentage);
@@ -114,9 +120,15 @@ export function ProvenanceScoreGauge({ events, product }: Props) {
                 {breakdown.authorizedActorDepth}/10
               </span>
             </li>
+            <li>
+              Actor Reputation:{' '}
+              <span className="font-mono text-[var(--foreground)]">
+                {breakdown.actorReputation}/10
+              </span>
+            </li>
           </ul>
           <p className="text-[var(--muted)] mt-2 text-xs">
-            Higher scores indicate more complete and consistent supply chain data.
+            Higher scores indicate more complete, consistent, and trustworthy supply chain data.
           </p>
         </div>
       )}

--- a/frontend/lib/services/eventTrust.ts
+++ b/frontend/lib/services/eventTrust.ts
@@ -1,0 +1,170 @@
+import type { TrackingEvent } from '@/lib/types';
+import { calculateTrustScore, type ActorTrustWeight } from '@/lib/services/trustManagement';
+
+export interface ActorReputation extends ActorTrustWeight {
+  eventsSigned: number;
+  approvalCompliance: number;
+  timelinessScore: number;
+  recallInvolvement: number;
+  invalidMetadataCount: number;
+}
+
+export interface EventTrustScore {
+  eventKey: string;
+  actor: string;
+  actorTrustWeight: number;
+  eventTrustWeight: number;
+  status: 'trusted' | 'neutral' | 'suspicious' | 'blacklisted';
+  reason?: string;
+}
+
+const DEFAULT_TRUST_WEIGHT = 50;
+const MAX_ACTOR_EVENT_BONUS = 30;
+const MAX_APPROVAL_BONUS = 10;
+const MAX_TIMELINESS_BONUS = 15;
+const INVALID_METADATA_PENALTY = 5;
+const RECALL_INVOLVEMENT_PENALTY = 40;
+const TIMELINESS_WINDOW_SECONDS = 7 * 24 * 60 * 60; // 7 days
+
+function parseEventMetadata(event: TrackingEvent): Record<string, unknown> {
+  try {
+    return JSON.parse(event.metadata || '{}');
+  } catch {
+    return {};
+  }
+}
+
+function hasRecallFlag(metadata: Record<string, unknown>): boolean {
+  return metadata.recall === true || metadata.quality_issue === true || metadata.blacklist === true;
+}
+
+function hasApprovalFlag(metadata: Record<string, unknown>): boolean {
+  return metadata.approved === true;
+}
+
+function metadataIsComplete(metadata: Record<string, unknown>): boolean {
+  return Object.keys(metadata).length > 0;
+}
+
+export function calculateActorReputations(events: TrackingEvent[]): ActorReputation[] {
+  const actorMap = new Map<string, TrackingEvent[]>();
+  for (const event of events) {
+    actorMap.set(event.actor, [...(actorMap.get(event.actor) ?? []), event]);
+  }
+
+  const reputations: ActorReputation[] = [];
+  const now = Math.floor(Date.now() / 1000);
+
+  for (const [actor, actorEvents] of actorMap.entries()) {
+    const sortedEvents = [...actorEvents].sort((a, b) => a.timestamp - b.timestamp);
+    let approvedCount = 0;
+    let recallCount = 0;
+    let invalidMetadataCount = 0;
+    let timelyGaps = 0;
+
+    for (let i = 0; i < sortedEvents.length; i += 1) {
+      const metadata = parseEventMetadata(sortedEvents[i]);
+      if (hasApprovalFlag(metadata)) approvedCount += 1;
+      if (hasRecallFlag(metadata)) recallCount += 1;
+      if (!metadataIsComplete(metadata)) invalidMetadataCount += 1;
+
+      if (i > 0) {
+        const gap = sortedEvents[i].timestamp - sortedEvents[i - 1].timestamp;
+        if (gap > 0 && gap <= TIMELINESS_WINDOW_SECONDS) {
+          timelyGaps += 1;
+        }
+      }
+    }
+
+    const eventCount = sortedEvents.length;
+    const eventBonus = Math.min(eventCount * 3, MAX_ACTOR_EVENT_BONUS);
+    const approvalBonus = eventCount > 0 ? Math.min(Math.floor((approvedCount / eventCount) * MAX_APPROVAL_BONUS), MAX_APPROVAL_BONUS) : 0;
+    const timelinessBonus = Math.min(timelyGaps * 3, MAX_TIMELINESS_BONUS);
+
+    let trustWeight = DEFAULT_TRUST_WEIGHT + eventBonus + approvalBonus + timelinessBonus;
+    trustWeight -= invalidMetadataCount * INVALID_METADATA_PENALTY;
+    trustWeight = Math.min(100, Math.max(0, trustWeight));
+
+    const blacklisted = recallCount > 0;
+    const blacklistReason = blacklisted ? 'Recall involvement or quality issue' : '';
+    if (blacklisted) trustWeight = 0;
+
+    reputations.push({
+      actor,
+      trust_weight: trustWeight,
+      blacklisted,
+      blacklist_reason: blacklistReason,
+      last_updated: now,
+      eventsSigned: eventCount,
+      approvalCompliance: eventCount > 0 ? Math.round((approvedCount / eventCount) * 100) : 0,
+      timelinessScore: eventCount > 1 ? Math.min(100, Math.round((timelyGaps / (eventCount - 1)) * 100)) : 0,
+      recallInvolvement: recallCount,
+      invalidMetadataCount,
+    });
+  }
+
+  return reputations.sort((a, b) => b.trust_weight - a.trust_weight);
+}
+
+export function calculateEventTrust(
+  event: TrackingEvent,
+  actorReputation?: ActorReputation,
+): EventTrustScore {
+  const metadata = parseEventMetadata(event);
+  const actorTrustWeight = actorReputation?.trust_weight ?? DEFAULT_TRUST_WEIGHT;
+  const metadataScore = metadataIsComplete(metadata) ? 100 : 50;
+  const consistencyScore = actorReputation?.timelinessScore ?? 50;
+
+  const eventTrustWeight = Math.round(
+    actorTrustWeight * 0.7 + metadataScore * 0.2 + consistencyScore * 0.1,
+  );
+
+  const status = actorReputation?.blacklisted
+    ? 'blacklisted'
+    : eventTrustWeight >= 75
+      ? 'trusted'
+      : eventTrustWeight >= 50
+        ? 'neutral'
+        : 'suspicious';
+
+  const reason = actorReputation?.blacklisted
+    ? actorReputation.blacklist_reason
+    : metadataIsComplete(metadata)
+      ? undefined
+      : 'Event metadata is incomplete';
+
+  return {
+    eventKey: event.stableId ?? `${event.actor}-${event.timestamp}`,
+    actor: event.actor,
+    actorTrustWeight,
+    eventTrustWeight,
+    status,
+    reason,
+  };
+}
+
+export function averageActorTrustWeight(reputations: ActorReputation[]): number {
+  if (reputations.length === 0) return DEFAULT_TRUST_WEIGHT;
+  const total = reputations.reduce((sum, rep) => sum + rep.trust_weight, 0);
+  return Math.round(total / reputations.length);
+}
+
+export function getEventTrustBadgeClass(status: EventTrustScore['status']): string {
+  switch (status) {
+    case 'trusted':
+      return 'bg-green-100 text-green-800';
+    case 'neutral':
+      return 'bg-yellow-100 text-yellow-800';
+    case 'suspicious':
+      return 'bg-orange-100 text-orange-800';
+    case 'blacklisted':
+      return 'bg-red-100 text-red-800';
+    default:
+      return 'bg-gray-100 text-gray-800';
+  }
+}
+
+export function getEventTrustSummary(actorReputation: ActorReputation): string {
+  const score = calculateTrustScore(actorReputation);
+  return `${score.status} (${actorReputation.trust_weight}%)`;
+}

--- a/frontend/lib/utils/provenanceScore.ts
+++ b/frontend/lib/utils/provenanceScore.ts
@@ -9,13 +9,16 @@ export interface ProvenanceScoreBreakdown {
   uniqueActors: number;
   /** Bonus for authorized actor depth (multi-party authorization). */
   authorizedActorDepth: number;
+  /** Actor reputation component derived from event actor trust scores. */
+  actorReputation: number;
 }
 
-const MAX_SCORE = 80; // raised from 70 to accommodate new factor
+const MAX_SCORE = 90; // includes actor reputation as a trust factor
 
 export function calculateProvenanceScore(
   events: TrackingEvent[],
   product?: Pick<Product, 'authorizedActors'>,
+  actorReputationWeight: number = 50,
 ): ProvenanceScoreBreakdown {
   let score = 0;
 
@@ -69,6 +72,10 @@ export function calculateProvenanceScore(
   const authorizedActorDepthScore = Math.min(authorizedCount * 2, 10);
   score += authorizedActorDepthScore;
 
+  // 7. Actor reputation (up to 10 pts): average trust of all actors involved in the product history
+  const actorReputationScore = Math.min(Math.round((actorReputationWeight / 100) * 10), 10);
+  score += actorReputationScore;
+
   return {
     total: Math.min(score, MAX_SCORE),
     eventCount: eventCountScore,
@@ -77,6 +84,7 @@ export function calculateProvenanceScore(
     timingConsistency: timingScore,
     uniqueActors: actorScore,
     authorizedActorDepth: authorizedActorDepthScore,
+    actorReputation: actorReputationScore,
   };
 }
 


### PR DESCRIPTION
closes #470 

## PR Documentation

### Title
Implement actor reputation-based event trust scoring for provenance summaries

### Summary
This PR adds actor reputation tracking and event-level trust metrics to the frontend provenance experience. Actor trust now influences the overall provenance score, and each tracking event displays a trust badge derived from actor reputation plus metadata and timing signals.

### What changed

- **New trust service**
  - eventTrust.ts
  - Computes `ActorReputation` from event history
  - Calculates `EventTrustScore` for each event
  - Factors included:
    - approval compliance
    - event timeliness
    - metadata completeness
    - recall / quality issue involvement
    - historical actor event volume

- **Extended provenance scoring**
  - provenanceScore.ts
  - Added `actorReputation` component to score breakdown
  - Increased score ceiling to account for the new trust factor
  - Now uses average actor trust as part of provenance score computation

- **UI updates**
  - ProvenanceScoreGauge.tsx
    - Computes average actor reputation from current events
    - Shows actor reputation in tooltip breakdown
  - EventTimeline.tsx
    - Displays per-event trust badge and trust weight next to actor identity

- **Tests**
  - Added eventTrust.test.ts
  - Covers:
    - actor reputation calculation
    - blacklist detection
    - event trust derivation
    - provenance score influence from actor reputation

### Files changed

- eventTrust.ts
- provenanceScore.ts
- ProvenanceScoreGauge.tsx
- EventTimeline.tsx
- eventTrust.test.ts

### Testing
- Static checks via `get_errors` reported no issues in the modified files.
- Running Vitest was attempted, but the workspace PowerShell policy prevented executing `npm`/`npx` commands at this time.

### Notes
- This implementation is frontend-only and uses event history as the source of actor reputation.
- Contract-side trust storage / on-chain actor trust persistence has not been added in this PR.

### Suggested follow-up
- Add contract/read-model support for on-chain `ActorTrustWeight`
- Expose actor reputation details in product or actor profile views
- Run full frontend test suite once execution policy is resolved